### PR TITLE
Fix -Wundef warning under Ubuntu 14.04

### DIFF
--- a/cl_platform.h
+++ b/cl_platform.h
@@ -125,7 +125,7 @@ extern "C" {
             #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED __attribute__((deprecated))
             #define CL_EXT_PREFIX__VERSION_2_0_DEPRECATED
         #endif
-    #elif _WIN32
+    #elif defined(_WIN32)
         #ifdef CL_USE_DEPRECATED_OPENCL_1_0_APIS
             #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED
             #define CL_EXT_PREFIX__VERSION_1_0_DEPRECATED    


### PR DESCRIPTION
I guess gcc in Ubuntu 14.04 does not define __GNUC__. Oh well.