### PR TITLE
provide patch for PowerPC where 'vector' is unset

### DIFF
--- a/cl_platform.h
+++ b/cl_platform.h
@@ -408,14 +408,25 @@ typedef unsigned int cl_GLenum;
 
 /* Define basic vector types */
 #if defined( __VEC__ )
-   #include <altivec.h>   /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
-   typedef vector unsigned char     __cl_uchar16;
-   typedef vector signed char       __cl_char16;
-   typedef vector unsigned short    __cl_ushort8;
-   typedef vector signed short      __cl_short8;
-   typedef vector unsigned int      __cl_uint4;
-   typedef vector signed int        __cl_int4;
-   typedef vector float             __cl_float4;
+   #if defined(__powerpc__)
+       typedef __vector unsigned char     __cl_uchar16;
+       typedef __vector signed char       __cl_char16;
+       typedef __vector unsigned short    __cl_ushort8;
+       typedef __vector signed short      __cl_short8;
+       typedef __vector unsigned int      __cl_uint4;
+       typedef __vector signed int        __cl_int4;
+       typedef __vector float             __cl_float4;
+   #else 
+       #include <altivec.h>   /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
+       typedef vector unsigned char     __cl_uchar16;
+       typedef vector signed char       __cl_char16;
+       typedef vector unsigned short    __cl_ushort8;
+       typedef vector signed short      __cl_short8;
+       typedef vector unsigned int      __cl_uint4;
+       typedef vector signed int        __cl_int4;
+       typedef vector float             __cl_float4;
+   #endif
+
    #define  __CL_UCHAR16__  1
    #define  __CL_CHAR16__   1
    #define  __CL_USHORT8__  1


### PR DESCRIPTION
While developing on a PowerPC cluster I discovered an error when including the cl_platform.h file complaining about 'vector' not naming a type.  I discovered in this [issue](https://github.com/bmwcarit/meta-ros/issues/355) referencing opencv having the same problem.  The following patch fixes this problem.