### PR TITLE
clang warning

### DIFF
--- a/opencl11/CL/cl_gl_ext.h
+++ b/opencl11/CL/cl_gl_ext.h
@@ -46,7 +46,7 @@ extern "C" {
 
 /*
  * For each extension, follow this template
- * /* cl_VEN_extname extension  */
+ *  cl_VEN_extname extension  */
 /* #define cl_VEN_extname 1
  * ... define new types, if any
  * ... define new tokens, if any


### PR DESCRIPTION
Hi!
We can fix clang warning:
cl_gl_ext.h:49:4: warning: '/*' within block comment [-Wcomment]
 * /* cl_VEN_extname extension  */

Thanks!