### PR TITLE
added clSetCommandQueueProperty to unified headers

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -1695,6 +1695,24 @@ clGetExtensionFunctionAddressForPlatform(cl_platform_id /* platform */,
 
 #endif
 
+#ifdef CL_USE_DEPRECATED_OPENCL_1_0_APIS
+    /*
+     *  WARNING:
+     *     This API introduces mutable state into the OpenCL implementation. It has been REMOVED
+     *  to better facilitate thread safety.  The 1.0 API is not thread safe. It is not tested by the
+     *  OpenCL 1.1 conformance test, and consequently may not work or may not work dependably.
+     *  It is likely to be non-performant. Use of this API is not advised. Use at your own risk.
+     *
+     *  Software developers previously relying on this API are instructed to set the command queue
+     *  properties when creating the queue, instead.
+     */
+    extern CL_API_ENTRY cl_int CL_API_CALL
+    clSetCommandQueueProperty(cl_command_queue              /* command_queue */,
+                              cl_command_queue_properties   /* properties */,
+                              cl_bool                        /* enable */,
+                              cl_command_queue_properties * /* old_properties */) CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED;
+#endif /* CL_USE_DEPRECATED_OPENCL_1_0_APIS */
+
 /* Deprecated OpenCL 1.1 APIs */
 extern CL_API_ENTRY CL_EXT_PREFIX__VERSION_1_1_DEPRECATED cl_mem CL_API_CALL
 clCreateImage2D(cl_context              /* context */,


### PR DESCRIPTION
This PR adds clSetCommandQueueProperty to the unified headers.

Note, clSetCommandQueueProperty wasn't in the non-unified 1.2-2.2 headers either, though it was in the 1.0-1.1 headers.  I think we should add it back, at least when configuring the unified headers for OpenCL 1.0 or 1.1.

It's a deprecated OpenCL 1.0 API, so it's protected by CL_USE_DEPRECATED_OPENCL_1_0_APIS, but it's otherwise still available for all OpenCL versions.  This is the same mechanism used by the non-unified OpenCL 1.1 headers.