### PR TITLE
Fix for users trying to access CL_DEVICE_DOUBLE_FP_CONFIG on OpenCL 1.1 or lower

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -327,8 +327,8 @@ typedef struct _cl_buffer_region {
 #define CL_DEVICE_PLATFORM                               0x1031
 #ifdef CL_VERSION_1_2
 #define CL_DEVICE_DOUBLE_FP_CONFIG                       0x1032
-#define CL_DEVICE_HALF_FP_CONFIG                         0x1033
 #endif
+/* 0x1033 reserved for CL_DEVICE_HALF_FP_CONFIG which is already defined in "cl_ext.h" */
 #ifdef CL_VERSION_1_1
 #define CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF            0x1034
 #define CL_DEVICE_HOST_UNIFIED_MEMORY                    0x1035   /* deprecated */

--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -44,7 +44,11 @@ extern "C" {
 #endif
 
 /* cl_khr_fp64 extension - no extension #define since it has no functions  */
-/* CL_DEVICE_DOUBLE_FP_CONFIG is defined in CL.h. */
+/* CL_DEVICE_DOUBLE_FP_CONFIG is defined in CL.h for OpenCL >= 120 */
+
+#if CL_TARGET_OPENCL_VERSION <= 110
+#define CL_DEVICE_DOUBLE_FP_CONFIG                       0x1032
+#endif
 
 /* cl_khr_fp16 extension - no extension #define since it has no functions  */
 #define CL_DEVICE_HALF_FP_CONFIG                    0x1033


### PR DESCRIPTION
Currently, trying to query for double precision standards using `CL_DEVICE_DOUBLE_FP_CONFIG` on **OpenCL 1.1** or lower, throws an error saying "**_the macro is undeclared in this scope_**". Querying for `half` using `CL_DEVICE_HALF_FP_CONFIG` works fine, hence double should work as well. 

Furthermore, The **OpenCL 1.0** and **1.1** specification, in section **9.3.8**, also state that applications can query configuration information for devices that support double precision floating-point using the above macro.

The issue arises because `cl.h` defines the macro for `CL_VERSION_1_2` which means for **OpenCL 1.2** or greater. Then `cl_ext.h` states that the macro is already defined in `cl.h` and doesn't define it. This leaves out **OpenCL version 1.1** and **1.0**. Note that `CL_DEVICE_HALF_FP_CONFIG` is defined in the `cl_ext.h` regardless of the version, hence it works fine for all versions.

The commit fixes this issue by adding the macro definition in `cl_ext.h` for **OpenCL 1.1** and **1.0**. It also removes `CL_DEVICE_HALF_FP_CONFIG` from `cl.h` since it is already defined in `cl_ext.h` where it should be since `cl_khr_fp16` is still an extension and not a core feature in my knowledge.

Note:- 
I have checked the both `cl.h` and `cl_ext.h` generated from **CUDA toolkit 7** which supports till OpenCL version 1.1. And the commit changes comply with these old headers. The old headers do define `CL_DEVICE_DOUBLE_FP_CONFIG` in `cl_ext.h`.

Thanks.

