### PR TITLE
Remove all Apple specific content from headers

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -29,13 +29,8 @@
 #ifndef __OPENCL_CL_H
 #define __OPENCL_CL_H
 
-#ifdef __APPLE__
-#include <OpenCL/cl_version.h>
-#include <OpenCL/cl_platform.h>
-#else
 #include <CL/cl_version.h>
 #include <CL/cl_platform.h>
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -1780,4 +1775,3 @@ clEnqueueTask(cl_command_queue  /* command_queue */,
 #endif
 
 #endif  /* __OPENCL_CL_H */
-

--- a/CL/cl_egl.h
+++ b/CL/cl_egl.h
@@ -29,11 +29,7 @@
 #ifndef __OPENCL_CL_EGL_H
 #define __OPENCL_CL_EGL_H
 
-#ifdef __APPLE__
-
-#else
 #include <CL/cl.h>
-#endif  
 
 #ifdef __cplusplus
 extern "C" {

--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -36,12 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef __APPLE__
-    #include <OpenCL/cl.h>
-    #include <AvailabilityMacros.h>
-#else
-    #include <CL/cl.h>
-#endif
+#include <CL/cl.h>
 
 /* cl_khr_fp64 extension - no extension #define since it has no functions  */
 /* CL_DEVICE_DOUBLE_FP_CONFIG is defined in CL.h for OpenCL >= 120 */

--- a/CL/cl_ext_intel.h
+++ b/CL/cl_ext_intel.h
@@ -52,13 +52,8 @@ Notes:
 #ifndef __CL_EXT_INTEL_H
 #define __CL_EXT_INTEL_H
 
-#ifdef __APPLE__
-    #include <OpenCL/cl.h>
-    #include <OpenCL/cl_platform.h>
-#else
-    #include <CL/cl.h>
-    #include <CL/cl_platform.h>
-#endif
+#include <CL/cl.h>
+#include <CL/cl_platform.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -426,4 +421,3 @@ typedef cl_uint cl_diagnostics_verbose_level;
 #endif
 
 #endif /* __CL_EXT_INTEL_H */
-

--- a/CL/cl_gl.h
+++ b/CL/cl_gl.h
@@ -29,11 +29,7 @@
 #ifndef __OPENCL_CL_GL_H
 #define __OPENCL_CL_GL_H
 
-#ifdef __APPLE__
-#include <OpenCL/cl.h>
-#else
 #include <CL/cl.h>
-#endif	
 
 #ifdef __cplusplus
 extern "C" {

--- a/CL/cl_gl_ext.h
+++ b/CL/cl_gl_ext.h
@@ -38,11 +38,7 @@
 extern "C" {
 #endif
 
-#ifdef __APPLE__
-    #include <OpenCL/cl_gl.h>
-#else
-    #include <CL/cl_gl.h>
-#endif
+#include <CL/cl_gl.h>
 
 /*
  * For each extension, follow this template

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -29,14 +29,7 @@
 #ifndef __CL_PLATFORM_H
 #define __CL_PLATFORM_H
 
-#ifdef __APPLE__
-    #include <OpenCL/cl_version.h>
-
-    /* Contains #defines for AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER below */
-    #include <AvailabilityMacros.h>
-#else
-    #include <CL/cl_version.h>
-#endif
+#include <CL/cl_version.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,139 +53,115 @@ extern "C" {
  * deprecation but is deprecated in versions later than 1.1.
  */
 
-#ifdef __APPLE__
-    #define CL_EXTENSION_WEAK_LINK       __attribute__((weak_import))
-    #define CL_API_SUFFIX__VERSION_1_0                  AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER
-    #define CL_EXT_SUFFIX__VERSION_1_0                  CL_EXTENSION_WEAK_LINK AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER
-    #define CL_API_SUFFIX__VERSION_1_1                  AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER
-    #define GCL_API_SUFFIX__VERSION_1_1                 AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER
-    #define CL_EXT_SUFFIX__VERSION_1_1                  CL_EXTENSION_WEAK_LINK AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER
-    #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED       CL_EXTENSION_WEAK_LINK AVAILABLE_MAC_OS_X_VERSION_10_6_AND_LATER_BUT_DEPRECATED_IN_MAC_OS_X_VERSION_10_7
+#define CL_EXTENSION_WEAK_LINK
+#define CL_API_SUFFIX__VERSION_1_0
+#define CL_EXT_SUFFIX__VERSION_1_0
+#define CL_API_SUFFIX__VERSION_1_1
+#define CL_EXT_SUFFIX__VERSION_1_1
+#define CL_API_SUFFIX__VERSION_1_2
+#define CL_EXT_SUFFIX__VERSION_1_2
+#define CL_API_SUFFIX__VERSION_2_0
+#define CL_EXT_SUFFIX__VERSION_2_0
+#define CL_API_SUFFIX__VERSION_2_1
+#define CL_EXT_SUFFIX__VERSION_2_1
+#define CL_API_SUFFIX__VERSION_2_2
+#define CL_EXT_SUFFIX__VERSION_2_2
 
-    #ifdef AVAILABLE_MAC_OS_X_VERSION_10_8_AND_LATER
-        #define CL_API_SUFFIX__VERSION_1_2              AVAILABLE_MAC_OS_X_VERSION_10_8_AND_LATER
-        #define GCL_API_SUFFIX__VERSION_1_2             AVAILABLE_MAC_OS_X_VERSION_10_8_AND_LATER
-        #define CL_EXT_SUFFIX__VERSION_1_2              CL_EXTENSION_WEAK_LINK AVAILABLE_MAC_OS_X_VERSION_10_8_AND_LATER
-        #define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
-        #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED   CL_EXTENSION_WEAK_LINK AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER_BUT_DEPRECATED_IN_MAC_OS_X_VERSION_10_8
-    #else
-        #warning  This path should never happen outside of internal operating system development.  AvailabilityMacros do not function correctly here!
-        #define CL_API_SUFFIX__VERSION_1_2              AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER
-        #define GCL_API_SUFFIX__VERSION_1_2             AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER
-        #define CL_EXT_SUFFIX__VERSION_1_2              CL_EXTENSION_WEAK_LINK AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER
-        #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED   CL_EXTENSION_WEAK_LINK AVAILABLE_MAC_OS_X_VERSION_10_7_AND_LATER
-    #endif
-#else
-    #define CL_EXTENSION_WEAK_LINK
-    #define CL_API_SUFFIX__VERSION_1_0
-    #define CL_EXT_SUFFIX__VERSION_1_0
-    #define CL_API_SUFFIX__VERSION_1_1
-    #define CL_EXT_SUFFIX__VERSION_1_1
-    #define CL_API_SUFFIX__VERSION_1_2
-    #define CL_EXT_SUFFIX__VERSION_1_2
-    #define CL_API_SUFFIX__VERSION_2_0
-    #define CL_EXT_SUFFIX__VERSION_2_0
-    #define CL_API_SUFFIX__VERSION_2_1
-    #define CL_EXT_SUFFIX__VERSION_2_1
-    #define CL_API_SUFFIX__VERSION_2_2
-    #define CL_EXT_SUFFIX__VERSION_2_2
-
-    #ifdef __GNUC__
-        #ifdef CL_USE_DEPRECATED_OPENCL_1_0_APIS
-            #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_1_0_DEPRECATED
-        #else
-            #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED __attribute__((deprecated))
-            #define CL_EXT_PREFIX__VERSION_1_0_DEPRECATED
-        #endif
-
-        #ifdef CL_USE_DEPRECATED_OPENCL_1_1_APIS
-            #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
-        #else
-            #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED __attribute__((deprecated))
-            #define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
-        #endif
-
-        #ifdef CL_USE_DEPRECATED_OPENCL_1_2_APIS
-            #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED
-        #else
-            #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED __attribute__((deprecated))
-            #define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED
-         #endif
-
-        #ifdef CL_USE_DEPRECATED_OPENCL_2_0_APIS
-            #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_2_0_DEPRECATED
-        #else
-            #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED __attribute__((deprecated))
-            #define CL_EXT_PREFIX__VERSION_2_0_DEPRECATED
-        #endif
-
-        #ifdef CL_USE_DEPRECATED_OPENCL_2_1_APIS
-            #define CL_EXT_SUFFIX__VERSION_2_1_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_2_1_DEPRECATED
-        #else
-            #define CL_EXT_SUFFIX__VERSION_2_1_DEPRECATED __attribute__((deprecated))
-            #define CL_EXT_PREFIX__VERSION_2_1_DEPRECATED
-        #endif
-    #elif defined(_WIN32)
-        #ifdef CL_USE_DEPRECATED_OPENCL_1_0_APIS
-            #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_1_0_DEPRECATED
-        #else
-            #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_1_0_DEPRECATED __declspec(deprecated)
-        #endif
-
-        #ifdef CL_USE_DEPRECATED_OPENCL_1_1_APIS
-            #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
-        #else
-            #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED __declspec(deprecated)
-        #endif
-
-        #ifdef CL_USE_DEPRECATED_OPENCL_1_2_APIS
-            #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED
-        #else
-            #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED __declspec(deprecated)
-        #endif
-
-        #ifdef CL_USE_DEPRECATED_OPENCL_2_0_APIS
-            #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_2_0_DEPRECATED
-        #else
-            #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_2_0_DEPRECATED __declspec(deprecated)
-        #endif
-
-        #ifdef CL_USE_DEPRECATED_OPENCL_2_1_APIS
-            #define CL_EXT_SUFFIX__VERSION_2_1_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_2_1_DEPRECATED
-        #else
-            #define CL_EXT_SUFFIX__VERSION_2_1_DEPRECATED
-            #define CL_EXT_PREFIX__VERSION_2_1_DEPRECATED __declspec(deprecated)
-        #endif
-    #else
+#ifdef __GNUC__
+    #ifdef CL_USE_DEPRECATED_OPENCL_1_0_APIS
         #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED
         #define CL_EXT_PREFIX__VERSION_1_0_DEPRECATED
+    #else
+        #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED __attribute__((deprecated))
+        #define CL_EXT_PREFIX__VERSION_1_0_DEPRECATED
+    #endif
 
+    #ifdef CL_USE_DEPRECATED_OPENCL_1_1_APIS
         #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
         #define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
+    #else
+        #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED __attribute__((deprecated))
+        #define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
+    #endif
 
+    #ifdef CL_USE_DEPRECATED_OPENCL_1_2_APIS
         #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED
         #define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED
+    #else
+        #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED __attribute__((deprecated))
+        #define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED
+     #endif
 
+    #ifdef CL_USE_DEPRECATED_OPENCL_2_0_APIS
         #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED
         #define CL_EXT_PREFIX__VERSION_2_0_DEPRECATED
+    #else
+        #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED __attribute__((deprecated))
+        #define CL_EXT_PREFIX__VERSION_2_0_DEPRECATED
+    #endif
 
+    #ifdef CL_USE_DEPRECATED_OPENCL_2_1_APIS
         #define CL_EXT_SUFFIX__VERSION_2_1_DEPRECATED
         #define CL_EXT_PREFIX__VERSION_2_1_DEPRECATED
+    #else
+        #define CL_EXT_SUFFIX__VERSION_2_1_DEPRECATED __attribute__((deprecated))
+        #define CL_EXT_PREFIX__VERSION_2_1_DEPRECATED
     #endif
+#elif defined(_WIN32)
+    #ifdef CL_USE_DEPRECATED_OPENCL_1_0_APIS
+        #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED
+        #define CL_EXT_PREFIX__VERSION_1_0_DEPRECATED
+    #else
+        #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED
+        #define CL_EXT_PREFIX__VERSION_1_0_DEPRECATED __declspec(deprecated)
+    #endif
+
+    #ifdef CL_USE_DEPRECATED_OPENCL_1_1_APIS
+        #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+        #define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
+    #else
+        #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+        #define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED __declspec(deprecated)
+    #endif
+
+    #ifdef CL_USE_DEPRECATED_OPENCL_1_2_APIS
+        #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED
+        #define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED
+    #else
+        #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED
+        #define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED __declspec(deprecated)
+    #endif
+
+    #ifdef CL_USE_DEPRECATED_OPENCL_2_0_APIS
+        #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED
+        #define CL_EXT_PREFIX__VERSION_2_0_DEPRECATED
+    #else
+        #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED
+        #define CL_EXT_PREFIX__VERSION_2_0_DEPRECATED __declspec(deprecated)
+    #endif
+
+    #ifdef CL_USE_DEPRECATED_OPENCL_2_1_APIS
+        #define CL_EXT_SUFFIX__VERSION_2_1_DEPRECATED
+        #define CL_EXT_PREFIX__VERSION_2_1_DEPRECATED
+    #else
+        #define CL_EXT_SUFFIX__VERSION_2_1_DEPRECATED
+        #define CL_EXT_PREFIX__VERSION_2_1_DEPRECATED __declspec(deprecated)
+    #endif
+#else
+    #define CL_EXT_SUFFIX__VERSION_1_0_DEPRECATED
+    #define CL_EXT_PREFIX__VERSION_1_0_DEPRECATED
+
+    #define CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+    #define CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
+
+    #define CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED
+    #define CL_EXT_PREFIX__VERSION_1_2_DEPRECATED
+
+    #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED
+    #define CL_EXT_PREFIX__VERSION_2_0_DEPRECATED
+
+    #define CL_EXT_SUFFIX__VERSION_2_1_DEPRECATED
+    #define CL_EXT_PREFIX__VERSION_2_1_DEPRECATED
 #endif
 
 #if (defined (_WIN32) && defined(_MSC_VER))

--- a/CL/opencl.h
+++ b/CL/opencl.h
@@ -35,25 +35,13 @@
 extern "C" {
 #endif
 
-#ifdef __APPLE__
-
-#include <OpenCL/cl.h>
-#include <OpenCL/cl_gl.h>
-#include <OpenCL/cl_gl_ext.h>
-#include <OpenCL/cl_ext.h>
-
-#else
-
 #include <CL/cl.h>
 #include <CL/cl_gl.h>
 #include <CL/cl_gl_ext.h>
 #include <CL/cl_ext.h>
-
-#endif
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif  /* __OPENCL_H   */
-


### PR DESCRIPTION
These various deltas made it extremely difficult to work with non-Apple implementations of OpenCL on macOS. Apple always shipped their own versions of the headers anyway, and now that Apple have officially deprecated OpenCL on their platforms there is no reason to keep these deltas.

Fixes https://github.com/KhronosGroup/OpenCL-Headers/issues/31 as well as a few other unreported issues.

This probably needs some discussion before merging, potentially inside the OpenCL WG. In particular, if anyone has concerns that this might break their own workflows on macOS please let me know and we can discuss. Arguably I could have left the Apple extension declarations in `cl_ext.h` since they weren't causing problems, so I'm interested if people have thoughts on this.

@kpet Would be great if you could give this a quick test to see if it fixes your issues. FWIW this change lets me build clvk on macOS without any changes.