### PR TITLE
add suffixed enums for cl_khr_mipmap_image

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -619,6 +619,9 @@ typedef struct _cl_buffer_region {
 #define CL_SAMPLER_ADDRESSING_MODE                  0x1153
 #define CL_SAMPLER_FILTER_MODE                      0x1154
 #ifdef CL_VERSION_2_0
+/* These enumerants are for the cl_khr_mipmap_image extension.
+   They have since been added to cl_ext.h with an appropriate
+   KHR suffix, but are left here for backwards compatibility. */
 #define CL_SAMPLER_MIP_FILTER_MODE                  0x1155
 #define CL_SAMPLER_LOD_MIN                          0x1156
 #define CL_SAMPLER_LOD_MAX                          0x1157
@@ -1064,7 +1067,7 @@ clSVMFree(cl_context        /* context */,
 
 extern CL_API_ENTRY cl_sampler CL_API_CALL
 clCreateSamplerWithProperties(cl_context                     /* context */,
-                              const cl_sampler_properties *  /* normalized_coords */,
+                              const cl_sampler_properties *  /* sampler_properties */,
                               cl_int *                       /* errcode_ret */) CL_API_SUFFIX__VERSION_2_0;
 
 #endif

--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -438,7 +438,7 @@ typedef struct _cl_mem_android_native_buffer_host_ptr
  * cl_img_cached_allocations extension *
  ******************************************/
 
-/* Flag values used by clCreteBuffer */
+/* Flag values used by clCreateBuffer */
 #define CL_MEM_USE_UNCACHED_CPU_MEMORY_IMG          (1 << 26)
 #define CL_MEM_USE_CACHED_CPU_MEMORY_IMG            (1 << 27)
 
@@ -448,7 +448,7 @@ typedef struct _cl_mem_android_native_buffer_host_ptr
  ******************************************/
 #define cl_img_use_gralloc_ptr 1
 
-/* Flag values used by clCreteBuffer */
+/* Flag values used by clCreateBuffer */
 #define CL_MEM_USE_GRALLOC_PTR_IMG                  (1 << 28)
 
 /* To be used by clGetEventInfo: */
@@ -511,6 +511,16 @@ typedef CL_API_ENTRY cl_int
                               size_t /*param_value_size*/,
                               void* /*param_value*/,
                               size_t* /*param_value_size_ret*/ ) CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED;
+
+
+/*********************************
+* cl_khr_mipmap_image extension
+*********************************/
+
+/* cl_sampler_properties */
+#define CL_SAMPLER_MIP_FILTER_MODE_KHR              0x1155
+#define CL_SAMPLER_LOD_MIN_KHR                      0x1156
+#define CL_SAMPLER_LOD_MAX_KHR                      0x1157
 
 
 /*********************************


### PR DESCRIPTION
This change adds KHR suffixed enums to cl_ext.h for the cl_khr_mipmap_image extension, and a comment describing why the un-suffixed enums in the main cl.h are incorrect (but are left for compatibility).

See:
https://github.com/KhronosGroup/OpenCL-Headers/issues/33#issuecomment-429996700