### PR TITLE
Use __vector instead of vector to fix altivec builds

### DIFF
--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -401,13 +401,13 @@ typedef unsigned int cl_GLenum;
 /* Define basic vector types */
 #if defined( __VEC__ )
    #include <altivec.h>   /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
-   typedef vector unsigned char     __cl_uchar16;
-   typedef vector signed char       __cl_char16;
-   typedef vector unsigned short    __cl_ushort8;
-   typedef vector signed short      __cl_short8;
-   typedef vector unsigned int      __cl_uint4;
-   typedef vector signed int        __cl_int4;
-   typedef vector float             __cl_float4;
+   typedef __vector unsigned char     __cl_uchar16;
+   typedef __vector signed char       __cl_char16;
+   typedef __vector unsigned short    __cl_ushort8;
+   typedef __vector signed short      __cl_short8;
+   typedef __vector unsigned int      __cl_uint4;
+   typedef __vector signed int        __cl_int4;
+   typedef __vector float             __cl_float4;
    #define  __CL_UCHAR16__  1
    #define  __CL_CHAR16__   1
    #define  __CL_USHORT8__  1


### PR DESCRIPTION
Patch taken from Debian khronos-opencl-headers package:
https://sources.debian.org/patches/khronos-opencl-headers/1.2-svn26009-1/use__vector.patch/

Further discussion available on the Debian bug tracker:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=760310

Supersedes https://github.com/KhronosGroup/OpenCL-Headers/pull/20.