### PR TITLE
drop __attribute__((aligned(X))) from cl_X defs

### DIFF
--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -271,16 +271,16 @@ typedef double                  cl_double;
 /* scalar types  */
 typedef int8_t          cl_char;
 typedef uint8_t         cl_uchar;
-typedef int16_t         cl_short    __attribute__((aligned(2)));
-typedef uint16_t        cl_ushort   __attribute__((aligned(2)));
-typedef int32_t         cl_int      __attribute__((aligned(4)));
-typedef uint32_t        cl_uint     __attribute__((aligned(4)));
-typedef int64_t         cl_long     __attribute__((aligned(8)));
-typedef uint64_t        cl_ulong    __attribute__((aligned(8)));
+typedef int16_t         cl_short;
+typedef uint16_t        cl_ushort;
+typedef int32_t         cl_int;
+typedef uint32_t        cl_uint;
+typedef int64_t         cl_long;
+typedef uint64_t        cl_ulong;
 
-typedef uint16_t        cl_half     __attribute__((aligned(2)));
-typedef float           cl_float    __attribute__((aligned(4)));
-typedef double          cl_double   __attribute__((aligned(8)));
+typedef uint16_t        cl_half;
+typedef float           cl_float;
+typedef double          cl_double;
 
 /* Macro names and corresponding values defined by OpenCL */
 #define CL_CHAR_BIT         8


### PR DESCRIPTION
Currently, we add __attribute__((aligned(X))) for definitions like
cl_int, cl_short etc. This guarantees that the variable will be aligned
*at least* at an X byte boundary. We don't need to do this, for a few
reasons:

- Most of these types are fixed width (int32_t, int16_t, etc.). This
  means __attribute((aligned(X))) isn't doing anything, as the types are
  exactly the right size, so they will already be aligned to at least
  their size. float and double are not guaranteed to be any given width,
  though in practice they are almost always IEEE 754 floats and
  therefore 4 and 8 bytes respectively. If they were not 4/8 bytes, it's
  unclear that forcing 4/8 byte alignment would be good for either space
  or performance efficiency.

- Attributes don't carry over to templates, which ends up causing a
  GCC -Wignored-attributes warning in cl.hpp when we declare an
  std::vector<cl_int>. This warning is indicating that the attributes
  get dropped when put inside a template. Nothing seems to break when
  this happens, further suggesting that the attributes aren't really
  needed.

- The attributes aren't present on Windows, so if they were really
  needed, then Windows is currently broken. Again, it doesn't seem like
  anything is broken, so this is further evidence that we don't need to
  add these attributes.

See here for further reference on __attribute((aligned(X))):
https://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Type-Attributes.html