### PR TITLE
added suffixed enums for cl_khr_image2d_from_buffer

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -356,10 +356,10 @@ typedef struct _cl_buffer_region {
 #define CL_DEVICE_REFERENCE_COUNT                        0x1047
 #define CL_DEVICE_PREFERRED_INTEROP_USER_SYNC            0x1048
 #define CL_DEVICE_PRINTF_BUFFER_SIZE                     0x1049
-#define CL_DEVICE_IMAGE_PITCH_ALIGNMENT                  0x104A
-#define CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT           0x104B
 #endif
 #ifdef CL_VERSION_2_0
+#define CL_DEVICE_IMAGE_PITCH_ALIGNMENT                  0x104A
+#define CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT           0x104B
 #define CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS              0x104C
 #define CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE               0x104D
 #define CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES             0x104E

--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -147,20 +147,28 @@ typedef CL_API_ENTRY cl_program
                                            size_t       length,
                                            cl_int *     errcode_ret) CL_EXT_SUFFIX__VERSION_1_2;
 
-/* Extension: cl_khr_image2D_buffer
+/* Extension: cl_khr_image2d_from_buffer
  *
- * This extension allows a 2D image to be created from a cl_mem buffer without a copy.
- * The type associated with a 2D image created from a buffer in an OpenCL program is image2d_t.
- * Both the sampler and sampler-less read_image built-in functions are supported for 2D images
- * and 2D images created from a buffer.  Similarly, the write_image built-ins are also supported
- * for 2D images created from a buffer.
+ * This extension allows a 2D image to be created from a cl_mem buffer without
+ * a copy. The type associated with a 2D image created from a buffer in an
+ * OpenCL program is image2d_t. Both the sampler and sampler-less read_image
+ * built-in functions are supported for 2D images and 2D images created from
+ * a buffer.  Similarly, the write_image built-ins are also supported for 2D
+ * images created from a buffer.
  *
- * When the 2D image from buffer is created, the client must specify the width,
- * height, image format (i.e. channel order and channel data type) and optionally the row pitch
+ * When the 2D image from buffer is created, the client must specify the
+ * width, height, image format (i.e. channel order and channel data type)
+ * and optionally the row pitch.
  *
- * The pitch specified must be a multiple of CL_DEVICE_IMAGE_PITCH_ALIGNMENT pixels.
- * The base address of the buffer must be aligned to CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT pixels.
+ * The pitch specified must be a multiple of
+ * CL_DEVICE_IMAGE_PITCH_ALIGNMENT_KHR pixels.
+ * The base address of the buffer must be aligned to
+ * CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_KHR pixels.
  */
+
+#define CL_DEVICE_IMAGE_PITCH_ALIGNMENT_KHR              0x104A
+#define CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_KHR       0x104B
+
 
 /**************************************
  * cl_khr_initialize_memory extension *


### PR DESCRIPTION
This is a partial fix for #42.

This change adds `KHR` suffixed enums for `cl_khr_imaged2d_from_buffer` to cl_ext.h.

It also moves the un-suffixed enums for `cl_khr_image2d_from_buffer` in cl.h to a section protected by `#ifdef CL_VERSION_2_0`, not `#ifdef CL_VERSION_1_2`, since the extension became a core feature in OpenCL 2.0.