### PR TITLE
Fix _cl_image_desc for OpenCL 1.2 compatibility

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -137,19 +137,23 @@ typedef struct _cl_image_desc {
     size_t                  image_slice_pitch;
     cl_uint                 num_mip_levels;
     cl_uint                 num_samples;
+#ifdef CL_VERSION_2_0
 #ifdef __GNUC__
     __extension__   /* Prevents warnings about anonymous union in -pedantic builds */
 #endif
 #ifdef _MSC_VER
-#pragma warning( push )  
+#pragma warning( push )
 #pragma warning( disable : 4201 ) /* Prevents warning about nameless struct/union in /W4 /Za builds */
 #endif
     union {
+#endif
       cl_mem                  buffer;
+#ifdef CL_VERSION_2_0
       cl_mem                  mem_object;
     };
 #ifdef _MSC_VER
-#pragma warning( pop )  
+#pragma warning( pop )
+#endif
 #endif
 } cl_image_desc;
 


### PR DESCRIPTION
As can be seen [here](https://github.com/KhronosGroup/OpenCL-Headers/blob/e986688daf750633898dfd3994e14a9e618f2aa5/opencl12/CL/cl.h#L102), the original OpenCL 1.2 headers, right before the unification, had the following definition for `cl_image_desc`:

```c
typedef struct _cl_image_desc {
    cl_mem_object_type      image_type;
    size_t                  image_width;
    size_t                  image_height;
    size_t                  image_depth;
    size_t                  image_array_size;
    size_t                  image_row_pitch;
    size_t                  image_slice_pitch;
    cl_uint                 num_mip_levels;
    cl_uint                 num_samples;
    cl_mem               buffer;
} cl_image_desc;
```

However, during the unification, the OpenCL 1.2 definition for `cl_image_desc` was changed according to OpenCL 2.0+, making the unified headers somewhat incompatible with 1.2. The proposed fix adds preprocessor checks for sections of code which should only be present in OpenCL 2.0+.