### PR TITLE
Add CMake Packaging + CI For Package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+linux: &linux
+   os: linux
+   dist: xenial
+   language: python
+   python: "3.7"
+   services:
+     - docker
+matrix:
+   include:
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49
+
+install:
+  - chmod +x .travis/install.sh
+  - ./.travis/install.sh
+
+script:
+  - chmod +x .travis/run.sh
+  - ./.travis/run.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    brew install cmake || brew upgrade cmake || true
+
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+
+    pyenv install 3.7.1
+    pyenv virtualenv 3.7.1 conan
+    pyenv rehash
+    pyenv activate conan
+fi
+
+pip install conan --upgrade
+pip install conan_package_tools
+
+conan user

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+    pyenv activate conan
+fi
+
+python build.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(OpenCLHeaders VERSION 2.2 LANGUAGES NONE)
 
 add_library(OpenCLHeaders INTERFACE)
+add_library(OpenCL::OpenCLHeaders ALIAS OpenCLHeaders)
 target_include_directories(OpenCLHeaders INTERFACE
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 	$<INSTALL_INTERFACE:include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.0)
+project(OpenCLHeaders VERSION 2.2 LANGUAGES NONE)
+
+add_library(OpenCLHeaders INTERFACE)
+target_include_directories(OpenCLHeaders INTERFACE
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:include>
+)
+
+install(TARGETS OpenCLHeaders EXPORT OpenCLHeadersTargets)
+install(DIRECTORY "CL" DESTINATION include)
+
+export(EXPORT OpenCLHeadersTargets
+  FILE "${PROJECT_BINARY_DIR}/OpenCLHeaders/OpenCLHeadersTargets.cmake"
+  NAMESPACE OpenCL::
+)
+file(WRITE "${PROJECT_BINARY_DIR}/OpenCLHeaders/OpenCLHeadersConfig.cmake"
+	"include(\"\${CMAKE_CURRENT_LIST_DIR}/OpenCLHeadersTargets.cmake\")"
+)
+
+set(config_package_location lib/cmake/OpenCLHeaders)
+install(EXPORT OpenCLHeadersTargets
+  FILE OpenCLHeadersTargets.cmake
+  NAMESPACE OpenCL::
+  DESTINATION ${config_package_location}
+)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenCLHeaders/OpenCLHeadersConfig.cmake
+  DESTINATION ${config_package_location}
+)
+
+unset(CMAKE_SIZEOF_VOID_P)
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/OpenCLHeaders/OpenCLHeadersConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/OpenCLHeaders/OpenCLHeadersConfigVersion.cmake"
+  DESTINATION ${config_package_location}
+)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,27 @@ https://github.com/KhronosGroup/OpenCL-Headers
 Issues, proposed fixes for issues, and other suggested changes should be
 created using Github.
 
+## CMake Package
+While the headers may just be copied as-is, this repository also contains a
+CMake script with an install rule to allow for packaging the headers.
+
+```bash
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/path/to/desired/prefix
+cmake --build build --target install
+```
+
+To consume the package:
+
+```bash
+cmake path/to/opencl/app -DOpenCLHeaders_ROOT=/chosen/install/prefix
+```
+
+```cmake
+add_executable(app main.cpp)
+find_package(OpenCLHeaders REQUIRED)
+target_link_libraries(app PRIVATE OpenCL::OpenCLHeaders)
+```
+
 ## Branch Structure
 
 The OpenCL API headers in this repository are Unified headers and are designed
@@ -28,7 +49,7 @@ the OpenCL API version.
 For example, to enforce usage of no more than the OpenCL 1.2 APIs, you may
 include the OpenCL API headers as follows:
 
-```
+```c
 #define CL_TARGET_OPENCL_VERSION 120
 #include <CL/opencl.h>
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+build: false
+
+environment:
+    PYTHON: "C:\\Python37"
+    
+    matrix:
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+          CONAN_VISUAL_VERSIONS: 12
+
+install:
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%
+  - pip.exe install conan --upgrade
+  - pip.exe install conan_package_tools
+  - conan user # It creates the conan data directory
+
+test_script:
+  - python build.py

--- a/build.py
+++ b/build.py
@@ -1,0 +1,11 @@
+from cpt.packager import ConanMultiPackager
+import datetime
+
+if __name__ == "__main__":
+    builder = ConanMultiPackager(
+    	username="khronos",
+    	login_username="khronos",
+    	channel="stable"
+	)
+    builder.add_common_builds()
+    builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,23 @@
+from conans import ConanFile, tools, CMake
+import os
+
+
+class OpenCLHeadersConan(ConanFile):
+    name = "opencl-headers"
+    version = "20190502"
+    license = "Apache-2.0"
+    author = "Khronos Group <webmaster@khronos.org>"
+    url = "https://github.com/KhronosGroup/OpenCL-ICD-Loader"
+    description = "Khronos OpenCL Headers"
+    topics = ("khronos", "opencl", "headers")
+    exports_sources = "CMakeLists.txt", "CL/*"
+    no_copy_source = True
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+        cmake.install()
+
+    def package_id(self):
+        self.info.header_only()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.0)
+project(PackageTest C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(OpenCLHeaders REQUIRED)
+
+add_executable(example example.c)
+target_link_libraries(example OpenCL::OpenCLHeaders)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class OpenCLHeadersTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)

--- a/test_package/example.c
+++ b/test_package/example.c
@@ -1,0 +1,9 @@
+#define CL_TARGET_OPENCL_VERSION 220
+#include <CL/cl.h>
+
+int main(void) {
+	cl_platform_id id;
+	cl_int result;
+	result = 0;
+	return result;
+}


### PR DESCRIPTION
# Rationale

## State of using OpenCL in CMake
The canonical way of using OpenCL inside of a CMake-based project goes like this:
```cmake
add_executable(app main.cpp)
find_package(OpenCL REQUIRED)
target_link_libraries(app PRIVATE OpenCL::OpenCL)
```

This works because [Kitware added a `FindOpenCL.cmake`](https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/FindOpenCL.cmake) to the standard CMake distribution which is executed during the `find_package` call. This comes with a few problems:
* `FindOpenCL.cmake` has to consider many different OpenCL implementations, that may or may not use an ICD. Therefore, it could only guess what the dependencies of the found `libOpenCL` are. As of now, there are no dependencies added at all.
* The Khronos ICD loader depends on `libdl` and `libpthread` on Linux. Just linking with `OpenCL::OpenCL` will likely result in undefined references.
* Looking at the big picture, we're depending on a third party (Kitware) to do the packaging for us. This shouldn't be the case. We, as vendors, know best what our code needs in order to be consumed by library users. Cut the middleman!

## What does this have to do with the Headers?
The obvious solution would be for the ICD loader to install an `OpenCLConfig.cmake` and put our dependencies there. However, since the headers are a separate project, they are an external dependency that must be referenced (or rather should; since we don't want to install the headers upon ICD installation). This can happen by shipping a `FindOpenCLHeader.cmake` along with the ICD or by adding CMake packaging to the Headers as well. The latter solution is what this PR is about.

## Other benefits
* Projects that just need the OpenCL headers, but not the ICD (such as OpenCL implementations) can now start to `find_package(OpenCLHeaders)` and keep the headers out of their tree.
* We now have CI in place that can be extended further. Same goes for the CMakeLists and the possibility to add proper tests.

## Implementation details
* The CMakeLists does not compile any code. It merely adds installation rules.
* CI is implemented by creating a Conan test package. The test package is built for different configurations. Since this uses Docker images, new compilers can easily be added  later on if desired.
* The README was improved to document how the headers are assumed to be consued.