### PR TITLE
Add enum value for `cl_khronos_vendor_id`

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -871,6 +871,9 @@ typedef struct _cl_buffer_region {
 
 #endif
 
+/* cl_khronos_vendor_id */
+#define CL_KHRONOS_VENDOR_ID_CODEPLAY               0x10004
+
 /********************************************************************************************************/
 
 /* Platform API */


### PR DESCRIPTION
Enum value depends on OpenCL spec change in https://github.com/KhronosGroup/OpenCL-Docs/pull/203

Including platform vendor IDs in the headers matches the convention of Vulkan, where this gets done automatically