### PR TITLE
Experimental enum for Khronos vendor ID

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -121,6 +121,7 @@ typedef cl_uint             cl_kernel_exec_info;
 #endif
 #ifdef CL_EXPERIMENTAL
 typedef cl_bitfield         cl_device_atomic_capabilities;
+typedef cl_uint             cl_khronos_vendor_id;
 #endif
 
 typedef struct _cl_image_format {


### PR DESCRIPTION
Represents a non-PCIe address `CL_DEVICE_VENDOR_ID` with the Khronos vendor ID.

Matching xml in https://github.com/KhronosGroup/OpenCL-Docs/pull/235