### PR TITLE
add missing error code CL_CONTEXT_TERMINATED_KHR

### DIFF
--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -181,6 +181,8 @@ typedef CL_API_ENTRY cl_program
  * cl_khr_terminate_context extension *
  **************************************/
 
+#define CL_CONTEXT_TERMINATED_KHR                   -1121
+
 #define CL_DEVICE_TERMINATE_CAPABILITY_KHR          0x2031
 #define CL_CONTEXT_TERMINATE_KHR                    0x2032
 


### PR DESCRIPTION
Fixes #69.

The corresponding XML change is here: https://github.com/KhronosGroup/OpenCL-Docs/pull/244