### PR TITLE
Make CL/cl_icd.h self-contained

### DIFF
--- a/CL/cl_icd.h
+++ b/CL/cl_icd.h
@@ -34,6 +34,12 @@
 #include <CL/cl_ext.h>
 #include <CL/cl_gl.h>
 
+#if defined(_WIN32)
+#include <CL/cl_d3d11.h>
+#include <CL/cl_d3d10.h>
+#include <CL/cl_dx9_media_sharing.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Update included DirectX 10 header and include the DirectX sharing headers from CL/cl_icd.h.
This addresses #80 and is necessary to build clvk on Windows.