### PR TITLE
update headers to latest OpenCL 3.0 API changes

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -1303,11 +1303,11 @@ clLinkProgram(cl_context           context,
 
 #ifdef CL_VERSION_2_2
 
-extern CL_API_ENTRY cl_int CL_API_CALL
+extern CL_API_ENTRY CL_EXT_PREFIX__VERSION_2_2_DEPRECATED cl_int CL_API_CALL
 clSetProgramReleaseCallback(cl_program          program,
                             void (CL_CALLBACK * pfn_notify)(cl_program program,
                                                             void * user_data),
-                            void *              user_data) CL_API_SUFFIX__VERSION_2_2;
+                            void *              user_data) CL_EXT_SUFFIX__VERSION_2_2_DEPRECATED;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clSetProgramSpecializationConstant(cl_program  program,

--- a/CL/cl.h
+++ b/CL/cl.h
@@ -412,6 +412,7 @@ typedef struct _cl_name_version {
 #define CL_DEVICE_OPENCL_C_FEATURES                      0x106F
 #define CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES            0x1070
 #define CL_DEVICE_PIPE_SUPPORT                           0x1071
+#define CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED      0x1072
 #endif
 
 /* cl_device_fp_config - bitfield */

--- a/CL/cl.h
+++ b/CL/cl.h
@@ -1031,6 +1031,16 @@ clGetContextInfo(cl_context         context,
                  void *             param_value,
                  size_t *           param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
+#ifdef CL_VERSION_3_0
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clSetContextDestructorCallback(cl_context         context,
+                               void (CL_CALLBACK* pfn_notify)(cl_context context,
+                                                              void* user_data),
+                               void*              user_data) CL_API_SUFFIX__VERSION_3_0;
+
+#endif
+
 /* Command Queue APIs */
 
 #ifdef CL_VERSION_2_0

--- a/CL/cl_icd.h
+++ b/CL/cl_icd.h
@@ -163,10 +163,16 @@ typedef CL_API_ENTRY cl_mem(CL_API_CALL *cl_api_clCreateImageWithProperties)(
     const cl_image_format *image_format, const cl_image_desc *image_desc,
     void *host_ptr, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_3_0;
 
+typedef CL_API_ENTRY cl_int(CL_API_CALL* clSetContextDestructorCallback)(
+    cl_context context,
+    void(CL_CALLBACK* pfn_notify)(cl_context context, void* user_data),
+    void* user_data) CL_API_SUFFIX__VERSION_3_0;
+
 #else
 
 typedef void *cl_api_clCreateBufferWithProperties;
 typedef void *cl_api_clCreateImageWithProperties;
+typedef void *cl_api_clSetContextDestructorCallback;
 
 #endif
 
@@ -1277,6 +1283,7 @@ typedef struct _cl_icd_dispatch {
   /* OpenCL 3.0 */
   cl_api_clCreateBufferWithProperties clCreateBufferWithProperties;
   cl_api_clCreateImageWithProperties clCreateImageWithProperties;
+  cl_api_clSetContextDestructorCallback clSetContextDestructorCallback;
 
 } cl_icd_dispatch;
 

--- a/CL/cl_icd.h
+++ b/CL/cl_icd.h
@@ -163,7 +163,7 @@ typedef CL_API_ENTRY cl_mem(CL_API_CALL *cl_api_clCreateImageWithProperties)(
     const cl_image_format *image_format, const cl_image_desc *image_desc,
     void *host_ptr, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_3_0;
 
-typedef CL_API_ENTRY cl_int(CL_API_CALL* clSetContextDestructorCallback)(
+typedef CL_API_ENTRY cl_int(CL_API_CALL* cl_api_clSetContextDestructorCallback)(
     cl_context context,
     void(CL_CALLBACK* pfn_notify)(cl_context context, void* user_data),
     void* user_data) CL_API_SUFFIX__VERSION_3_0;


### PR DESCRIPTION
This PR contains three updates based on the latest OpenCL API changes.  I think it's easiest to review these as one PR, but I can separate them if desired:

1. Adds the `clSetContextDestructorCallback` API function (fixes #98)
2. Adds the `CL_DEVICE_LATEST_CONFORMANCE_PASSED` enum (fixes #99)
3. Deprecates the `clSetProgramReleaseCallback` API function (fixes #100)