### PR TITLE
Add cl_intel_create_buffer_with_properties and cl_intel_mem_channel_property extensions

### DIFF
--- a/CL/cl_ext_intel.h
+++ b/CL/cl_ext_intel.h
@@ -675,6 +675,30 @@ clEnqueueMemAdviseINTEL_fn)(
             const cl_event* event_wait_list,
             cl_event* event);
 
+/***************************************************
+* cl_intel_create_buffer_with_properties extension *
+****************************************************/
+
+#define cl_intel_create_buffer_with_properties 1
+
+extern CL_API_ENTRY cl_mem CL_API_CALL
+clCreateBufferWithPropertiesINTEL(
+    cl_context   context,
+    const cl_mem_properties_intel* properties,
+    cl_mem_flags flags,
+    size_t       size,
+    void *       host_ptr,
+    cl_int *     errcode_ret) CL_EXT_SUFFIX__VERSION_1_0;
+
+typedef CL_API_ENTRY cl_mem (CL_API_CALL *
+clCreateBufferWithPropertiesINTEL_fn)(
+    cl_context   context,
+    const cl_mem_properties_intel* properties,
+    cl_mem_flags flags,
+    size_t       size,
+    void *       host_ptr,
+    cl_int *     errcode_ret) CL_EXT_SUFFIX__VERSION_1_0;
+
 #ifdef __cplusplus
 }
 #endif

--- a/CL/cl_ext_intel.h
+++ b/CL/cl_ext_intel.h
@@ -699,6 +699,12 @@ clCreateBufferWithPropertiesINTEL_fn)(
     void *       host_ptr,
     cl_int *     errcode_ret) CL_EXT_SUFFIX__VERSION_1_0;
 
+/******************************************
+* cl_intel_mem_channel_property extension *
+*******************************************/
+
+#define CL_MEM_CHANNEL_INTEL            0x4213
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Add cl_intel_create_buffer_with_properties extension function
Spec: https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_intel_create_buffer_with_properties.asciidoc
This extension allows OpenCL 1.x and 2.x devices to support the clCreateBufferWithProperties API that was added in OpenCL 3.0. This allows older OpenCL implementations to support other optional extensions or features that use the clCreateBufferWithProperties API to specify additional buffer properties, without recreating the API that is already part of OpenCL 3.0.

- Add CL_MEM_CHANNEL_INTEL property enum
Spec: https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_intel_mem_channel_property.asciidoc
This extension allows programmers to request that a buffer allocation be implemented in a particular region of memory.