### PR TITLE
update APIs and enums for cl_intel_unified_shared_memory for rev Q

### DIFF
--- a/CL/cl_ext_intel.h
+++ b/CL/cl_ext_intel.h
@@ -409,7 +409,7 @@ typedef cl_uint cl_diagnostics_verbose_level;
 * cl_intel_unified_shared_memory extension *
 ********************************************/
 
-/* These APIs are in sync with Revision O of the cl_intel_unified_shared_memory spec! */
+/* These APIs are in sync with Revision Q of the cl_intel_unified_shared_memory spec! */
 
 #define cl_intel_unified_shared_memory 1
 
@@ -531,6 +531,16 @@ clMemFreeINTEL(
 
 typedef CL_API_ENTRY cl_int (CL_API_CALL *
 clMemFreeINTEL_fn)(
+            cl_context context,
+            void* ptr);
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clMemBlockingFreeINTEL(
+            cl_context context,
+            void* ptr);
+
+typedef CL_API_ENTRY cl_int (CL_API_CALL *
+clMemBlockingFreeINTEL_fn)(
             cl_context context,
             void* ptr);
 


### PR DESCRIPTION
The USM spec may be found here:

https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/USM/cl_intel_unified_shared_memory.asciidoc

Specifically, this PR adds the API for clMemBlockingFreeINTEL.