### PR TITLE
header changes for cl_intel_mem_force_host_memory

### DIFF
--- a/CL/cl_ext_intel.h
+++ b/CL/cl_ext_intel.h
@@ -705,6 +705,15 @@ clCreateBufferWithPropertiesINTEL_fn)(
 
 #define CL_MEM_CHANNEL_INTEL            0x4213
 
+/*********************************
+* cl_intel_mem_force_host_memory *
+**********************************/
+
+#define cl_intel_mem_force_host_memory 1
+
+/* cl_mem_flags */
+#define CL_MEM_FORCE_HOST_MEMORY_INTEL                      (1 << 20)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR adds the header changes for the `cl_intel_mem_force_host_memory` extension.

The spec PR with XML changes is here:
https://github.com/KhronosGroup/OpenCL-Docs/pull/446