### PR TITLE
Avoid anon structs when MSVC uses /Za

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -133,22 +133,24 @@ typedef struct _cl_image_desc {
     size_t                  image_slice_pitch;
     cl_uint                 num_mip_levels;
     cl_uint                 num_samples;
-#ifdef CL_VERSION_2_0
-#ifdef __GNUC__
-    __extension__   /* Prevents warnings about anonymous union in -pedantic builds */
-#endif
+#ifdef CL_VERSION_2_0 && __CL_HAS_ANON_STRUCT__
 #ifdef _MSC_VER
+#if _MSC_VER >= 1500
 #pragma warning( push )
 #pragma warning( disable : 4201 ) /* Prevents warning about nameless struct/union in /W4 /Za builds */
 #endif
+#endif
+    __CL_ANON_STRUCT__
     union {
 #endif
       cl_mem                  buffer;
-#ifdef CL_VERSION_2_0
+#ifdef CL_VERSION_2_0 && __CL_HAS_ANON_STRUCT__
       cl_mem                  mem_object;
     };
 #ifdef _MSC_VER
+#if _MSC_VER >= 1500
 #pragma warning( pop )
+#endif
 #endif
 #endif
 } cl_image_desc;

--- a/CL/cl.h
+++ b/CL/cl.h
@@ -133,7 +133,8 @@ typedef struct _cl_image_desc {
     size_t                  image_slice_pitch;
     cl_uint                 num_mip_levels;
     cl_uint                 num_samples;
-#ifdef CL_VERSION_2_0 && __CL_HAS_ANON_STRUCT__
+#ifdef CL_VERSION_2_0
+#if __CL_HAS_ANON_STRUCT__
 #ifdef _MSC_VER
 #if _MSC_VER >= 1500
 #pragma warning( push )
@@ -143,13 +144,16 @@ typedef struct _cl_image_desc {
     __CL_ANON_STRUCT__
     union {
 #endif
+#endif
       cl_mem                  buffer;
-#ifdef CL_VERSION_2_0 && __CL_HAS_ANON_STRUCT__
+#ifdef CL_VERSION_2_0
+#if __CL_HAS_ANON_STRUCT__
       cl_mem                  mem_object;
     };
 #ifdef _MSC_VER
 #if _MSC_VER >= 1500
 #pragma warning( pop )
+#endif
 #endif
 #endif
 #endif

--- a/CL/cl_d3d10.h
+++ b/CL/cl_d3d10.h
@@ -17,7 +17,18 @@
 #ifndef __OPENCL_CL_D3D10_H
 #define __OPENCL_CL_D3D10_H
 
+#if defined( _WIN32) && defined(_MSC_VER)
+#if _MSC_VER >=1500
+#pragma warning( push )
+#pragma warning( disable : 4201 )
+#endif
+#endif
 #include <d3d10.h>
+#if defined( _WIN32) && defined(_MSC_VER)
+#if _MSC_VER >=1500
+#pragma warning( pop )
+#endif
+#endif
 #include <CL/cl.h>
 #include <CL/cl_platform.h>
 

--- a/CL/cl_d3d10.h
+++ b/CL/cl_d3d10.h
@@ -17,14 +17,14 @@
 #ifndef __OPENCL_CL_D3D10_H
 #define __OPENCL_CL_D3D10_H
 
-#if defined( _WIN32) && defined(_MSC_VER)
+#if defined(_MSC_VER)
 #if _MSC_VER >=1500
 #pragma warning( push )
 #pragma warning( disable : 4201 )
 #endif
 #endif
 #include <d3d10.h>
-#if defined( _WIN32) && defined(_MSC_VER)
+#if defined(_MSC_VER)
 #if _MSC_VER >=1500
 #pragma warning( pop )
 #endif

--- a/CL/cl_d3d11.h
+++ b/CL/cl_d3d11.h
@@ -17,7 +17,18 @@
 #ifndef __OPENCL_CL_D3D11_H
 #define __OPENCL_CL_D3D11_H
 
+#if defined( _WIN32) && defined(_MSC_VER)
+#if _MSC_VER >=1500
+#pragma warning( push )
+#pragma warning( disable : 4201 )
+#endif
+#endif
 #include <d3d11.h>
+#if defined( _WIN32) && defined(_MSC_VER)
+#if _MSC_VER >=1500
+#pragma warning( pop )
+#endif
+#endif
 #include <CL/cl.h>
 #include <CL/cl_platform.h>
 

--- a/CL/cl_d3d11.h
+++ b/CL/cl_d3d11.h
@@ -17,14 +17,14 @@
 #ifndef __OPENCL_CL_D3D11_H
 #define __OPENCL_CL_D3D11_H
 
-#if defined( _WIN32) && defined(_MSC_VER)
+#if defined(_MSC_VER)
 #if _MSC_VER >=1500
 #pragma warning( push )
 #pragma warning( disable : 4201 )
 #endif
 #endif
 #include <d3d11.h>
-#if defined( _WIN32) && defined(_MSC_VER)
+#if defined(_MSC_VER)
 #if _MSC_VER >=1500
 #pragma warning( pop )
 #endif

--- a/CL/cl_gl_ext.h
+++ b/CL/cl_gl_ext.h
@@ -30,7 +30,7 @@ extern "C" {
 
 extern CL_API_ENTRY cl_event CL_API_CALL
 clCreateEventFromGLsyncKHR(cl_context context,
-                           cl_GLsync  /*cl_GLsync*/,
+                           cl_GLsync  sync,
                            cl_int *   errcode_ret) CL_EXT_SUFFIX__VERSION_1_1;
 
 #ifdef __cplusplus

--- a/CL/cl_gl_ext.h
+++ b/CL/cl_gl_ext.h
@@ -30,7 +30,7 @@ extern "C" {
 
 extern CL_API_ENTRY cl_event CL_API_CALL
 clCreateEventFromGLsyncKHR(cl_context context,
-                           cl_GLsync  cl_GLsync,
+                           cl_GLsync  /*cl_GLsync*/,
                            cl_int *   errcode_ret) CL_EXT_SUFFIX__VERSION_1_1;
 
 #ifdef __cplusplus

--- a/CL/cl_half.h
+++ b/CL/cl_half.h
@@ -127,7 +127,7 @@ static inline cl_half cl_half_from_float(cl_float f, cl_half_rounding_mode round
   int32_t exp = f_exp - CL_FLT_MAX_EXP + 1;
 
   // Add FP16 exponent bias
-  uint16_t h_exp = exp + CL_HALF_MAX_EXP - 1;
+  uint16_t h_exp = (uint16_t)(exp + CL_HALF_MAX_EXP - 1);
 
   // Position of the bit that will become the FP16 mantissa LSB
   uint32_t lsb_pos = CL_FLT_MANT_DIG - CL_HALF_MANT_DIG;
@@ -138,7 +138,7 @@ static inline cl_half cl_half_from_float(cl_float f, cl_half_rounding_mode round
     if (f_mant)
     {
       // NaN -> propagate mantissa and silence it
-      uint16_t h_mant = f_mant >> lsb_pos;
+      uint16_t h_mant = (uint16_t)(f_mant >> lsb_pos);
       h_mant |= 0x200;
       return (sign << 15) | CL_HALF_EXP_MASK | h_mant;
     }
@@ -179,7 +179,7 @@ static inline cl_half cl_half_from_float(cl_float f, cl_half_rounding_mode round
   }
 
   // Generate FP16 mantissa by shifting FP32 mantissa
-  uint16_t h_mant = f_mant >> lsb_pos;
+  uint16_t h_mant = (uint16_t)(f_mant >> lsb_pos);
 
   // Check whether we need to round
   uint32_t halfway = 1 << (lsb_pos - 1);

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -1375,8 +1375,6 @@ typedef union
 }
 #endif
 
-#undef __CL_HAS_ANON_STRUCT__
-#undef __CL_ANON_STRUCT__
 #if defined( _WIN32) && defined(_MSC_VER) && ! defined(__STDC__)
     #if _MSC_VER >=1500
     #pragma warning( pop )

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -484,7 +484,7 @@ typedef unsigned int cl_GLenum;
 #elif defined( __GNUC__) && ! defined( __STRICT_ANSI__ )
 #define  __CL_HAS_ANON_STRUCT__ 1
 #define  __CL_ANON_STRUCT__ __extension__
-#elif defined( _WIN32) && defined(_MSC_VER)
+#elif defined( _WIN32) && defined(_MSC_VER) && ! defined(__STDC__)
     #if _MSC_VER >= 1500
    /* Microsoft Developer Studio 2008 supports anonymous structs, but
     * complains by default. */

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -1377,7 +1377,7 @@ typedef union
 
 #undef __CL_HAS_ANON_STRUCT__
 #undef __CL_ANON_STRUCT__
-#if defined( _WIN32) && defined(_MSC_VER)
+#if defined( _WIN32) && defined(_MSC_VER) && ! defined(__STDC__)
     #if _MSC_VER >=1500
     #pragma warning( pop )
     #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,13 +6,6 @@ enable_testing()
 
 include_directories(${PROJECT_SOURCE_DIR}/..)
 
-# Make sure headers do not produce warnings
-#if (NOT MSVC)
-#  add_compile_options(-Wall -Wextra -Werror -pedantic -Wno-format)
-#else()
-#  add_compile_options(/W4 /WX /Za)
-#endif ()
-
 # Add a test for a given source file for each version of OpenCL
 function(add_header_test NAME SOURCE)
   foreach(VERSION 100 110 120 200 210 220 300)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,11 +7,11 @@ enable_testing()
 include_directories(${PROJECT_SOURCE_DIR}/..)
 
 # Make sure headers do not produce warnings
-if (NOT MSVC)
-  add_compile_options(-Wall -Wextra -Werror -pedantic -Wno-format)
-else()
-  add_compile_options(/W4 /WX /Za)
-endif ()
+#if (NOT MSVC)
+#  add_compile_options(-Wall -Wextra -Werror -pedantic -Wno-format)
+#else()
+#  add_compile_options(/W4 /WX /Za)
+#endif ()
 
 # Add a test for a given source file for each version of OpenCL
 function(add_header_test NAME SOURCE)
@@ -19,7 +19,20 @@ function(add_header_test NAME SOURCE)
     set(TEST_EXE ${NAME}_${VERSION})
     add_executable(${TEST_EXE} ${SOURCE})
     target_compile_definitions(${TEST_EXE}
-      PUBLIC -DCL_TARGET_OPENCL_VERSION=${VERSION}
+      PUBLIC
+        -DCL_TARGET_OPENCL_VERSION=${VERSION}
+    )
+    # ICD on Windows uses system headers, which aren't strictly ANSI conformant
+    # and trigger warnings 
+    if(${NAME} STREQUAL cl_icd_h)
+      set(MSVC_COMPILE_DEFS /W4 /WX)
+    else()
+      set(MSVC_COMPILE_DEFS /W4 /WX /Za)
+    endif()
+    target_compile_options(${TEST_EXE}
+      PUBLIC
+        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Werror -pedantic -Wno-format>
+        $<$<CXX_COMPILER_ID:MSVC>:${MSVC_COMPILE_DEFS}>
     )
     add_test(NAME ${TEST_EXE} COMMAND ${TEST_EXE})
   endforeach(VERSION)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,9 @@ include_directories(${PROJECT_SOURCE_DIR}/..)
 
 # Make sure headers do not produce warnings
 if (NOT MSVC)
-add_compile_options(-Wall -Wextra -Werror -pedantic -Wno-format)
+  add_compile_options(-Wall -Wextra -Werror -pedantic -Wno-format)
+else()
+  add_compile_options(/W4 /WX /Za)
 endif ()
 
 # Add a test for a given source file for each version of OpenCL


### PR DESCRIPTION
This PR addresses #115