### PR TITLE
Revert using of __CL_HAS_ANON_STRUCT__ in cl.h

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -134,27 +134,21 @@ typedef struct _cl_image_desc {
     cl_uint                 num_mip_levels;
     cl_uint                 num_samples;
 #ifdef CL_VERSION_2_0
-#if __CL_HAS_ANON_STRUCT__
+#ifdef __GNUC__
+    __extension__   /* Prevents warnings about anonymous union in -pedantic builds */
+#endif
 #ifdef _MSC_VER
-#if _MSC_VER >= 1500
 #pragma warning( push )
 #pragma warning( disable : 4201 ) /* Prevents warning about nameless struct/union in /W4 /Za builds */
 #endif
-#endif
-    __CL_ANON_STRUCT__
     union {
-#endif
 #endif
       cl_mem                  buffer;
 #ifdef CL_VERSION_2_0
-#if __CL_HAS_ANON_STRUCT__
       cl_mem                  mem_object;
     };
 #ifdef _MSC_VER
-#if _MSC_VER >= 1500
 #pragma warning( pop )
-#endif
-#endif
 #endif
 #endif
 } cl_image_desc;

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -1375,6 +1375,8 @@ typedef union
 }
 #endif
 
+#undef __CL_HAS_ANON_STRUCT__
+#undef __CL_ANON_STRUCT__
 #if defined( _WIN32) && defined(_MSC_VER) && ! defined(__STDC__)
     #if _MSC_VER >=1500
     #pragma warning( pop )


### PR DESCRIPTION
This PR addresses #121, by reverting changes on `cl.h` of PR #116 