### PR TITLE
Add testing for cl_d3d10.h, cl_d3d11.h, and cl_dx9_media_sharing.h

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ function(add_header_test NAME SOURCE)
     # Some headers include system files which require anonymous structs
     # so we cannot test them with /Za:
     list(APPEND TEST_SKIP_ANSI_TESTING
-      cl_d3d10_h cl_d3d11_h cl_dx9_media_sharing_h cl_icd_h cl_layer_h)
+      cl_d3d10_h cl_d3d11_h cl_dx9_media_sharing_h cl_dx9_media_sharing_intel_h cl_icd_h cl_layer_h)
     list(FIND TEST_SKIP_ANSI_TESTING ${NAME} TEST_SKIP_INDEX)
     if(NOT (${TEST_SKIP_INDEX} GREATER -1 AND MSVC AND CMAKE_C_FLAGS MATCHES "/Za"))
       add_executable(${TEST_EXE} ${SOURCE})
@@ -25,6 +25,7 @@ add_header_test(cl_h test_cl.h.c)
 add_header_test(cl_d3d10_h test_cl_d3d10.h.c)
 add_header_test(cl_d3d11_h test_cl_d3d11.h.c)
 add_header_test(cl_dx9_media_sharing_h test_cl_dx9_media_sharing.h.c)
+add_header_test(cl_dx9_media_sharing_intel_h test_cl_dx9_media_sharing.h.c)
 add_header_test(cl_egl_h test_cl_egl.h.c)
 add_header_test(cl_ext_h test_cl_ext.h.c)
 add_header_test(cl_ext_intel_h test_cl_ext_intel.h.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,9 +2,12 @@
 function(add_header_test NAME SOURCE)
   foreach(VERSION 100 110 120 200 210 220 300)
     set(TEST_EXE ${NAME}_${VERSION})
-    # ICD on Windows uses system headers, which aren't strictly ANSI conformant
-    # and trigger warnings 
-    if(NOT (((NAME STREQUAL cl_icd_h) OR (NAME STREQUAL cl_layer_h)) AND MSVC AND CMAKE_C_FLAGS MATCHES "/Za"))
+    # Some headers include system files which require anonymous structs
+    # so we cannot test them with /Za:
+    list(APPEND TEST_SKIP_ANSI_TESTING
+      cl_d3d10_h cl_d3d11_h cl_dx9_media_sharing_h cl_icd_h cl_layer_h)
+    list(FIND TEST_SKIP_ANSI_TESTING ${NAME} TEST_SKIP_INDEX)
+    if(NOT (${TEST_SKIP_INDEX} GREATER -1 AND MSVC AND CMAKE_C_FLAGS MATCHES "/Za"))
       add_executable(${TEST_EXE} ${SOURCE})
       target_compile_definitions(${TEST_EXE}
         PUBLIC -DCL_TARGET_OPENCL_VERSION=${VERSION}
@@ -19,6 +22,9 @@ endfunction(add_header_test)
 
 # Tests
 add_header_test(cl_h test_cl.h.c)
+add_header_test(cl_d3d10_h test_cl_d3d10.h.c)
+add_header_test(cl_d3d11_h test_cl_d3d11.h.c)
+add_header_test(cl_dx9_media_sharing_h test_cl_dx9_media_sharing.h.c)
 add_header_test(cl_egl_h test_cl_egl.h.c)
 add_header_test(cl_ext_h test_cl_ext.h.c)
 add_header_test(cl_ext_intel_h test_cl_ext_intel.h.c)

--- a/tests/test_cl_d3d10.h.c
+++ b/tests/test_cl_d3d10.h.c
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2020 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <stdio.h>
+
+#if defined(_WIN32)
+#include "CL/cl_d3d10.h"
+#endif
+
+int main( void )
+{
+  printf("cl_d3d10.h standalone test PASSED.\n");
+  return 0;
+}

--- a/tests/test_cl_d3d11.h.c
+++ b/tests/test_cl_d3d11.h.c
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2020 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <stdio.h>
+
+#if defined(_WIN32)
+#include "CL/cl_d3d11.h"
+#endif
+
+int main( void )
+{
+  printf("cl_d3d11.h standalone test PASSED.\n");
+  return 0;
+}

--- a/tests/test_cl_dx9_media_sharing.h.c
+++ b/tests/test_cl_dx9_media_sharing.h.c
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2020 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <stdio.h>
+
+#if defined(_WIN32)
+#include "CL/cl_dx9_media_sharing.h"
+#endif
+
+int main( void )
+{
+  printf("cl_dx9_media_sharing.h standalone test PASSED.\n");
+  return 0;
+}

--- a/tests/test_cl_dx9_media_sharing_intel.h.c
+++ b/tests/test_cl_dx9_media_sharing_intel.h.c
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2020 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <stdio.h>
+
+#if defined(_WIN32)
+#include "CL/cl_dx9_media_sharing_intel.h"
+#endif
+
+int main( void )
+{
+  printf("cl_dx9_media_sharing_intel.h standalone test PASSED.\n");
+  return 0;
+}


### PR DESCRIPTION
Adds missing testing for cl_d3d10.h, cl_d3d11.h, and cl_dx9_media_sharing.h.