### PR TITLE
re-enable anonymous unions by default

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -134,27 +134,29 @@ typedef struct _cl_image_desc {
     cl_uint                 num_mip_levels;
     cl_uint                 num_samples;
 #ifdef CL_VERSION_2_0
-#if __CL_HAS_ANON_STRUCT__
-#ifdef _MSC_VER
-#if _MSC_VER >= 1500
+#if defined(__GNUC__)
+    __extension__                   /* Prevents warnings about anonymous union in -pedantic builds */
+#endif
+#if defined(_MSC_VER) && !defined(__STDC__)
 #pragma warning( push )
-#pragma warning( disable : 4201 ) /* Prevents warning about nameless struct/union in /W4 /Za builds */
+#pragma warning( disable : 4201 )   /* Prevents warning about nameless struct/union in /W4 builds */
 #endif
-#endif
-    __CL_ANON_STRUCT__
+#if defined(_MSC_VER) && defined(__STDC__)
+    /* Anonymous unions are not supported in /Za builds */
+#else
     union {
 #endif
 #endif
       cl_mem                  buffer;
 #ifdef CL_VERSION_2_0
-#if __CL_HAS_ANON_STRUCT__
+#if defined(_MSC_VER) && defined(__STDC__)
+    /* Anonymous unions are not supported in /Za builds */
+#else
       cl_mem                  mem_object;
     };
-#ifdef _MSC_VER
-#if _MSC_VER >= 1500
+#endif
+#if defined(_MSC_VER) && !defined(__STDC__)
 #pragma warning( pop )
-#endif
-#endif
 #endif
 #endif
 } cl_image_desc;


### PR DESCRIPTION
This is a slight relaxation of the changes in #116 to re-enable anonymous unions by default (but not anonymous structs), and to disable anonymous unions only when they are known to not be supported, which is currently only for MSVC builds with `/Za`.

See also #121 

It's probably easiest to review these changes by [comparing against the previous commit](https://github.com/KhronosGroup/OpenCL-Headers/compare/9d17180a33566500551ff98e9eba62b0867a6f64...bashbaug:relax-anonymous-union) before #116.  The main difference is the addition of an `#ifdef` block to bypass the anonymous union for `/Za' builds.

This change passed all of my testing on Windows, including the tests I added in #123.