### PR TITLE
switch the default version for the OpenCL headers to OpenCL 3.0

### DIFF
--- a/CL/cl_version.h
+++ b/CL/cl_version.h
@@ -19,8 +19,8 @@
 
 /* Detect which version to target */
 #if !defined(CL_TARGET_OPENCL_VERSION)
-#pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)")
-#define CL_TARGET_OPENCL_VERSION 220
+#pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 300 (OpenCL 3.0)")
+#define CL_TARGET_OPENCL_VERSION 300
 #endif
 #if CL_TARGET_OPENCL_VERSION != 100 && \
     CL_TARGET_OPENCL_VERSION != 110 && \
@@ -29,9 +29,9 @@
     CL_TARGET_OPENCL_VERSION != 210 && \
     CL_TARGET_OPENCL_VERSION != 220 && \
     CL_TARGET_OPENCL_VERSION != 300
-#pragma message("cl_version: CL_TARGET_OPENCL_VERSION is not a valid value (100, 110, 120, 200, 210, 220, 300). Defaulting to 220 (OpenCL 2.2)")
+#pragma message("cl_version: CL_TARGET_OPENCL_VERSION is not a valid value (100, 110, 120, 200, 210, 220, 300). Defaulting to 300 (OpenCL 3.0)")
 #undef CL_TARGET_OPENCL_VERSION
-#define CL_TARGET_OPENCL_VERSION 220
+#define CL_TARGET_OPENCL_VERSION 300
 #endif
 
 


### PR DESCRIPTION
Since OpenCL 3.0 is now final, we should switch the default OpenCL version for the headers if no OpenCL version is provided to OpenCL 3.0 instead of OpenCL 2.2.