### PR TITLE
do not include cl_gl_ext.h from opencl.h

### DIFF
--- a/CL/opencl.h
+++ b/CL/opencl.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2020 The Khronos Group Inc.
+ * Copyright (c) 2008-2021 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ extern "C" {
 
 #include <CL/cl.h>
 #include <CL/cl_gl.h>
-#include <CL/cl_gl_ext.h>
 #include <CL/cl_ext.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Since the extensions from `cl_gl_ext.h` have been moved into `cl_gl.h` (by https://github.com/KhronosGroup/OpenCL-Headers/pull/156) it should not longer be included from `opencl.h`.  This will eliminate a build message for applications that only include `opencl.h`.