### PR TITLE
disable failing CI configs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        VER: [7, 8, 9]
+        #VER: [7, 8, 9]
+        VER: [7, 9] # gcc-8 is not installed on the Ubuntu 18.04 image
         EXT: [ON, OFF]
         GEN: [Unix Makefiles, Ninja]
         VAR: [Debug, Release]

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -260,7 +260,8 @@ jobs:
       matrix:
         VER: [8, 9]
         EXT: [ON, OFF]
-        GEN: [Xcode, Ninja Multi-Config]
+        #GEN: [Xcode, Ninja Multi-Config]
+        GEN: [Xcode] # Disabling Ninja - need to investigate setup-ninja?
         STD: [99, 11] # 90 results in errors
 
     steps:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   linux-gcc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         VER: [7, 8, 9]


### PR DESCRIPTION
We need to update our CI configs to work with recent GitHub actions changes.

This PR disables the failing configs until we do this.  Specific changes in this PR are:

1. Use the Ubuntu 18.04 image instead of the Ubuntu 20.04 (ubuntu-latest) image.
2. Disable the gcc-8 config since it is no longer included in the Ubuntu 18.04 image.
2. Disable the MacOS Ninja config since the current method of installing it is no longer working.

If this PR is merged I'll create an issue to track re-enabling whichever configs we want to re-enable.