### PR TITLE
Add missing 'stdint.h' include to 'CL/cl.h'

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -20,6 +20,8 @@
 #include <CL/cl_version.h>
 #include <CL/cl_platform.h>
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/CL/cl.h
+++ b/CL/cl.h
@@ -20,8 +20,6 @@
 #include <CL/cl_version.h>
 #include <CL/cl_platform.h>
 
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -19,6 +19,9 @@
 
 #include <CL/cl_version.h>
 
+/* Always required to support intptr_t in cl.h */
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -234,8 +237,6 @@ typedef double                  cl_double;
 #define CL_INFINITY         CL_HUGE_VALF
 
 #else
-
-#include <stdint.h>
 
 /* scalar types  */
 typedef int8_t          cl_char;

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -19,9 +19,6 @@
 
 #include <CL/cl_version.h>
 
-/* Always required to support intptr_t in cl.h */
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -138,6 +135,12 @@ extern "C" {
 
 #if (defined (_WIN32) && defined(_MSC_VER))
 
+/* intptr_t is used in cl.h and provided by stddef.h in Visual C++, but not in clang */
+/* stdint.h was missing before Visual Studio 2010, include it for later versions and for clang */
+#if defined(__clang__) || _MSC_VER >= 1600
+    #include <stdint.h>
+#endif
+
 /* scalar types  */
 typedef signed   __int8         cl_char;
 typedef unsigned __int8         cl_uchar;
@@ -237,6 +240,8 @@ typedef double                  cl_double;
 #define CL_INFINITY         CL_HUGE_VALF
 
 #else
+
+#include <stdint.h>
 
 /* scalar types  */
 typedef int8_t          cl_char;


### PR DESCRIPTION
The header `CL/cl.h` is using `intptr_t`, but doesn't include the required `stdint.h` header.

On non-Windows platforms the header is already included by `CL/cl_platform.h`, but on Windows it causes a compilation error if `stdint.h` is not included before using `CL/cl.h`.