### PR TITLE
Fix condition for warning 4201 pop

### DIFF
--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -1395,7 +1395,9 @@ typedef union
 }
 #endif
 
-#if defined( _WIN32) && defined(_MSC_VER) && ! defined(__STDC__)
+#if !defined(__cplusplus) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#elif defined( __GNUC__) && ! defined( __STRICT_ANSI__ )
+#elif defined( _WIN32) && defined(_MSC_VER) && ! defined(__STDC__)
     #if _MSC_VER >=1500
     #pragma warning( pop )
     #endif


### PR DESCRIPTION
Matching the condition for push.
New clang compiler version complains that the warning can be popped
without being pushed first.