### PR TITLE
add external memory, external semaphore, and semaphore provisional extensions

### DIFF
--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -954,8 +954,8 @@ typedef cl_ulong            cl_semaphore_payload_khr;
 
 /* cl_semaphore_info_khr or cl_semaphore_properties_khr */
 #define CL_SEMAPHORE_TYPE_KHR                               0x203D
-#define CL_DEVICE_HANDLE_LIST_KHR                           0x2051
-#define CL_DEVICE_HANDLE_LIST_END_KHR                       0
+/* enum CL_DEVICE_HANDLE_LIST_KHR */
+/* enum CL_DEVICE_HANDLE_LIST_END_KHR */
 
 /* cl_command_type */
 #define CL_COMMAND_SEMAPHORE_WAIT_KHR                       0x2042


### PR DESCRIPTION
Header updates for the provisional extensions `cl_khr_semaphore`, `cl_khr_external_semaphore` (and related extensions), and `cl_khr_external_memory` (and related extensions).  See: https://github.com/KhronosGroup/OpenCL-Docs/pull/695