### PR TITLE
Option to disable tests when subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ project(OpenCLHeaders
   # https://stackoverflow.com/questions/43379311/why-does-project-affect-cmakes-opinion-on-cmake-sizeof-void-p
 )
 
+option(OPENCL_HEADERS_BUILD_TESTING "Enable support for OpenCL C headers testing." OFF)
+
 include(GNUInstallDirs)
 
 add_library(Headers INTERFACE)
@@ -83,7 +85,9 @@ install(
   DESTINATION ${config_package_location}
 )
 
-if(BUILD_TESTING)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR OPENCL_HEADERS_BUILD_TESTING)
   include(CTest)
+endif()
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR OPENCL_HEADERS_BUILD_TESTING) AND BUILD_TESTING)
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
This PR follows the path paved by OpenCL-ICD-Loader crafted by @bashbaug [here](https://github.com/KhronosGroup/OpenCL-ICD-Loader/pull/117).

The behavior is:
- When built as top-level project
  - Tests by default are built.
  - To opt-out of testing, one uses the canonical `BUILD_TESTING` (on-by default)
- When built as a subproject
  - Tests are _not_ built by default
  - If tests are otherwise enabled (using the canonical `BUILD_TESTING` variable) one can opt-in to testing via `OPENCL_HEADERS_BUILD_TESTING`