### PR TITLE
Disable anon struct warnings for Clang on Win using GNU-like CLI

### DIFF
--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -516,6 +516,9 @@ typedef unsigned int cl_GLenum;
 #elif defined(__GNUC__) && ! defined(__STRICT_ANSI__)
 #define  __CL_HAS_ANON_STRUCT__ 1
 #define  __CL_ANON_STRUCT__ __extension__
+#elif defined(__clang__)
+#define  __CL_HAS_ANON_STRUCT__ 1
+#define  __CL_ANON_STRUCT__ __extension__
 #else
 #define  __CL_HAS_ANON_STRUCT__ 0
 #define  __CL_ANON_STRUCT__


### PR DESCRIPTION
I started compiling OpenCL-Layers on Windows using clang using both `clang-cl.exe` and `clang.exe`. When using the GNU-like CLI, it warns about anon-structs like GCC does too and the `__extension__` decorator is required.