### PR TITLE
Formatted headers and added style check.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,149 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Mozilla
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: AcrossEmptyLinesAndComments
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: AcrossEmptyLinesAndComments
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+AlwaysBreakAfterReturnType: TopLevel
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Never
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,11 +8,11 @@ jobs:
       - name: retrieve merge target info
         run: git fetch origin $GITHUB_BASE_REF
       - run: sudo apt-get update
-      - run: sudo apt-get install -y clang-format-10
+      - run: sudo apt-get install -y clang-format
       - name: run git-clang-format
         run: |
           target=$(git rev-parse origin/$GITHUB_BASE_REF)
-          git-clang-format-10 --quiet --diff $target > clang-format-diff
+          git-clang-format --quiet --diff $target > clang-format-diff
           lint=$(grep -v --color=never "no modified files to format" clang-format-diff || true)
           if [ ! -z "$lint" ]; then echo "format errors, inspect the clang-format-diff artifact for info"; exit 1; else exit 0; fi
         shell: bash

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,21 @@
+name: style-checks
+on: [pull_request]
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: retrieve merge target info
+        run: git fetch origin $GITHUB_BASE_REF
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y clang-format-10
+      - name: run git-clang-format
+        run: |
+          target=$(git rev-parse origin/$GITHUB_BASE_REF)
+          git-clang-format-10 --quiet --diff $target > clang-format-diff
+          lint=$(grep -v --color=never "no modified files to format" clang-format-diff || true)
+          if [ ! -z "$lint" ]; then echo "format errors, inspect the clang-format-diff artifact for info"; exit 1; else exit 0; fi
+        shell: bash
+      - name: output clang format diff
+        if: always()
+        run: cat ./clang-format-diff

--- a/CL/cl.h
+++ b/CL/cl.h
@@ -17,8 +17,8 @@
 #ifndef __OPENCL_CL_H
 #define __OPENCL_CL_H
 
-#include <CL/cl_version.h>
 #include <CL/cl_platform.h>
+#include <CL/cl_version.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,141 +26,150 @@ extern "C" {
 
 /******************************************************************************/
 
-typedef struct _cl_platform_id *    cl_platform_id;
-typedef struct _cl_device_id *      cl_device_id;
-typedef struct _cl_context *        cl_context;
-typedef struct _cl_command_queue *  cl_command_queue;
-typedef struct _cl_mem *            cl_mem;
-typedef struct _cl_program *        cl_program;
-typedef struct _cl_kernel *         cl_kernel;
-typedef struct _cl_event *          cl_event;
-typedef struct _cl_sampler *        cl_sampler;
+typedef struct _cl_platform_id*   cl_platform_id;
+typedef struct _cl_device_id*     cl_device_id;
+typedef struct _cl_context*       cl_context;
+typedef struct _cl_command_queue* cl_command_queue;
+typedef struct _cl_mem*           cl_mem;
+typedef struct _cl_program*       cl_program;
+typedef struct _cl_kernel*        cl_kernel;
+typedef struct _cl_event*         cl_event;
+typedef struct _cl_sampler*       cl_sampler;
 
-typedef cl_uint             cl_bool;                     /* WARNING!  Unlike cl_ types in cl_platform.h, cl_bool is not guaranteed to be the same size as the bool in kernels. */
-typedef cl_ulong            cl_bitfield;
-typedef cl_ulong            cl_properties;
-typedef cl_bitfield         cl_device_type;
-typedef cl_uint             cl_platform_info;
-typedef cl_uint             cl_device_info;
-typedef cl_bitfield         cl_device_fp_config;
-typedef cl_uint             cl_device_mem_cache_type;
-typedef cl_uint             cl_device_local_mem_type;
-typedef cl_bitfield         cl_device_exec_capabilities;
+typedef cl_uint
+  cl_bool; /* WARNING!  Unlike cl_ types in cl_platform.h, cl_bool is not
+              guaranteed to be the same size as the bool in kernels. */
+typedef cl_ulong    cl_bitfield;
+typedef cl_ulong    cl_properties;
+typedef cl_bitfield cl_device_type;
+typedef cl_uint     cl_platform_info;
+typedef cl_uint     cl_device_info;
+typedef cl_bitfield cl_device_fp_config;
+typedef cl_uint     cl_device_mem_cache_type;
+typedef cl_uint     cl_device_local_mem_type;
+typedef cl_bitfield cl_device_exec_capabilities;
 #ifdef CL_VERSION_2_0
-typedef cl_bitfield         cl_device_svm_capabilities;
+typedef cl_bitfield cl_device_svm_capabilities;
 #endif
-typedef cl_bitfield         cl_command_queue_properties;
+typedef cl_bitfield cl_command_queue_properties;
 #ifdef CL_VERSION_1_2
-typedef intptr_t            cl_device_partition_property;
-typedef cl_bitfield         cl_device_affinity_domain;
+typedef intptr_t    cl_device_partition_property;
+typedef cl_bitfield cl_device_affinity_domain;
 #endif
 
-typedef intptr_t            cl_context_properties;
-typedef cl_uint             cl_context_info;
+typedef intptr_t cl_context_properties;
+typedef cl_uint  cl_context_info;
 #ifdef CL_VERSION_2_0
-typedef cl_properties       cl_queue_properties;
+typedef cl_properties cl_queue_properties;
 #endif
-typedef cl_uint             cl_command_queue_info;
-typedef cl_uint             cl_channel_order;
-typedef cl_uint             cl_channel_type;
-typedef cl_bitfield         cl_mem_flags;
+typedef cl_uint     cl_command_queue_info;
+typedef cl_uint     cl_channel_order;
+typedef cl_uint     cl_channel_type;
+typedef cl_bitfield cl_mem_flags;
 #ifdef CL_VERSION_2_0
-typedef cl_bitfield         cl_svm_mem_flags;
+typedef cl_bitfield cl_svm_mem_flags;
 #endif
-typedef cl_uint             cl_mem_object_type;
-typedef cl_uint             cl_mem_info;
+typedef cl_uint cl_mem_object_type;
+typedef cl_uint cl_mem_info;
 #ifdef CL_VERSION_1_2
-typedef cl_bitfield         cl_mem_migration_flags;
+typedef cl_bitfield cl_mem_migration_flags;
 #endif
-typedef cl_uint             cl_image_info;
+typedef cl_uint cl_image_info;
 #ifdef CL_VERSION_1_1
-typedef cl_uint             cl_buffer_create_type;
+typedef cl_uint cl_buffer_create_type;
 #endif
-typedef cl_uint             cl_addressing_mode;
-typedef cl_uint             cl_filter_mode;
-typedef cl_uint             cl_sampler_info;
-typedef cl_bitfield         cl_map_flags;
+typedef cl_uint     cl_addressing_mode;
+typedef cl_uint     cl_filter_mode;
+typedef cl_uint     cl_sampler_info;
+typedef cl_bitfield cl_map_flags;
 #ifdef CL_VERSION_2_0
-typedef intptr_t            cl_pipe_properties;
-typedef cl_uint             cl_pipe_info;
+typedef intptr_t cl_pipe_properties;
+typedef cl_uint  cl_pipe_info;
 #endif
-typedef cl_uint             cl_program_info;
-typedef cl_uint             cl_program_build_info;
+typedef cl_uint cl_program_info;
+typedef cl_uint cl_program_build_info;
 #ifdef CL_VERSION_1_2
-typedef cl_uint             cl_program_binary_type;
+typedef cl_uint cl_program_binary_type;
 #endif
-typedef cl_int              cl_build_status;
-typedef cl_uint             cl_kernel_info;
+typedef cl_int  cl_build_status;
+typedef cl_uint cl_kernel_info;
 #ifdef CL_VERSION_1_2
-typedef cl_uint             cl_kernel_arg_info;
-typedef cl_uint             cl_kernel_arg_address_qualifier;
-typedef cl_uint             cl_kernel_arg_access_qualifier;
-typedef cl_bitfield         cl_kernel_arg_type_qualifier;
+typedef cl_uint     cl_kernel_arg_info;
+typedef cl_uint     cl_kernel_arg_address_qualifier;
+typedef cl_uint     cl_kernel_arg_access_qualifier;
+typedef cl_bitfield cl_kernel_arg_type_qualifier;
 #endif
-typedef cl_uint             cl_kernel_work_group_info;
+typedef cl_uint cl_kernel_work_group_info;
 #ifdef CL_VERSION_2_1
-typedef cl_uint             cl_kernel_sub_group_info;
+typedef cl_uint cl_kernel_sub_group_info;
 #endif
-typedef cl_uint             cl_event_info;
-typedef cl_uint             cl_command_type;
-typedef cl_uint             cl_profiling_info;
+typedef cl_uint cl_event_info;
+typedef cl_uint cl_command_type;
+typedef cl_uint cl_profiling_info;
 #ifdef CL_VERSION_2_0
-typedef cl_properties       cl_sampler_properties;
-typedef cl_uint             cl_kernel_exec_info;
+typedef cl_properties cl_sampler_properties;
+typedef cl_uint       cl_kernel_exec_info;
 #endif
 #ifdef CL_VERSION_3_0
-typedef cl_bitfield         cl_device_atomic_capabilities;
-typedef cl_bitfield         cl_device_device_enqueue_capabilities;
-typedef cl_uint             cl_khronos_vendor_id;
-typedef cl_properties       cl_mem_properties;
-typedef cl_uint             cl_version;
+typedef cl_bitfield   cl_device_atomic_capabilities;
+typedef cl_bitfield   cl_device_device_enqueue_capabilities;
+typedef cl_uint       cl_khronos_vendor_id;
+typedef cl_properties cl_mem_properties;
+typedef cl_uint       cl_version;
 #endif
 
-typedef struct _cl_image_format {
-    cl_channel_order        image_channel_order;
-    cl_channel_type         image_channel_data_type;
+typedef struct _cl_image_format
+{
+  cl_channel_order image_channel_order;
+  cl_channel_type  image_channel_data_type;
 } cl_image_format;
 
 #ifdef CL_VERSION_1_2
 
-typedef struct _cl_image_desc {
-    cl_mem_object_type      image_type;
-    size_t                  image_width;
-    size_t                  image_height;
-    size_t                  image_depth;
-    size_t                  image_array_size;
-    size_t                  image_row_pitch;
-    size_t                  image_slice_pitch;
-    cl_uint                 num_mip_levels;
-    cl_uint                 num_samples;
+typedef struct _cl_image_desc
+{
+  cl_mem_object_type image_type;
+  size_t             image_width;
+  size_t             image_height;
+  size_t             image_depth;
+  size_t             image_array_size;
+  size_t             image_row_pitch;
+  size_t             image_slice_pitch;
+  cl_uint            num_mip_levels;
+  cl_uint            num_samples;
 #ifdef CL_VERSION_2_0
 #if defined(__GNUC__)
-    __extension__                   /* Prevents warnings about anonymous union in -pedantic builds */
+  __extension__ /* Prevents warnings about anonymous union in -pedantic builds
+                 */
 #endif
 #if defined(_MSC_VER) && !defined(__STDC__)
-#pragma warning( push )
-#pragma warning( disable : 4201 )   /* Prevents warning about nameless struct/union in /W4 builds */
+#pragma warning(push)
+#pragma warning(disable : 4201) /* Prevents warning about nameless             \
+                                   struct/union in /W4 builds */
 #endif
 #ifdef __clang__
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wc11-extensions" /* Prevents warning about nameless union being C11 extension*/
+#pragma clang diagnostic ignored                                               \
+  "-Wc11-extensions" /* Prevents warning about nameless union being C11        \
+                        extension*/
 #endif
 #if defined(_MSC_VER) && defined(__STDC__)
-    /* Anonymous unions are not supported in /Za builds */
+  /* Anonymous unions are not supported in /Za builds */
 #else
-    union {
+  union
+  {
 #endif
 #endif
-      cl_mem                  buffer;
+    cl_mem buffer;
 #ifdef CL_VERSION_2_0
 #if defined(_MSC_VER) && defined(__STDC__)
-    /* Anonymous unions are not supported in /Za builds */
+  /* Anonymous unions are not supported in /Za builds */
 #else
-      cl_mem                  mem_object;
-    };
+    cl_mem mem_object;
+  };
 #endif
 #if defined(_MSC_VER) && !defined(__STDC__)
-#pragma warning( pop )
+#pragma warning(pop)
 #endif
 #ifdef __clang__
 #pragma clang diagnostic pop
@@ -172,9 +181,10 @@ typedef struct _cl_image_desc {
 
 #ifdef CL_VERSION_1_1
 
-typedef struct _cl_buffer_region {
-    size_t                  origin;
-    size_t                  size;
+typedef struct _cl_buffer_region
+{
+  size_t origin;
+  size_t size;
 } cl_buffer_region;
 
 #endif
@@ -183,9 +193,10 @@ typedef struct _cl_buffer_region {
 
 #define CL_NAME_VERSION_MAX_NAME_SIZE 64
 
-typedef struct _cl_name_version {
-    cl_version              version;
-    char                    name[CL_NAME_VERSION_MAX_NAME_SIZE];
+typedef struct _cl_name_version
+{
+  cl_version version;
+  char       name[CL_NAME_VERSION_MAX_NAME_SIZE];
 } cl_name_version;
 
 #endif
@@ -193,218 +204,218 @@ typedef struct _cl_name_version {
 /******************************************************************************/
 
 /* Error Codes */
-#define CL_SUCCESS                                  0
-#define CL_DEVICE_NOT_FOUND                         -1
-#define CL_DEVICE_NOT_AVAILABLE                     -2
-#define CL_COMPILER_NOT_AVAILABLE                   -3
-#define CL_MEM_OBJECT_ALLOCATION_FAILURE            -4
-#define CL_OUT_OF_RESOURCES                         -5
-#define CL_OUT_OF_HOST_MEMORY                       -6
-#define CL_PROFILING_INFO_NOT_AVAILABLE             -7
-#define CL_MEM_COPY_OVERLAP                         -8
-#define CL_IMAGE_FORMAT_MISMATCH                    -9
-#define CL_IMAGE_FORMAT_NOT_SUPPORTED               -10
-#define CL_BUILD_PROGRAM_FAILURE                    -11
-#define CL_MAP_FAILURE                              -12
+#define CL_SUCCESS                       0
+#define CL_DEVICE_NOT_FOUND              -1
+#define CL_DEVICE_NOT_AVAILABLE          -2
+#define CL_COMPILER_NOT_AVAILABLE        -3
+#define CL_MEM_OBJECT_ALLOCATION_FAILURE -4
+#define CL_OUT_OF_RESOURCES              -5
+#define CL_OUT_OF_HOST_MEMORY            -6
+#define CL_PROFILING_INFO_NOT_AVAILABLE  -7
+#define CL_MEM_COPY_OVERLAP              -8
+#define CL_IMAGE_FORMAT_MISMATCH         -9
+#define CL_IMAGE_FORMAT_NOT_SUPPORTED    -10
+#define CL_BUILD_PROGRAM_FAILURE         -11
+#define CL_MAP_FAILURE                   -12
 #ifdef CL_VERSION_1_1
-#define CL_MISALIGNED_SUB_BUFFER_OFFSET             -13
+#define CL_MISALIGNED_SUB_BUFFER_OFFSET              -13
 #define CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST -14
 #endif
 #ifdef CL_VERSION_1_2
-#define CL_COMPILE_PROGRAM_FAILURE                  -15
-#define CL_LINKER_NOT_AVAILABLE                     -16
-#define CL_LINK_PROGRAM_FAILURE                     -17
-#define CL_DEVICE_PARTITION_FAILED                  -18
-#define CL_KERNEL_ARG_INFO_NOT_AVAILABLE            -19
+#define CL_COMPILE_PROGRAM_FAILURE       -15
+#define CL_LINKER_NOT_AVAILABLE          -16
+#define CL_LINK_PROGRAM_FAILURE          -17
+#define CL_DEVICE_PARTITION_FAILED       -18
+#define CL_KERNEL_ARG_INFO_NOT_AVAILABLE -19
 #endif
 
-#define CL_INVALID_VALUE                            -30
-#define CL_INVALID_DEVICE_TYPE                      -31
-#define CL_INVALID_PLATFORM                         -32
-#define CL_INVALID_DEVICE                           -33
-#define CL_INVALID_CONTEXT                          -34
-#define CL_INVALID_QUEUE_PROPERTIES                 -35
-#define CL_INVALID_COMMAND_QUEUE                    -36
-#define CL_INVALID_HOST_PTR                         -37
-#define CL_INVALID_MEM_OBJECT                       -38
-#define CL_INVALID_IMAGE_FORMAT_DESCRIPTOR          -39
-#define CL_INVALID_IMAGE_SIZE                       -40
-#define CL_INVALID_SAMPLER                          -41
-#define CL_INVALID_BINARY                           -42
-#define CL_INVALID_BUILD_OPTIONS                    -43
-#define CL_INVALID_PROGRAM                          -44
-#define CL_INVALID_PROGRAM_EXECUTABLE               -45
-#define CL_INVALID_KERNEL_NAME                      -46
-#define CL_INVALID_KERNEL_DEFINITION                -47
-#define CL_INVALID_KERNEL                           -48
-#define CL_INVALID_ARG_INDEX                        -49
-#define CL_INVALID_ARG_VALUE                        -50
-#define CL_INVALID_ARG_SIZE                         -51
-#define CL_INVALID_KERNEL_ARGS                      -52
-#define CL_INVALID_WORK_DIMENSION                   -53
-#define CL_INVALID_WORK_GROUP_SIZE                  -54
-#define CL_INVALID_WORK_ITEM_SIZE                   -55
-#define CL_INVALID_GLOBAL_OFFSET                    -56
-#define CL_INVALID_EVENT_WAIT_LIST                  -57
-#define CL_INVALID_EVENT                            -58
-#define CL_INVALID_OPERATION                        -59
-#define CL_INVALID_GL_OBJECT                        -60
-#define CL_INVALID_BUFFER_SIZE                      -61
-#define CL_INVALID_MIP_LEVEL                        -62
-#define CL_INVALID_GLOBAL_WORK_SIZE                 -63
+#define CL_INVALID_VALUE                   -30
+#define CL_INVALID_DEVICE_TYPE             -31
+#define CL_INVALID_PLATFORM                -32
+#define CL_INVALID_DEVICE                  -33
+#define CL_INVALID_CONTEXT                 -34
+#define CL_INVALID_QUEUE_PROPERTIES        -35
+#define CL_INVALID_COMMAND_QUEUE           -36
+#define CL_INVALID_HOST_PTR                -37
+#define CL_INVALID_MEM_OBJECT              -38
+#define CL_INVALID_IMAGE_FORMAT_DESCRIPTOR -39
+#define CL_INVALID_IMAGE_SIZE              -40
+#define CL_INVALID_SAMPLER                 -41
+#define CL_INVALID_BINARY                  -42
+#define CL_INVALID_BUILD_OPTIONS           -43
+#define CL_INVALID_PROGRAM                 -44
+#define CL_INVALID_PROGRAM_EXECUTABLE      -45
+#define CL_INVALID_KERNEL_NAME             -46
+#define CL_INVALID_KERNEL_DEFINITION       -47
+#define CL_INVALID_KERNEL                  -48
+#define CL_INVALID_ARG_INDEX               -49
+#define CL_INVALID_ARG_VALUE               -50
+#define CL_INVALID_ARG_SIZE                -51
+#define CL_INVALID_KERNEL_ARGS             -52
+#define CL_INVALID_WORK_DIMENSION          -53
+#define CL_INVALID_WORK_GROUP_SIZE         -54
+#define CL_INVALID_WORK_ITEM_SIZE          -55
+#define CL_INVALID_GLOBAL_OFFSET           -56
+#define CL_INVALID_EVENT_WAIT_LIST         -57
+#define CL_INVALID_EVENT                   -58
+#define CL_INVALID_OPERATION               -59
+#define CL_INVALID_GL_OBJECT               -60
+#define CL_INVALID_BUFFER_SIZE             -61
+#define CL_INVALID_MIP_LEVEL               -62
+#define CL_INVALID_GLOBAL_WORK_SIZE        -63
 #ifdef CL_VERSION_1_1
-#define CL_INVALID_PROPERTY                         -64
+#define CL_INVALID_PROPERTY -64
 #endif
 #ifdef CL_VERSION_1_2
-#define CL_INVALID_IMAGE_DESCRIPTOR                 -65
-#define CL_INVALID_COMPILER_OPTIONS                 -66
-#define CL_INVALID_LINKER_OPTIONS                   -67
-#define CL_INVALID_DEVICE_PARTITION_COUNT           -68
+#define CL_INVALID_IMAGE_DESCRIPTOR       -65
+#define CL_INVALID_COMPILER_OPTIONS       -66
+#define CL_INVALID_LINKER_OPTIONS         -67
+#define CL_INVALID_DEVICE_PARTITION_COUNT -68
 #endif
 #ifdef CL_VERSION_2_0
-#define CL_INVALID_PIPE_SIZE                        -69
-#define CL_INVALID_DEVICE_QUEUE                     -70
+#define CL_INVALID_PIPE_SIZE    -69
+#define CL_INVALID_DEVICE_QUEUE -70
 #endif
 #ifdef CL_VERSION_2_2
-#define CL_INVALID_SPEC_ID                          -71
-#define CL_MAX_SIZE_RESTRICTION_EXCEEDED            -72
+#define CL_INVALID_SPEC_ID               -71
+#define CL_MAX_SIZE_RESTRICTION_EXCEEDED -72
 #endif
 
-
 /* cl_bool */
-#define CL_FALSE                                    0
-#define CL_TRUE                                     1
+#define CL_FALSE 0
+#define CL_TRUE  1
 #ifdef CL_VERSION_1_2
-#define CL_BLOCKING                                 CL_TRUE
-#define CL_NON_BLOCKING                             CL_FALSE
+#define CL_BLOCKING     CL_TRUE
+#define CL_NON_BLOCKING CL_FALSE
 #endif
 
 /* cl_platform_info */
-#define CL_PLATFORM_PROFILE                         0x0900
-#define CL_PLATFORM_VERSION                         0x0901
-#define CL_PLATFORM_NAME                            0x0902
-#define CL_PLATFORM_VENDOR                          0x0903
-#define CL_PLATFORM_EXTENSIONS                      0x0904
+#define CL_PLATFORM_PROFILE    0x0900
+#define CL_PLATFORM_VERSION    0x0901
+#define CL_PLATFORM_NAME       0x0902
+#define CL_PLATFORM_VENDOR     0x0903
+#define CL_PLATFORM_EXTENSIONS 0x0904
 #ifdef CL_VERSION_2_1
-#define CL_PLATFORM_HOST_TIMER_RESOLUTION           0x0905
+#define CL_PLATFORM_HOST_TIMER_RESOLUTION 0x0905
 #endif
 #ifdef CL_VERSION_3_0
-#define CL_PLATFORM_NUMERIC_VERSION                 0x0906
-#define CL_PLATFORM_EXTENSIONS_WITH_VERSION         0x0907
+#define CL_PLATFORM_NUMERIC_VERSION         0x0906
+#define CL_PLATFORM_EXTENSIONS_WITH_VERSION 0x0907
 #endif
 
 /* cl_device_type - bitfield */
-#define CL_DEVICE_TYPE_DEFAULT                      (1 << 0)
-#define CL_DEVICE_TYPE_CPU                          (1 << 1)
-#define CL_DEVICE_TYPE_GPU                          (1 << 2)
-#define CL_DEVICE_TYPE_ACCELERATOR                  (1 << 3)
+#define CL_DEVICE_TYPE_DEFAULT     (1 << 0)
+#define CL_DEVICE_TYPE_CPU         (1 << 1)
+#define CL_DEVICE_TYPE_GPU         (1 << 2)
+#define CL_DEVICE_TYPE_ACCELERATOR (1 << 3)
 #ifdef CL_VERSION_1_2
-#define CL_DEVICE_TYPE_CUSTOM                       (1 << 4)
+#define CL_DEVICE_TYPE_CUSTOM (1 << 4)
 #endif
-#define CL_DEVICE_TYPE_ALL                          0xFFFFFFFF
+#define CL_DEVICE_TYPE_ALL                      0xFFFFFFFF
 
 /* cl_device_info */
-#define CL_DEVICE_TYPE                                   0x1000
-#define CL_DEVICE_VENDOR_ID                              0x1001
-#define CL_DEVICE_MAX_COMPUTE_UNITS                      0x1002
-#define CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS               0x1003
-#define CL_DEVICE_MAX_WORK_GROUP_SIZE                    0x1004
-#define CL_DEVICE_MAX_WORK_ITEM_SIZES                    0x1005
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR            0x1006
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT           0x1007
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT             0x1008
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG            0x1009
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT           0x100A
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE          0x100B
-#define CL_DEVICE_MAX_CLOCK_FREQUENCY                    0x100C
-#define CL_DEVICE_ADDRESS_BITS                           0x100D
-#define CL_DEVICE_MAX_READ_IMAGE_ARGS                    0x100E
-#define CL_DEVICE_MAX_WRITE_IMAGE_ARGS                   0x100F
-#define CL_DEVICE_MAX_MEM_ALLOC_SIZE                     0x1010
-#define CL_DEVICE_IMAGE2D_MAX_WIDTH                      0x1011
-#define CL_DEVICE_IMAGE2D_MAX_HEIGHT                     0x1012
-#define CL_DEVICE_IMAGE3D_MAX_WIDTH                      0x1013
-#define CL_DEVICE_IMAGE3D_MAX_HEIGHT                     0x1014
-#define CL_DEVICE_IMAGE3D_MAX_DEPTH                      0x1015
-#define CL_DEVICE_IMAGE_SUPPORT                          0x1016
-#define CL_DEVICE_MAX_PARAMETER_SIZE                     0x1017
-#define CL_DEVICE_MAX_SAMPLERS                           0x1018
-#define CL_DEVICE_MEM_BASE_ADDR_ALIGN                    0x1019
-#define CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE               0x101A
-#define CL_DEVICE_SINGLE_FP_CONFIG                       0x101B
-#define CL_DEVICE_GLOBAL_MEM_CACHE_TYPE                  0x101C
-#define CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE              0x101D
-#define CL_DEVICE_GLOBAL_MEM_CACHE_SIZE                  0x101E
-#define CL_DEVICE_GLOBAL_MEM_SIZE                        0x101F
-#define CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE               0x1020
-#define CL_DEVICE_MAX_CONSTANT_ARGS                      0x1021
-#define CL_DEVICE_LOCAL_MEM_TYPE                         0x1022
-#define CL_DEVICE_LOCAL_MEM_SIZE                         0x1023
-#define CL_DEVICE_ERROR_CORRECTION_SUPPORT               0x1024
-#define CL_DEVICE_PROFILING_TIMER_RESOLUTION             0x1025
-#define CL_DEVICE_ENDIAN_LITTLE                          0x1026
-#define CL_DEVICE_AVAILABLE                              0x1027
-#define CL_DEVICE_COMPILER_AVAILABLE                     0x1028
-#define CL_DEVICE_EXECUTION_CAPABILITIES                 0x1029
-#define CL_DEVICE_QUEUE_PROPERTIES                       0x102A    /* deprecated */
+#define CL_DEVICE_TYPE                          0x1000
+#define CL_DEVICE_VENDOR_ID                     0x1001
+#define CL_DEVICE_MAX_COMPUTE_UNITS             0x1002
+#define CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS      0x1003
+#define CL_DEVICE_MAX_WORK_GROUP_SIZE           0x1004
+#define CL_DEVICE_MAX_WORK_ITEM_SIZES           0x1005
+#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR   0x1006
+#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT  0x1007
+#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT    0x1008
+#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG   0x1009
+#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT  0x100A
+#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE 0x100B
+#define CL_DEVICE_MAX_CLOCK_FREQUENCY           0x100C
+#define CL_DEVICE_ADDRESS_BITS                  0x100D
+#define CL_DEVICE_MAX_READ_IMAGE_ARGS           0x100E
+#define CL_DEVICE_MAX_WRITE_IMAGE_ARGS          0x100F
+#define CL_DEVICE_MAX_MEM_ALLOC_SIZE            0x1010
+#define CL_DEVICE_IMAGE2D_MAX_WIDTH             0x1011
+#define CL_DEVICE_IMAGE2D_MAX_HEIGHT            0x1012
+#define CL_DEVICE_IMAGE3D_MAX_WIDTH             0x1013
+#define CL_DEVICE_IMAGE3D_MAX_HEIGHT            0x1014
+#define CL_DEVICE_IMAGE3D_MAX_DEPTH             0x1015
+#define CL_DEVICE_IMAGE_SUPPORT                 0x1016
+#define CL_DEVICE_MAX_PARAMETER_SIZE            0x1017
+#define CL_DEVICE_MAX_SAMPLERS                  0x1018
+#define CL_DEVICE_MEM_BASE_ADDR_ALIGN           0x1019
+#define CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE      0x101A
+#define CL_DEVICE_SINGLE_FP_CONFIG              0x101B
+#define CL_DEVICE_GLOBAL_MEM_CACHE_TYPE         0x101C
+#define CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE     0x101D
+#define CL_DEVICE_GLOBAL_MEM_CACHE_SIZE         0x101E
+#define CL_DEVICE_GLOBAL_MEM_SIZE               0x101F
+#define CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE      0x1020
+#define CL_DEVICE_MAX_CONSTANT_ARGS             0x1021
+#define CL_DEVICE_LOCAL_MEM_TYPE                0x1022
+#define CL_DEVICE_LOCAL_MEM_SIZE                0x1023
+#define CL_DEVICE_ERROR_CORRECTION_SUPPORT      0x1024
+#define CL_DEVICE_PROFILING_TIMER_RESOLUTION    0x1025
+#define CL_DEVICE_ENDIAN_LITTLE                 0x1026
+#define CL_DEVICE_AVAILABLE                     0x1027
+#define CL_DEVICE_COMPILER_AVAILABLE            0x1028
+#define CL_DEVICE_EXECUTION_CAPABILITIES        0x1029
+#define CL_DEVICE_QUEUE_PROPERTIES              0x102A /* deprecated */
 #ifdef CL_VERSION_2_0
-#define CL_DEVICE_QUEUE_ON_HOST_PROPERTIES               0x102A
+#define CL_DEVICE_QUEUE_ON_HOST_PROPERTIES 0x102A
 #endif
-#define CL_DEVICE_NAME                                   0x102B
-#define CL_DEVICE_VENDOR                                 0x102C
-#define CL_DRIVER_VERSION                                0x102D
-#define CL_DEVICE_PROFILE                                0x102E
-#define CL_DEVICE_VERSION                                0x102F
-#define CL_DEVICE_EXTENSIONS                             0x1030
-#define CL_DEVICE_PLATFORM                               0x1031
+#define CL_DEVICE_NAME       0x102B
+#define CL_DEVICE_VENDOR     0x102C
+#define CL_DRIVER_VERSION    0x102D
+#define CL_DEVICE_PROFILE    0x102E
+#define CL_DEVICE_VERSION    0x102F
+#define CL_DEVICE_EXTENSIONS 0x1030
+#define CL_DEVICE_PLATFORM   0x1031
 #ifdef CL_VERSION_1_2
-#define CL_DEVICE_DOUBLE_FP_CONFIG                       0x1032
+#define CL_DEVICE_DOUBLE_FP_CONFIG 0x1032
 #endif
-/* 0x1033 reserved for CL_DEVICE_HALF_FP_CONFIG which is already defined in "cl_ext.h" */
+/* 0x1033 reserved for CL_DEVICE_HALF_FP_CONFIG which is already defined in
+ * "cl_ext.h" */
 #ifdef CL_VERSION_1_1
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF            0x1034
-#define CL_DEVICE_HOST_UNIFIED_MEMORY                    0x1035   /* deprecated */
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR               0x1036
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT              0x1037
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_INT                0x1038
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG               0x1039
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT              0x103A
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE             0x103B
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF               0x103C
-#define CL_DEVICE_OPENCL_C_VERSION                       0x103D
+#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF 0x1034
+#define CL_DEVICE_HOST_UNIFIED_MEMORY         0x1035 /* deprecated */
+#define CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR    0x1036
+#define CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT   0x1037
+#define CL_DEVICE_NATIVE_VECTOR_WIDTH_INT     0x1038
+#define CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG    0x1039
+#define CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT   0x103A
+#define CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE  0x103B
+#define CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF    0x103C
+#define CL_DEVICE_OPENCL_C_VERSION            0x103D
 #endif
 #ifdef CL_VERSION_1_2
-#define CL_DEVICE_LINKER_AVAILABLE                       0x103E
-#define CL_DEVICE_BUILT_IN_KERNELS                       0x103F
-#define CL_DEVICE_IMAGE_MAX_BUFFER_SIZE                  0x1040
-#define CL_DEVICE_IMAGE_MAX_ARRAY_SIZE                   0x1041
-#define CL_DEVICE_PARENT_DEVICE                          0x1042
-#define CL_DEVICE_PARTITION_MAX_SUB_DEVICES              0x1043
-#define CL_DEVICE_PARTITION_PROPERTIES                   0x1044
-#define CL_DEVICE_PARTITION_AFFINITY_DOMAIN              0x1045
-#define CL_DEVICE_PARTITION_TYPE                         0x1046
-#define CL_DEVICE_REFERENCE_COUNT                        0x1047
-#define CL_DEVICE_PREFERRED_INTEROP_USER_SYNC            0x1048
-#define CL_DEVICE_PRINTF_BUFFER_SIZE                     0x1049
+#define CL_DEVICE_LINKER_AVAILABLE            0x103E
+#define CL_DEVICE_BUILT_IN_KERNELS            0x103F
+#define CL_DEVICE_IMAGE_MAX_BUFFER_SIZE       0x1040
+#define CL_DEVICE_IMAGE_MAX_ARRAY_SIZE        0x1041
+#define CL_DEVICE_PARENT_DEVICE               0x1042
+#define CL_DEVICE_PARTITION_MAX_SUB_DEVICES   0x1043
+#define CL_DEVICE_PARTITION_PROPERTIES        0x1044
+#define CL_DEVICE_PARTITION_AFFINITY_DOMAIN   0x1045
+#define CL_DEVICE_PARTITION_TYPE              0x1046
+#define CL_DEVICE_REFERENCE_COUNT             0x1047
+#define CL_DEVICE_PREFERRED_INTEROP_USER_SYNC 0x1048
+#define CL_DEVICE_PRINTF_BUFFER_SIZE          0x1049
 #endif
 #ifdef CL_VERSION_2_0
-#define CL_DEVICE_IMAGE_PITCH_ALIGNMENT                  0x104A
-#define CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT           0x104B
-#define CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS              0x104C
-#define CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE               0x104D
-#define CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES             0x104E
-#define CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE         0x104F
-#define CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE               0x1050
-#define CL_DEVICE_MAX_ON_DEVICE_QUEUES                   0x1051
-#define CL_DEVICE_MAX_ON_DEVICE_EVENTS                   0x1052
-#define CL_DEVICE_SVM_CAPABILITIES                       0x1053
-#define CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE   0x1054
-#define CL_DEVICE_MAX_PIPE_ARGS                          0x1055
-#define CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS           0x1056
-#define CL_DEVICE_PIPE_MAX_PACKET_SIZE                   0x1057
-#define CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT    0x1058
-#define CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT      0x1059
-#define CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT       0x105A
+#define CL_DEVICE_IMAGE_PITCH_ALIGNMENT                0x104A
+#define CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT         0x104B
+#define CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS            0x104C
+#define CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE             0x104D
+#define CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES           0x104E
+#define CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE       0x104F
+#define CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE             0x1050
+#define CL_DEVICE_MAX_ON_DEVICE_QUEUES                 0x1051
+#define CL_DEVICE_MAX_ON_DEVICE_EVENTS                 0x1052
+#define CL_DEVICE_SVM_CAPABILITIES                     0x1053
+#define CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE 0x1054
+#define CL_DEVICE_MAX_PIPE_ARGS                        0x1055
+#define CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS         0x1056
+#define CL_DEVICE_PIPE_MAX_PACKET_SIZE                 0x1057
+#define CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT  0x1058
+#define CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT    0x1059
+#define CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT     0x105A
 #endif
 #ifdef CL_VERSION_2_1
 #define CL_DEVICE_IL_VERSION                             0x105B
@@ -412,80 +423,80 @@ typedef struct _cl_name_version {
 #define CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS 0x105D
 #endif
 #ifdef CL_VERSION_3_0
-#define CL_DEVICE_NUMERIC_VERSION                        0x105E
-#define CL_DEVICE_EXTENSIONS_WITH_VERSION                0x1060
-#define CL_DEVICE_ILS_WITH_VERSION                       0x1061
-#define CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION          0x1062
-#define CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES             0x1063
-#define CL_DEVICE_ATOMIC_FENCE_CAPABILITIES              0x1064
-#define CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT         0x1065
-#define CL_DEVICE_OPENCL_C_ALL_VERSIONS                  0x1066
-#define CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE     0x1067
+#define CL_DEVICE_NUMERIC_VERSION                         0x105E
+#define CL_DEVICE_EXTENSIONS_WITH_VERSION                 0x1060
+#define CL_DEVICE_ILS_WITH_VERSION                        0x1061
+#define CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION           0x1062
+#define CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES              0x1063
+#define CL_DEVICE_ATOMIC_FENCE_CAPABILITIES               0x1064
+#define CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT          0x1065
+#define CL_DEVICE_OPENCL_C_ALL_VERSIONS                   0x1066
+#define CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE      0x1067
 #define CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT 0x1068
-#define CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT          0x1069
+#define CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT           0x1069
 /* 0x106A to 0x106E - Reserved for upcoming KHR extension */
-#define CL_DEVICE_OPENCL_C_FEATURES                      0x106F
-#define CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES            0x1070
-#define CL_DEVICE_PIPE_SUPPORT                           0x1071
-#define CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED      0x1072
+#define CL_DEVICE_OPENCL_C_FEATURES                       0x106F
+#define CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES             0x1070
+#define CL_DEVICE_PIPE_SUPPORT                            0x1071
+#define CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED       0x1072
 #endif
 
 /* cl_device_fp_config - bitfield */
-#define CL_FP_DENORM                                (1 << 0)
-#define CL_FP_INF_NAN                               (1 << 1)
-#define CL_FP_ROUND_TO_NEAREST                      (1 << 2)
-#define CL_FP_ROUND_TO_ZERO                         (1 << 3)
-#define CL_FP_ROUND_TO_INF                          (1 << 4)
-#define CL_FP_FMA                                   (1 << 5)
+#define CL_FP_DENORM           (1 << 0)
+#define CL_FP_INF_NAN          (1 << 1)
+#define CL_FP_ROUND_TO_NEAREST (1 << 2)
+#define CL_FP_ROUND_TO_ZERO    (1 << 3)
+#define CL_FP_ROUND_TO_INF     (1 << 4)
+#define CL_FP_FMA              (1 << 5)
 #ifdef CL_VERSION_1_1
-#define CL_FP_SOFT_FLOAT                            (1 << 6)
+#define CL_FP_SOFT_FLOAT (1 << 6)
 #endif
 #ifdef CL_VERSION_1_2
-#define CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT         (1 << 7)
+#define CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT (1 << 7)
 #endif
 
 /* cl_device_mem_cache_type */
-#define CL_NONE                                     0x0
-#define CL_READ_ONLY_CACHE                          0x1
-#define CL_READ_WRITE_CACHE                         0x2
+#define CL_NONE                                0x0
+#define CL_READ_ONLY_CACHE                     0x1
+#define CL_READ_WRITE_CACHE                    0x2
 
 /* cl_device_local_mem_type */
-#define CL_LOCAL                                    0x1
-#define CL_GLOBAL                                   0x2
+#define CL_LOCAL                               0x1
+#define CL_GLOBAL                              0x2
 
 /* cl_device_exec_capabilities - bitfield */
-#define CL_EXEC_KERNEL                              (1 << 0)
-#define CL_EXEC_NATIVE_KERNEL                       (1 << 1)
+#define CL_EXEC_KERNEL                         (1 << 0)
+#define CL_EXEC_NATIVE_KERNEL                  (1 << 1)
 
 /* cl_command_queue_properties - bitfield */
-#define CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE      (1 << 0)
-#define CL_QUEUE_PROFILING_ENABLE                   (1 << 1)
+#define CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE (1 << 0)
+#define CL_QUEUE_PROFILING_ENABLE              (1 << 1)
 #ifdef CL_VERSION_2_0
-#define CL_QUEUE_ON_DEVICE                          (1 << 2)
-#define CL_QUEUE_ON_DEVICE_DEFAULT                  (1 << 3)
+#define CL_QUEUE_ON_DEVICE         (1 << 2)
+#define CL_QUEUE_ON_DEVICE_DEFAULT (1 << 3)
 #endif
 
 /* cl_context_info */
-#define CL_CONTEXT_REFERENCE_COUNT                  0x1080
-#define CL_CONTEXT_DEVICES                          0x1081
-#define CL_CONTEXT_PROPERTIES                       0x1082
+#define CL_CONTEXT_REFERENCE_COUNT 0x1080
+#define CL_CONTEXT_DEVICES         0x1081
+#define CL_CONTEXT_PROPERTIES      0x1082
 #ifdef CL_VERSION_1_1
-#define CL_CONTEXT_NUM_DEVICES                      0x1083
+#define CL_CONTEXT_NUM_DEVICES 0x1083
 #endif
 
 /* cl_context_properties */
-#define CL_CONTEXT_PLATFORM                         0x1084
+#define CL_CONTEXT_PLATFORM 0x1084
 #ifdef CL_VERSION_1_2
-#define CL_CONTEXT_INTEROP_USER_SYNC                0x1085
+#define CL_CONTEXT_INTEROP_USER_SYNC 0x1085
 #endif
 
 #ifdef CL_VERSION_1_2
 
 /* cl_device_partition_property */
-#define CL_DEVICE_PARTITION_EQUALLY                 0x1086
-#define CL_DEVICE_PARTITION_BY_COUNTS               0x1087
-#define CL_DEVICE_PARTITION_BY_COUNTS_LIST_END      0x0
-#define CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN      0x1088
+#define CL_DEVICE_PARTITION_EQUALLY            0x1086
+#define CL_DEVICE_PARTITION_BY_COUNTS          0x1087
+#define CL_DEVICE_PARTITION_BY_COUNTS_LIST_END 0x0
+#define CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN 0x1088
 
 #endif
 
@@ -504,228 +515,228 @@ typedef struct _cl_name_version {
 #ifdef CL_VERSION_2_0
 
 /* cl_device_svm_capabilities */
-#define CL_DEVICE_SVM_COARSE_GRAIN_BUFFER           (1 << 0)
-#define CL_DEVICE_SVM_FINE_GRAIN_BUFFER             (1 << 1)
-#define CL_DEVICE_SVM_FINE_GRAIN_SYSTEM             (1 << 2)
-#define CL_DEVICE_SVM_ATOMICS                       (1 << 3)
+#define CL_DEVICE_SVM_COARSE_GRAIN_BUFFER (1 << 0)
+#define CL_DEVICE_SVM_FINE_GRAIN_BUFFER   (1 << 1)
+#define CL_DEVICE_SVM_FINE_GRAIN_SYSTEM   (1 << 2)
+#define CL_DEVICE_SVM_ATOMICS             (1 << 3)
 
 #endif
 
 /* cl_command_queue_info */
-#define CL_QUEUE_CONTEXT                            0x1090
-#define CL_QUEUE_DEVICE                             0x1091
-#define CL_QUEUE_REFERENCE_COUNT                    0x1092
-#define CL_QUEUE_PROPERTIES                         0x1093
+#define CL_QUEUE_CONTEXT         0x1090
+#define CL_QUEUE_DEVICE          0x1091
+#define CL_QUEUE_REFERENCE_COUNT 0x1092
+#define CL_QUEUE_PROPERTIES      0x1093
 #ifdef CL_VERSION_2_0
-#define CL_QUEUE_SIZE                               0x1094
+#define CL_QUEUE_SIZE 0x1094
 #endif
 #ifdef CL_VERSION_2_1
-#define CL_QUEUE_DEVICE_DEFAULT                     0x1095
+#define CL_QUEUE_DEVICE_DEFAULT 0x1095
 #endif
 #ifdef CL_VERSION_3_0
-#define CL_QUEUE_PROPERTIES_ARRAY                   0x1098
+#define CL_QUEUE_PROPERTIES_ARRAY 0x1098
 #endif
 
 /* cl_mem_flags and cl_svm_mem_flags - bitfield */
-#define CL_MEM_READ_WRITE                           (1 << 0)
-#define CL_MEM_WRITE_ONLY                           (1 << 1)
-#define CL_MEM_READ_ONLY                            (1 << 2)
-#define CL_MEM_USE_HOST_PTR                         (1 << 3)
-#define CL_MEM_ALLOC_HOST_PTR                       (1 << 4)
-#define CL_MEM_COPY_HOST_PTR                        (1 << 5)
+#define CL_MEM_READ_WRITE     (1 << 0)
+#define CL_MEM_WRITE_ONLY     (1 << 1)
+#define CL_MEM_READ_ONLY      (1 << 2)
+#define CL_MEM_USE_HOST_PTR   (1 << 3)
+#define CL_MEM_ALLOC_HOST_PTR (1 << 4)
+#define CL_MEM_COPY_HOST_PTR  (1 << 5)
 /* reserved                                         (1 << 6)    */
 #ifdef CL_VERSION_1_2
-#define CL_MEM_HOST_WRITE_ONLY                      (1 << 7)
-#define CL_MEM_HOST_READ_ONLY                       (1 << 8)
-#define CL_MEM_HOST_NO_ACCESS                       (1 << 9)
+#define CL_MEM_HOST_WRITE_ONLY (1 << 7)
+#define CL_MEM_HOST_READ_ONLY  (1 << 8)
+#define CL_MEM_HOST_NO_ACCESS  (1 << 9)
 #endif
 #ifdef CL_VERSION_2_0
-#define CL_MEM_SVM_FINE_GRAIN_BUFFER                (1 << 10)   /* used by cl_svm_mem_flags only */
-#define CL_MEM_SVM_ATOMICS                          (1 << 11)   /* used by cl_svm_mem_flags only */
-#define CL_MEM_KERNEL_READ_AND_WRITE                (1 << 12)
+#define CL_MEM_SVM_FINE_GRAIN_BUFFER                                           \
+  (1 << 10) /* used by cl_svm_mem_flags only */
+#define CL_MEM_SVM_ATOMICS           (1 << 11) /* used by cl_svm_mem_flags only */
+#define CL_MEM_KERNEL_READ_AND_WRITE (1 << 12)
 #endif
 
 #ifdef CL_VERSION_1_2
 
 /* cl_mem_migration_flags - bitfield */
-#define CL_MIGRATE_MEM_OBJECT_HOST                  (1 << 0)
-#define CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED     (1 << 1)
+#define CL_MIGRATE_MEM_OBJECT_HOST              (1 << 0)
+#define CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED (1 << 1)
 
 #endif
 
 /* cl_channel_order */
-#define CL_R                                        0x10B0
-#define CL_A                                        0x10B1
-#define CL_RG                                       0x10B2
-#define CL_RA                                       0x10B3
-#define CL_RGB                                      0x10B4
-#define CL_RGBA                                     0x10B5
-#define CL_BGRA                                     0x10B6
-#define CL_ARGB                                     0x10B7
-#define CL_INTENSITY                                0x10B8
-#define CL_LUMINANCE                                0x10B9
+#define CL_R         0x10B0
+#define CL_A         0x10B1
+#define CL_RG        0x10B2
+#define CL_RA        0x10B3
+#define CL_RGB       0x10B4
+#define CL_RGBA      0x10B5
+#define CL_BGRA      0x10B6
+#define CL_ARGB      0x10B7
+#define CL_INTENSITY 0x10B8
+#define CL_LUMINANCE 0x10B9
 #ifdef CL_VERSION_1_1
-#define CL_Rx                                       0x10BA
-#define CL_RGx                                      0x10BB
-#define CL_RGBx                                     0x10BC
+#define CL_Rx   0x10BA
+#define CL_RGx  0x10BB
+#define CL_RGBx 0x10BC
 #endif
 #ifdef CL_VERSION_1_2
-#define CL_DEPTH                                    0x10BD
-#define CL_DEPTH_STENCIL                            0x10BE
+#define CL_DEPTH         0x10BD
+#define CL_DEPTH_STENCIL 0x10BE
 #endif
 #ifdef CL_VERSION_2_0
-#define CL_sRGB                                     0x10BF
-#define CL_sRGBx                                    0x10C0
-#define CL_sRGBA                                    0x10C1
-#define CL_sBGRA                                    0x10C2
-#define CL_ABGR                                     0x10C3
+#define CL_sRGB  0x10BF
+#define CL_sRGBx 0x10C0
+#define CL_sRGBA 0x10C1
+#define CL_sBGRA 0x10C2
+#define CL_ABGR  0x10C3
 #endif
 
 /* cl_channel_type */
-#define CL_SNORM_INT8                               0x10D0
-#define CL_SNORM_INT16                              0x10D1
-#define CL_UNORM_INT8                               0x10D2
-#define CL_UNORM_INT16                              0x10D3
-#define CL_UNORM_SHORT_565                          0x10D4
-#define CL_UNORM_SHORT_555                          0x10D5
-#define CL_UNORM_INT_101010                         0x10D6
-#define CL_SIGNED_INT8                              0x10D7
-#define CL_SIGNED_INT16                             0x10D8
-#define CL_SIGNED_INT32                             0x10D9
-#define CL_UNSIGNED_INT8                            0x10DA
-#define CL_UNSIGNED_INT16                           0x10DB
-#define CL_UNSIGNED_INT32                           0x10DC
-#define CL_HALF_FLOAT                               0x10DD
-#define CL_FLOAT                                    0x10DE
+#define CL_SNORM_INT8       0x10D0
+#define CL_SNORM_INT16      0x10D1
+#define CL_UNORM_INT8       0x10D2
+#define CL_UNORM_INT16      0x10D3
+#define CL_UNORM_SHORT_565  0x10D4
+#define CL_UNORM_SHORT_555  0x10D5
+#define CL_UNORM_INT_101010 0x10D6
+#define CL_SIGNED_INT8      0x10D7
+#define CL_SIGNED_INT16     0x10D8
+#define CL_SIGNED_INT32     0x10D9
+#define CL_UNSIGNED_INT8    0x10DA
+#define CL_UNSIGNED_INT16   0x10DB
+#define CL_UNSIGNED_INT32   0x10DC
+#define CL_HALF_FLOAT       0x10DD
+#define CL_FLOAT            0x10DE
 #ifdef CL_VERSION_1_2
-#define CL_UNORM_INT24                              0x10DF
+#define CL_UNORM_INT24 0x10DF
 #endif
 #ifdef CL_VERSION_2_1
-#define CL_UNORM_INT_101010_2                       0x10E0
+#define CL_UNORM_INT_101010_2 0x10E0
 #endif
 
 /* cl_mem_object_type */
-#define CL_MEM_OBJECT_BUFFER                        0x10F0
-#define CL_MEM_OBJECT_IMAGE2D                       0x10F1
-#define CL_MEM_OBJECT_IMAGE3D                       0x10F2
+#define CL_MEM_OBJECT_BUFFER  0x10F0
+#define CL_MEM_OBJECT_IMAGE2D 0x10F1
+#define CL_MEM_OBJECT_IMAGE3D 0x10F2
 #ifdef CL_VERSION_1_2
-#define CL_MEM_OBJECT_IMAGE2D_ARRAY                 0x10F3
-#define CL_MEM_OBJECT_IMAGE1D                       0x10F4
-#define CL_MEM_OBJECT_IMAGE1D_ARRAY                 0x10F5
-#define CL_MEM_OBJECT_IMAGE1D_BUFFER                0x10F6
+#define CL_MEM_OBJECT_IMAGE2D_ARRAY  0x10F3
+#define CL_MEM_OBJECT_IMAGE1D        0x10F4
+#define CL_MEM_OBJECT_IMAGE1D_ARRAY  0x10F5
+#define CL_MEM_OBJECT_IMAGE1D_BUFFER 0x10F6
 #endif
 #ifdef CL_VERSION_2_0
-#define CL_MEM_OBJECT_PIPE                          0x10F7
+#define CL_MEM_OBJECT_PIPE 0x10F7
 #endif
 
 /* cl_mem_info */
-#define CL_MEM_TYPE                                 0x1100
-#define CL_MEM_FLAGS                                0x1101
-#define CL_MEM_SIZE                                 0x1102
-#define CL_MEM_HOST_PTR                             0x1103
-#define CL_MEM_MAP_COUNT                            0x1104
-#define CL_MEM_REFERENCE_COUNT                      0x1105
-#define CL_MEM_CONTEXT                              0x1106
+#define CL_MEM_TYPE            0x1100
+#define CL_MEM_FLAGS           0x1101
+#define CL_MEM_SIZE            0x1102
+#define CL_MEM_HOST_PTR        0x1103
+#define CL_MEM_MAP_COUNT       0x1104
+#define CL_MEM_REFERENCE_COUNT 0x1105
+#define CL_MEM_CONTEXT         0x1106
 #ifdef CL_VERSION_1_1
-#define CL_MEM_ASSOCIATED_MEMOBJECT                 0x1107
-#define CL_MEM_OFFSET                               0x1108
+#define CL_MEM_ASSOCIATED_MEMOBJECT 0x1107
+#define CL_MEM_OFFSET               0x1108
 #endif
 #ifdef CL_VERSION_2_0
-#define CL_MEM_USES_SVM_POINTER                     0x1109
+#define CL_MEM_USES_SVM_POINTER 0x1109
 #endif
 #ifdef CL_VERSION_3_0
-#define CL_MEM_PROPERTIES                           0x110A
+#define CL_MEM_PROPERTIES 0x110A
 #endif
 
 /* cl_image_info */
-#define CL_IMAGE_FORMAT                             0x1110
-#define CL_IMAGE_ELEMENT_SIZE                       0x1111
-#define CL_IMAGE_ROW_PITCH                          0x1112
-#define CL_IMAGE_SLICE_PITCH                        0x1113
-#define CL_IMAGE_WIDTH                              0x1114
-#define CL_IMAGE_HEIGHT                             0x1115
-#define CL_IMAGE_DEPTH                              0x1116
+#define CL_IMAGE_FORMAT       0x1110
+#define CL_IMAGE_ELEMENT_SIZE 0x1111
+#define CL_IMAGE_ROW_PITCH    0x1112
+#define CL_IMAGE_SLICE_PITCH  0x1113
+#define CL_IMAGE_WIDTH        0x1114
+#define CL_IMAGE_HEIGHT       0x1115
+#define CL_IMAGE_DEPTH        0x1116
 #ifdef CL_VERSION_1_2
-#define CL_IMAGE_ARRAY_SIZE                         0x1117
-#define CL_IMAGE_BUFFER                             0x1118
-#define CL_IMAGE_NUM_MIP_LEVELS                     0x1119
-#define CL_IMAGE_NUM_SAMPLES                        0x111A
+#define CL_IMAGE_ARRAY_SIZE     0x1117
+#define CL_IMAGE_BUFFER         0x1118
+#define CL_IMAGE_NUM_MIP_LEVELS 0x1119
+#define CL_IMAGE_NUM_SAMPLES    0x111A
 #endif
-
 
 /* cl_pipe_info */
 #ifdef CL_VERSION_2_0
-#define CL_PIPE_PACKET_SIZE                         0x1120
-#define CL_PIPE_MAX_PACKETS                         0x1121
+#define CL_PIPE_PACKET_SIZE 0x1120
+#define CL_PIPE_MAX_PACKETS 0x1121
 #endif
 #ifdef CL_VERSION_3_0
-#define CL_PIPE_PROPERTIES                          0x1122
+#define CL_PIPE_PROPERTIES 0x1122
 #endif
 
 /* cl_addressing_mode */
-#define CL_ADDRESS_NONE                             0x1130
-#define CL_ADDRESS_CLAMP_TO_EDGE                    0x1131
-#define CL_ADDRESS_CLAMP                            0x1132
-#define CL_ADDRESS_REPEAT                           0x1133
+#define CL_ADDRESS_NONE          0x1130
+#define CL_ADDRESS_CLAMP_TO_EDGE 0x1131
+#define CL_ADDRESS_CLAMP         0x1132
+#define CL_ADDRESS_REPEAT        0x1133
 #ifdef CL_VERSION_1_1
-#define CL_ADDRESS_MIRRORED_REPEAT                  0x1134
+#define CL_ADDRESS_MIRRORED_REPEAT 0x1134
 #endif
 
 /* cl_filter_mode */
-#define CL_FILTER_NEAREST                           0x1140
-#define CL_FILTER_LINEAR                            0x1141
+#define CL_FILTER_NEAREST            0x1140
+#define CL_FILTER_LINEAR             0x1141
 
 /* cl_sampler_info */
-#define CL_SAMPLER_REFERENCE_COUNT                  0x1150
-#define CL_SAMPLER_CONTEXT                          0x1151
-#define CL_SAMPLER_NORMALIZED_COORDS                0x1152
-#define CL_SAMPLER_ADDRESSING_MODE                  0x1153
-#define CL_SAMPLER_FILTER_MODE                      0x1154
+#define CL_SAMPLER_REFERENCE_COUNT   0x1150
+#define CL_SAMPLER_CONTEXT           0x1151
+#define CL_SAMPLER_NORMALIZED_COORDS 0x1152
+#define CL_SAMPLER_ADDRESSING_MODE   0x1153
+#define CL_SAMPLER_FILTER_MODE       0x1154
 #ifdef CL_VERSION_2_0
 /* These enumerants are for the cl_khr_mipmap_image extension.
    They have since been added to cl_ext.h with an appropriate
    KHR suffix, but are left here for backwards compatibility. */
-#define CL_SAMPLER_MIP_FILTER_MODE                  0x1155
-#define CL_SAMPLER_LOD_MIN                          0x1156
-#define CL_SAMPLER_LOD_MAX                          0x1157
+#define CL_SAMPLER_MIP_FILTER_MODE 0x1155
+#define CL_SAMPLER_LOD_MIN         0x1156
+#define CL_SAMPLER_LOD_MAX         0x1157
 #endif
 #ifdef CL_VERSION_3_0
-#define CL_SAMPLER_PROPERTIES                       0x1158
+#define CL_SAMPLER_PROPERTIES 0x1158
 #endif
 
 /* cl_map_flags - bitfield */
-#define CL_MAP_READ                                 (1 << 0)
-#define CL_MAP_WRITE                                (1 << 1)
+#define CL_MAP_READ  (1 << 0)
+#define CL_MAP_WRITE (1 << 1)
 #ifdef CL_VERSION_1_2
-#define CL_MAP_WRITE_INVALIDATE_REGION              (1 << 2)
+#define CL_MAP_WRITE_INVALIDATE_REGION (1 << 2)
 #endif
 
 /* cl_program_info */
-#define CL_PROGRAM_REFERENCE_COUNT                  0x1160
-#define CL_PROGRAM_CONTEXT                          0x1161
-#define CL_PROGRAM_NUM_DEVICES                      0x1162
-#define CL_PROGRAM_DEVICES                          0x1163
-#define CL_PROGRAM_SOURCE                           0x1164
-#define CL_PROGRAM_BINARY_SIZES                     0x1165
-#define CL_PROGRAM_BINARIES                         0x1166
+#define CL_PROGRAM_REFERENCE_COUNT 0x1160
+#define CL_PROGRAM_CONTEXT         0x1161
+#define CL_PROGRAM_NUM_DEVICES     0x1162
+#define CL_PROGRAM_DEVICES         0x1163
+#define CL_PROGRAM_SOURCE          0x1164
+#define CL_PROGRAM_BINARY_SIZES    0x1165
+#define CL_PROGRAM_BINARIES        0x1166
 #ifdef CL_VERSION_1_2
-#define CL_PROGRAM_NUM_KERNELS                      0x1167
-#define CL_PROGRAM_KERNEL_NAMES                     0x1168
+#define CL_PROGRAM_NUM_KERNELS  0x1167
+#define CL_PROGRAM_KERNEL_NAMES 0x1168
 #endif
 #ifdef CL_VERSION_2_1
-#define CL_PROGRAM_IL                               0x1169
+#define CL_PROGRAM_IL 0x1169
 #endif
 #ifdef CL_VERSION_2_2
-#define CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT       0x116A
-#define CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT       0x116B
+#define CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT 0x116A
+#define CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT 0x116B
 #endif
 
 /* cl_program_build_info */
-#define CL_PROGRAM_BUILD_STATUS                     0x1181
-#define CL_PROGRAM_BUILD_OPTIONS                    0x1182
-#define CL_PROGRAM_BUILD_LOG                        0x1183
+#define CL_PROGRAM_BUILD_STATUS  0x1181
+#define CL_PROGRAM_BUILD_OPTIONS 0x1182
+#define CL_PROGRAM_BUILD_LOG     0x1183
 #ifdef CL_VERSION_1_2
-#define CL_PROGRAM_BINARY_TYPE                      0x1184
+#define CL_PROGRAM_BINARY_TYPE 0x1184
 #endif
 #ifdef CL_VERSION_2_0
 #define CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE 0x1185
@@ -734,191 +745,191 @@ typedef struct _cl_name_version {
 #ifdef CL_VERSION_1_2
 
 /* cl_program_binary_type */
-#define CL_PROGRAM_BINARY_TYPE_NONE                 0x0
-#define CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT      0x1
-#define CL_PROGRAM_BINARY_TYPE_LIBRARY              0x2
-#define CL_PROGRAM_BINARY_TYPE_EXECUTABLE           0x4
+#define CL_PROGRAM_BINARY_TYPE_NONE            0x0
+#define CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT 0x1
+#define CL_PROGRAM_BINARY_TYPE_LIBRARY         0x2
+#define CL_PROGRAM_BINARY_TYPE_EXECUTABLE      0x4
 
 #endif
 
 /* cl_build_status */
-#define CL_BUILD_SUCCESS                            0
-#define CL_BUILD_NONE                               -1
-#define CL_BUILD_ERROR                              -2
-#define CL_BUILD_IN_PROGRESS                        -3
+#define CL_BUILD_SUCCESS          0
+#define CL_BUILD_NONE             -1
+#define CL_BUILD_ERROR            -2
+#define CL_BUILD_IN_PROGRESS      -3
 
 /* cl_kernel_info */
-#define CL_KERNEL_FUNCTION_NAME                     0x1190
-#define CL_KERNEL_NUM_ARGS                          0x1191
-#define CL_KERNEL_REFERENCE_COUNT                   0x1192
-#define CL_KERNEL_CONTEXT                           0x1193
-#define CL_KERNEL_PROGRAM                           0x1194
+#define CL_KERNEL_FUNCTION_NAME   0x1190
+#define CL_KERNEL_NUM_ARGS        0x1191
+#define CL_KERNEL_REFERENCE_COUNT 0x1192
+#define CL_KERNEL_CONTEXT         0x1193
+#define CL_KERNEL_PROGRAM         0x1194
 #ifdef CL_VERSION_1_2
-#define CL_KERNEL_ATTRIBUTES                        0x1195
+#define CL_KERNEL_ATTRIBUTES 0x1195
 #endif
 
 #ifdef CL_VERSION_1_2
 
 /* cl_kernel_arg_info */
-#define CL_KERNEL_ARG_ADDRESS_QUALIFIER             0x1196
-#define CL_KERNEL_ARG_ACCESS_QUALIFIER              0x1197
-#define CL_KERNEL_ARG_TYPE_NAME                     0x1198
-#define CL_KERNEL_ARG_TYPE_QUALIFIER                0x1199
-#define CL_KERNEL_ARG_NAME                          0x119A
+#define CL_KERNEL_ARG_ADDRESS_QUALIFIER 0x1196
+#define CL_KERNEL_ARG_ACCESS_QUALIFIER  0x1197
+#define CL_KERNEL_ARG_TYPE_NAME         0x1198
+#define CL_KERNEL_ARG_TYPE_QUALIFIER    0x1199
+#define CL_KERNEL_ARG_NAME              0x119A
 
 #endif
 
 #ifdef CL_VERSION_1_2
 
 /* cl_kernel_arg_address_qualifier */
-#define CL_KERNEL_ARG_ADDRESS_GLOBAL                0x119B
-#define CL_KERNEL_ARG_ADDRESS_LOCAL                 0x119C
-#define CL_KERNEL_ARG_ADDRESS_CONSTANT              0x119D
-#define CL_KERNEL_ARG_ADDRESS_PRIVATE               0x119E
+#define CL_KERNEL_ARG_ADDRESS_GLOBAL   0x119B
+#define CL_KERNEL_ARG_ADDRESS_LOCAL    0x119C
+#define CL_KERNEL_ARG_ADDRESS_CONSTANT 0x119D
+#define CL_KERNEL_ARG_ADDRESS_PRIVATE  0x119E
 
 #endif
 
 #ifdef CL_VERSION_1_2
 
 /* cl_kernel_arg_access_qualifier */
-#define CL_KERNEL_ARG_ACCESS_READ_ONLY              0x11A0
-#define CL_KERNEL_ARG_ACCESS_WRITE_ONLY             0x11A1
-#define CL_KERNEL_ARG_ACCESS_READ_WRITE             0x11A2
-#define CL_KERNEL_ARG_ACCESS_NONE                   0x11A3
+#define CL_KERNEL_ARG_ACCESS_READ_ONLY  0x11A0
+#define CL_KERNEL_ARG_ACCESS_WRITE_ONLY 0x11A1
+#define CL_KERNEL_ARG_ACCESS_READ_WRITE 0x11A2
+#define CL_KERNEL_ARG_ACCESS_NONE       0x11A3
 
 #endif
 
 #ifdef CL_VERSION_1_2
 
 /* cl_kernel_arg_type_qualifier */
-#define CL_KERNEL_ARG_TYPE_NONE                     0
-#define CL_KERNEL_ARG_TYPE_CONST                    (1 << 0)
-#define CL_KERNEL_ARG_TYPE_RESTRICT                 (1 << 1)
-#define CL_KERNEL_ARG_TYPE_VOLATILE                 (1 << 2)
+#define CL_KERNEL_ARG_TYPE_NONE     0
+#define CL_KERNEL_ARG_TYPE_CONST    (1 << 0)
+#define CL_KERNEL_ARG_TYPE_RESTRICT (1 << 1)
+#define CL_KERNEL_ARG_TYPE_VOLATILE (1 << 2)
 #ifdef CL_VERSION_2_0
-#define CL_KERNEL_ARG_TYPE_PIPE                     (1 << 3)
+#define CL_KERNEL_ARG_TYPE_PIPE (1 << 3)
 #endif
 
 #endif
 
 /* cl_kernel_work_group_info */
-#define CL_KERNEL_WORK_GROUP_SIZE                   0x11B0
-#define CL_KERNEL_COMPILE_WORK_GROUP_SIZE           0x11B1
-#define CL_KERNEL_LOCAL_MEM_SIZE                    0x11B2
+#define CL_KERNEL_WORK_GROUP_SIZE                    0x11B0
+#define CL_KERNEL_COMPILE_WORK_GROUP_SIZE            0x11B1
+#define CL_KERNEL_LOCAL_MEM_SIZE                     0x11B2
 #define CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE 0x11B3
-#define CL_KERNEL_PRIVATE_MEM_SIZE                  0x11B4
+#define CL_KERNEL_PRIVATE_MEM_SIZE                   0x11B4
 #ifdef CL_VERSION_1_2
-#define CL_KERNEL_GLOBAL_WORK_SIZE                  0x11B5
+#define CL_KERNEL_GLOBAL_WORK_SIZE 0x11B5
 #endif
 
 #ifdef CL_VERSION_2_1
 
 /* cl_kernel_sub_group_info */
-#define CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE    0x2033
-#define CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE       0x2034
-#define CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT    0x11B8
-#define CL_KERNEL_MAX_NUM_SUB_GROUPS                0x11B9
-#define CL_KERNEL_COMPILE_NUM_SUB_GROUPS            0x11BA
+#define CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE 0x2033
+#define CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE    0x2034
+#define CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT 0x11B8
+#define CL_KERNEL_MAX_NUM_SUB_GROUPS             0x11B9
+#define CL_KERNEL_COMPILE_NUM_SUB_GROUPS         0x11BA
 
 #endif
 
 #ifdef CL_VERSION_2_0
 
 /* cl_kernel_exec_info */
-#define CL_KERNEL_EXEC_INFO_SVM_PTRS                0x11B6
-#define CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM   0x11B7
+#define CL_KERNEL_EXEC_INFO_SVM_PTRS              0x11B6
+#define CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM 0x11B7
 
 #endif
 
 /* cl_event_info */
-#define CL_EVENT_COMMAND_QUEUE                      0x11D0
-#define CL_EVENT_COMMAND_TYPE                       0x11D1
-#define CL_EVENT_REFERENCE_COUNT                    0x11D2
-#define CL_EVENT_COMMAND_EXECUTION_STATUS           0x11D3
+#define CL_EVENT_COMMAND_QUEUE            0x11D0
+#define CL_EVENT_COMMAND_TYPE             0x11D1
+#define CL_EVENT_REFERENCE_COUNT          0x11D2
+#define CL_EVENT_COMMAND_EXECUTION_STATUS 0x11D3
 #ifdef CL_VERSION_1_1
-#define CL_EVENT_CONTEXT                            0x11D4
+#define CL_EVENT_CONTEXT 0x11D4
 #endif
 
 /* cl_command_type */
-#define CL_COMMAND_NDRANGE_KERNEL                   0x11F0
-#define CL_COMMAND_TASK                             0x11F1
-#define CL_COMMAND_NATIVE_KERNEL                    0x11F2
-#define CL_COMMAND_READ_BUFFER                      0x11F3
-#define CL_COMMAND_WRITE_BUFFER                     0x11F4
-#define CL_COMMAND_COPY_BUFFER                      0x11F5
-#define CL_COMMAND_READ_IMAGE                       0x11F6
-#define CL_COMMAND_WRITE_IMAGE                      0x11F7
-#define CL_COMMAND_COPY_IMAGE                       0x11F8
-#define CL_COMMAND_COPY_IMAGE_TO_BUFFER             0x11F9
-#define CL_COMMAND_COPY_BUFFER_TO_IMAGE             0x11FA
-#define CL_COMMAND_MAP_BUFFER                       0x11FB
-#define CL_COMMAND_MAP_IMAGE                        0x11FC
-#define CL_COMMAND_UNMAP_MEM_OBJECT                 0x11FD
-#define CL_COMMAND_MARKER                           0x11FE
-#define CL_COMMAND_ACQUIRE_GL_OBJECTS               0x11FF
-#define CL_COMMAND_RELEASE_GL_OBJECTS               0x1200
+#define CL_COMMAND_NDRANGE_KERNEL       0x11F0
+#define CL_COMMAND_TASK                 0x11F1
+#define CL_COMMAND_NATIVE_KERNEL        0x11F2
+#define CL_COMMAND_READ_BUFFER          0x11F3
+#define CL_COMMAND_WRITE_BUFFER         0x11F4
+#define CL_COMMAND_COPY_BUFFER          0x11F5
+#define CL_COMMAND_READ_IMAGE           0x11F6
+#define CL_COMMAND_WRITE_IMAGE          0x11F7
+#define CL_COMMAND_COPY_IMAGE           0x11F8
+#define CL_COMMAND_COPY_IMAGE_TO_BUFFER 0x11F9
+#define CL_COMMAND_COPY_BUFFER_TO_IMAGE 0x11FA
+#define CL_COMMAND_MAP_BUFFER           0x11FB
+#define CL_COMMAND_MAP_IMAGE            0x11FC
+#define CL_COMMAND_UNMAP_MEM_OBJECT     0x11FD
+#define CL_COMMAND_MARKER               0x11FE
+#define CL_COMMAND_ACQUIRE_GL_OBJECTS   0x11FF
+#define CL_COMMAND_RELEASE_GL_OBJECTS   0x1200
 #ifdef CL_VERSION_1_1
-#define CL_COMMAND_READ_BUFFER_RECT                 0x1201
-#define CL_COMMAND_WRITE_BUFFER_RECT                0x1202
-#define CL_COMMAND_COPY_BUFFER_RECT                 0x1203
-#define CL_COMMAND_USER                             0x1204
+#define CL_COMMAND_READ_BUFFER_RECT  0x1201
+#define CL_COMMAND_WRITE_BUFFER_RECT 0x1202
+#define CL_COMMAND_COPY_BUFFER_RECT  0x1203
+#define CL_COMMAND_USER              0x1204
 #endif
 #ifdef CL_VERSION_1_2
-#define CL_COMMAND_BARRIER                          0x1205
-#define CL_COMMAND_MIGRATE_MEM_OBJECTS              0x1206
-#define CL_COMMAND_FILL_BUFFER                      0x1207
-#define CL_COMMAND_FILL_IMAGE                       0x1208
+#define CL_COMMAND_BARRIER             0x1205
+#define CL_COMMAND_MIGRATE_MEM_OBJECTS 0x1206
+#define CL_COMMAND_FILL_BUFFER         0x1207
+#define CL_COMMAND_FILL_IMAGE          0x1208
 #endif
 #ifdef CL_VERSION_2_0
-#define CL_COMMAND_SVM_FREE                         0x1209
-#define CL_COMMAND_SVM_MEMCPY                       0x120A
-#define CL_COMMAND_SVM_MEMFILL                      0x120B
-#define CL_COMMAND_SVM_MAP                          0x120C
-#define CL_COMMAND_SVM_UNMAP                        0x120D
+#define CL_COMMAND_SVM_FREE    0x1209
+#define CL_COMMAND_SVM_MEMCPY  0x120A
+#define CL_COMMAND_SVM_MEMFILL 0x120B
+#define CL_COMMAND_SVM_MAP     0x120C
+#define CL_COMMAND_SVM_UNMAP   0x120D
 #endif
 #ifdef CL_VERSION_3_0
-#define CL_COMMAND_SVM_MIGRATE_MEM                  0x120E
+#define CL_COMMAND_SVM_MIGRATE_MEM 0x120E
 #endif
 
 /* command execution status */
-#define CL_COMPLETE                                 0x0
-#define CL_RUNNING                                  0x1
-#define CL_SUBMITTED                                0x2
-#define CL_QUEUED                                   0x3
+#define CL_COMPLETE  0x0
+#define CL_RUNNING   0x1
+#define CL_SUBMITTED 0x2
+#define CL_QUEUED    0x3
 
 /* cl_buffer_create_type */
 #ifdef CL_VERSION_1_1
-#define CL_BUFFER_CREATE_TYPE_REGION                0x1220
+#define CL_BUFFER_CREATE_TYPE_REGION 0x1220
 #endif
 
 /* cl_profiling_info */
-#define CL_PROFILING_COMMAND_QUEUED                 0x1280
-#define CL_PROFILING_COMMAND_SUBMIT                 0x1281
-#define CL_PROFILING_COMMAND_START                  0x1282
-#define CL_PROFILING_COMMAND_END                    0x1283
+#define CL_PROFILING_COMMAND_QUEUED 0x1280
+#define CL_PROFILING_COMMAND_SUBMIT 0x1281
+#define CL_PROFILING_COMMAND_START  0x1282
+#define CL_PROFILING_COMMAND_END    0x1283
 #ifdef CL_VERSION_2_0
-#define CL_PROFILING_COMMAND_COMPLETE               0x1284
+#define CL_PROFILING_COMMAND_COMPLETE 0x1284
 #endif
 
 /* cl_device_atomic_capabilities - bitfield */
 #ifdef CL_VERSION_3_0
-#define CL_DEVICE_ATOMIC_ORDER_RELAXED          (1 << 0)
-#define CL_DEVICE_ATOMIC_ORDER_ACQ_REL          (1 << 1)
-#define CL_DEVICE_ATOMIC_ORDER_SEQ_CST          (1 << 2)
-#define CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM        (1 << 3)
-#define CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP       (1 << 4)
-#define CL_DEVICE_ATOMIC_SCOPE_DEVICE           (1 << 5)
-#define CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES      (1 << 6)
+#define CL_DEVICE_ATOMIC_ORDER_RELAXED     (1 << 0)
+#define CL_DEVICE_ATOMIC_ORDER_ACQ_REL     (1 << 1)
+#define CL_DEVICE_ATOMIC_ORDER_SEQ_CST     (1 << 2)
+#define CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM   (1 << 3)
+#define CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP  (1 << 4)
+#define CL_DEVICE_ATOMIC_SCOPE_DEVICE      (1 << 5)
+#define CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES (1 << 6)
 #endif
 
 /* cl_device_device_enqueue_capabilities - bitfield */
 #ifdef CL_VERSION_3_0
-#define CL_DEVICE_QUEUE_SUPPORTED               (1 << 0)
-#define CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT     (1 << 1)
+#define CL_DEVICE_QUEUE_SUPPORTED           (1 << 0)
+#define CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT (1 << 1)
 #endif
 
 /* cl_khronos_vendor_id */
-#define CL_KHRONOS_VENDOR_ID_CODEPLAY               0x10004
+#define CL_KHRONOS_VENDOR_ID_CODEPLAY 0x10004
 
 #ifdef CL_VERSION_3_0
 
@@ -931,19 +942,19 @@ typedef struct _cl_name_version {
 #define CL_VERSION_MINOR_MASK ((1 << CL_VERSION_MINOR_BITS) - 1)
 #define CL_VERSION_PATCH_MASK ((1 << CL_VERSION_PATCH_BITS) - 1)
 
-#define CL_VERSION_MAJOR(version) \
+#define CL_VERSION_MAJOR(version)                                              \
   ((version) >> (CL_VERSION_MINOR_BITS + CL_VERSION_PATCH_BITS))
 
-#define CL_VERSION_MINOR(version) \
+#define CL_VERSION_MINOR(version)                                              \
   (((version) >> CL_VERSION_PATCH_BITS) & CL_VERSION_MINOR_MASK)
 
-#define CL_VERSION_PATCH(version) ((version) & CL_VERSION_PATCH_MASK)
+#define CL_VERSION_PATCH(version) ((version)&CL_VERSION_PATCH_MASK)
 
-#define CL_MAKE_VERSION(major, minor, patch)                      \
-  ((((major) & CL_VERSION_MAJOR_MASK)                             \
-       << (CL_VERSION_MINOR_BITS + CL_VERSION_PATCH_BITS)) |      \
-   (((minor) & CL_VERSION_MINOR_MASK) << CL_VERSION_PATCH_BITS) | \
-   ((patch) & CL_VERSION_PATCH_MASK))
+#define CL_MAKE_VERSION(major, minor, patch)                                   \
+  ((((major)&CL_VERSION_MAJOR_MASK)                                            \
+    << (CL_VERSION_MINOR_BITS + CL_VERSION_PATCH_BITS)) |                      \
+   (((minor)&CL_VERSION_MINOR_MASK) << CL_VERSION_PATCH_BITS) |                \
+   ((patch)&CL_VERSION_PATCH_MASK))
 
 #endif
 
@@ -951,40 +962,40 @@ typedef struct _cl_name_version {
 
 /* Platform API */
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetPlatformIDs(cl_uint          num_entries,
-                 cl_platform_id * platforms,
-                 cl_uint *        num_platforms) CL_API_SUFFIX__VERSION_1_0;
+clGetPlatformIDs(cl_uint         num_entries,
+                 cl_platform_id* platforms,
+                 cl_uint*        num_platforms) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clGetPlatformInfo(cl_platform_id   platform,
                   cl_platform_info param_name,
                   size_t           param_value_size,
-                  void *           param_value,
-                  size_t *         param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+                  void*            param_value,
+                  size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 /* Device APIs */
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetDeviceIDs(cl_platform_id   platform,
-               cl_device_type   device_type,
-               cl_uint          num_entries,
-               cl_device_id *   devices,
-               cl_uint *        num_devices) CL_API_SUFFIX__VERSION_1_0;
+clGetDeviceIDs(cl_platform_id platform,
+               cl_device_type device_type,
+               cl_uint        num_entries,
+               cl_device_id*  devices,
+               cl_uint*       num_devices) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetDeviceInfo(cl_device_id    device,
-                cl_device_info  param_name,
-                size_t          param_value_size,
-                void *          param_value,
-                size_t *        param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetDeviceInfo(cl_device_id   device,
+                cl_device_info param_name,
+                size_t         param_value_size,
+                void*          param_value,
+                size_t*        param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCreateSubDevices(cl_device_id                         in_device,
-                   const cl_device_partition_property * properties,
-                   cl_uint                              num_devices,
-                   cl_device_id *                       out_devices,
-                   cl_uint *                            num_devices_ret) CL_API_SUFFIX__VERSION_1_2;
+clCreateSubDevices(cl_device_id                        in_device,
+                   const cl_device_partition_property* properties,
+                   cl_uint                             num_devices,
+                   cl_device_id*                       out_devices,
+                   cl_uint* num_devices_ret) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clRetainDevice(cl_device_id device) CL_API_SUFFIX__VERSION_1_2;
@@ -997,42 +1008,43 @@ clReleaseDevice(cl_device_id device) CL_API_SUFFIX__VERSION_1_2;
 #ifdef CL_VERSION_2_1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clSetDefaultDeviceCommandQueue(cl_context           context,
-                               cl_device_id         device,
-                               cl_command_queue     command_queue) CL_API_SUFFIX__VERSION_2_1;
+clSetDefaultDeviceCommandQueue(cl_context       context,
+                               cl_device_id     device,
+                               cl_command_queue command_queue)
+  CL_API_SUFFIX__VERSION_2_1;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetDeviceAndHostTimer(cl_device_id    device,
-                        cl_ulong*       device_timestamp,
-                        cl_ulong*       host_timestamp) CL_API_SUFFIX__VERSION_2_1;
+clGetDeviceAndHostTimer(cl_device_id device,
+                        cl_ulong*    device_timestamp,
+                        cl_ulong*    host_timestamp) CL_API_SUFFIX__VERSION_2_1;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clGetHostTimer(cl_device_id device,
-               cl_ulong *   host_timestamp) CL_API_SUFFIX__VERSION_2_1;
+               cl_ulong*    host_timestamp) CL_API_SUFFIX__VERSION_2_1;
 
 #endif
 
 /* Context APIs */
 extern CL_API_ENTRY cl_context CL_API_CALL
-clCreateContext(const cl_context_properties * properties,
-                cl_uint              num_devices,
-                const cl_device_id * devices,
-                void (CL_CALLBACK * pfn_notify)(const char * errinfo,
-                                                const void * private_info,
-                                                size_t       cb,
-                                                void *       user_data),
-                void *               user_data,
-                cl_int *             errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+clCreateContext(const cl_context_properties* properties,
+                cl_uint                      num_devices,
+                const cl_device_id*          devices,
+                void(CL_CALLBACK* pfn_notify)(const char* errinfo,
+                                              const void* private_info,
+                                              size_t      cb,
+                                              void*       user_data),
+                void*   user_data,
+                cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_context CL_API_CALL
-clCreateContextFromType(const cl_context_properties * properties,
-                        cl_device_type      device_type,
-                        void (CL_CALLBACK * pfn_notify)(const char * errinfo,
-                                                        const void * private_info,
-                                                        size_t       cb,
-                                                        void *       user_data),
-                        void *              user_data,
-                        cl_int *            errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+clCreateContextFromType(const cl_context_properties* properties,
+                        cl_device_type               device_type,
+                        void(CL_CALLBACK* pfn_notify)(const char* errinfo,
+                                                      const void* private_info,
+                                                      size_t      cb,
+                                                      void*       user_data),
+                        void*   user_data,
+                        cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clRetainContext(cl_context context) CL_API_SUFFIX__VERSION_1_0;
@@ -1041,19 +1053,19 @@ extern CL_API_ENTRY cl_int CL_API_CALL
 clReleaseContext(cl_context context) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetContextInfo(cl_context         context,
-                 cl_context_info    param_name,
-                 size_t             param_value_size,
-                 void *             param_value,
-                 size_t *           param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetContextInfo(cl_context      context,
+                 cl_context_info param_name,
+                 size_t          param_value_size,
+                 void*           param_value,
+                 size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_3_0
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clSetContextDestructorCallback(cl_context         context,
-                               void (CL_CALLBACK* pfn_notify)(cl_context context,
-                                                              void* user_data),
-                               void*              user_data) CL_API_SUFFIX__VERSION_3_0;
+clSetContextDestructorCallback(cl_context context,
+                               void(CL_CALLBACK* pfn_notify)(cl_context context,
+                                                             void* user_data),
+                               void* user_data) CL_API_SUFFIX__VERSION_3_0;
 
 #endif
 
@@ -1062,10 +1074,11 @@ clSetContextDestructorCallback(cl_context         context,
 #ifdef CL_VERSION_2_0
 
 extern CL_API_ENTRY cl_command_queue CL_API_CALL
-clCreateCommandQueueWithProperties(cl_context               context,
-                                   cl_device_id             device,
-                                   const cl_queue_properties *    properties,
-                                   cl_int *                 errcode_ret) CL_API_SUFFIX__VERSION_2_0;
+clCreateCommandQueueWithProperties(cl_context                 context,
+                                   cl_device_id               device,
+                                   const cl_queue_properties* properties,
+                                   cl_int*                    errcode_ret)
+  CL_API_SUFFIX__VERSION_2_0;
 
 #endif
 
@@ -1073,76 +1086,77 @@ extern CL_API_ENTRY cl_int CL_API_CALL
 clRetainCommandQueue(cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clReleaseCommandQueue(cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0;
+clReleaseCommandQueue(cl_command_queue command_queue)
+  CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clGetCommandQueueInfo(cl_command_queue      command_queue,
                       cl_command_queue_info param_name,
                       size_t                param_value_size,
-                      void *                param_value,
-                      size_t *              param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+                      void*                 param_value,
+                      size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 /* Memory Object APIs */
 extern CL_API_ENTRY cl_mem CL_API_CALL
 clCreateBuffer(cl_context   context,
                cl_mem_flags flags,
                size_t       size,
-               void *       host_ptr,
-               cl_int *     errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+               void*        host_ptr,
+               cl_int*      errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_1
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateSubBuffer(cl_mem                   buffer,
-                  cl_mem_flags             flags,
-                  cl_buffer_create_type    buffer_create_type,
-                  const void *             buffer_create_info,
-                  cl_int *                 errcode_ret) CL_API_SUFFIX__VERSION_1_1;
+clCreateSubBuffer(cl_mem                buffer,
+                  cl_mem_flags          flags,
+                  cl_buffer_create_type buffer_create_type,
+                  const void*           buffer_create_info,
+                  cl_int*               errcode_ret) CL_API_SUFFIX__VERSION_1_1;
 
 #endif
 
 #ifdef CL_VERSION_1_2
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateImage(cl_context              context,
-              cl_mem_flags            flags,
-              const cl_image_format * image_format,
-              const cl_image_desc *   image_desc,
-              void *                  host_ptr,
-              cl_int *                errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+clCreateImage(cl_context             context,
+              cl_mem_flags           flags,
+              const cl_image_format* image_format,
+              const cl_image_desc*   image_desc,
+              void*                  host_ptr,
+              cl_int*                errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 #endif
 
 #ifdef CL_VERSION_2_0
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreatePipe(cl_context                 context,
-             cl_mem_flags               flags,
-             cl_uint                    pipe_packet_size,
-             cl_uint                    pipe_max_packets,
-             const cl_pipe_properties * properties,
-             cl_int *                   errcode_ret) CL_API_SUFFIX__VERSION_2_0;
+clCreatePipe(cl_context                context,
+             cl_mem_flags              flags,
+             cl_uint                   pipe_packet_size,
+             cl_uint                   pipe_max_packets,
+             const cl_pipe_properties* properties,
+             cl_int*                   errcode_ret) CL_API_SUFFIX__VERSION_2_0;
 
 #endif
 
 #ifdef CL_VERSION_3_0
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateBufferWithProperties(cl_context                context,
-                             const cl_mem_properties * properties,
-                             cl_mem_flags              flags,
-                             size_t                    size,
-                             void *                    host_ptr,
-                             cl_int *                  errcode_ret) CL_API_SUFFIX__VERSION_3_0;
+clCreateBufferWithProperties(cl_context               context,
+                             const cl_mem_properties* properties,
+                             cl_mem_flags             flags,
+                             size_t                   size,
+                             void*                    host_ptr,
+                             cl_int* errcode_ret) CL_API_SUFFIX__VERSION_3_0;
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateImageWithProperties(cl_context                context,
-                            const cl_mem_properties * properties,
-                            cl_mem_flags              flags,
-                            const cl_image_format *   image_format,
-                            const cl_image_desc *     image_desc,
-                            void *                    host_ptr,
-                            cl_int *                  errcode_ret) CL_API_SUFFIX__VERSION_3_0;
+clCreateImageWithProperties(cl_context               context,
+                            const cl_mem_properties* properties,
+                            cl_mem_flags             flags,
+                            const cl_image_format*   image_format,
+                            const cl_image_desc*     image_desc,
+                            void*                    host_ptr,
+                            cl_int* errcode_ret) CL_API_SUFFIX__VERSION_3_0;
 
 #endif
 
@@ -1153,35 +1167,36 @@ extern CL_API_ENTRY cl_int CL_API_CALL
 clReleaseMemObject(cl_mem memobj) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetSupportedImageFormats(cl_context           context,
-                           cl_mem_flags         flags,
-                           cl_mem_object_type   image_type,
-                           cl_uint              num_entries,
-                           cl_image_format *    image_formats,
-                           cl_uint *            num_image_formats) CL_API_SUFFIX__VERSION_1_0;
+clGetSupportedImageFormats(cl_context         context,
+                           cl_mem_flags       flags,
+                           cl_mem_object_type image_type,
+                           cl_uint            num_entries,
+                           cl_image_format*   image_formats,
+                           cl_uint*           num_image_formats)
+  CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetMemObjectInfo(cl_mem           memobj,
-                   cl_mem_info      param_name,
-                   size_t           param_value_size,
-                   void *           param_value,
-                   size_t *         param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetMemObjectInfo(cl_mem      memobj,
+                   cl_mem_info param_name,
+                   size_t      param_value_size,
+                   void*       param_value,
+                   size_t*     param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetImageInfo(cl_mem           image,
-               cl_image_info    param_name,
-               size_t           param_value_size,
-               void *           param_value,
-               size_t *         param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetImageInfo(cl_mem        image,
+               cl_image_info param_name,
+               size_t        param_value_size,
+               void*         param_value,
+               size_t*       param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_2_0
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetPipeInfo(cl_mem           pipe,
-              cl_pipe_info     param_name,
-              size_t           param_value_size,
-              void *           param_value,
-              size_t *         param_value_size_ret) CL_API_SUFFIX__VERSION_2_0;
+clGetPipeInfo(cl_mem       pipe,
+              cl_pipe_info param_name,
+              size_t       param_value_size,
+              void*        param_value,
+              size_t*      param_value_size_ret) CL_API_SUFFIX__VERSION_2_0;
 
 #endif
 
@@ -1189,9 +1204,9 @@ clGetPipeInfo(cl_mem           pipe,
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clSetMemObjectDestructorCallback(cl_mem memobj,
-                                 void (CL_CALLBACK * pfn_notify)(cl_mem memobj,
-                                                                 void * user_data),
-                                 void * user_data) CL_API_SUFFIX__VERSION_1_1;
+                                 void(CL_CALLBACK* pfn_notify)(cl_mem memobj,
+                                                               void* user_data),
+                                 void* user_data) CL_API_SUFFIX__VERSION_1_1;
 
 #endif
 
@@ -1199,15 +1214,14 @@ clSetMemObjectDestructorCallback(cl_mem memobj,
 
 #ifdef CL_VERSION_2_0
 
-extern CL_API_ENTRY void * CL_API_CALL
+extern CL_API_ENTRY void* CL_API_CALL
 clSVMAlloc(cl_context       context,
            cl_svm_mem_flags flags,
            size_t           size,
            cl_uint          alignment) CL_API_SUFFIX__VERSION_2_0;
 
 extern CL_API_ENTRY void CL_API_CALL
-clSVMFree(cl_context        context,
-          void *            svm_pointer) CL_API_SUFFIX__VERSION_2_0;
+clSVMFree(cl_context context, void* svm_pointer) CL_API_SUFFIX__VERSION_2_0;
 
 #endif
 
@@ -1216,9 +1230,9 @@ clSVMFree(cl_context        context,
 #ifdef CL_VERSION_2_0
 
 extern CL_API_ENTRY cl_sampler CL_API_CALL
-clCreateSamplerWithProperties(cl_context                     context,
-                              const cl_sampler_properties *  sampler_properties,
-                              cl_int *                       errcode_ret) CL_API_SUFFIX__VERSION_2_0;
+clCreateSamplerWithProperties(cl_context                   context,
+                              const cl_sampler_properties* sampler_properties,
+                              cl_int* errcode_ret) CL_API_SUFFIX__VERSION_2_0;
 
 #endif
 
@@ -1229,47 +1243,48 @@ extern CL_API_ENTRY cl_int CL_API_CALL
 clReleaseSampler(cl_sampler sampler) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetSamplerInfo(cl_sampler         sampler,
-                 cl_sampler_info    param_name,
-                 size_t             param_value_size,
-                 void *             param_value,
-                 size_t *           param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetSamplerInfo(cl_sampler      sampler,
+                 cl_sampler_info param_name,
+                 size_t          param_value_size,
+                 void*           param_value,
+                 size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 /* Program Object APIs */
 extern CL_API_ENTRY cl_program CL_API_CALL
-clCreateProgramWithSource(cl_context        context,
-                          cl_uint           count,
-                          const char **     strings,
-                          const size_t *    lengths,
-                          cl_int *          errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+clCreateProgramWithSource(cl_context    context,
+                          cl_uint       count,
+                          const char**  strings,
+                          const size_t* lengths,
+                          cl_int*       errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_program CL_API_CALL
-clCreateProgramWithBinary(cl_context                     context,
-                          cl_uint                        num_devices,
-                          const cl_device_id *           device_list,
-                          const size_t *                 lengths,
-                          const unsigned char **         binaries,
-                          cl_int *                       binary_status,
-                          cl_int *                       errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+clCreateProgramWithBinary(cl_context            context,
+                          cl_uint               num_devices,
+                          const cl_device_id*   device_list,
+                          const size_t*         lengths,
+                          const unsigned char** binaries,
+                          cl_int*               binary_status,
+                          cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
 extern CL_API_ENTRY cl_program CL_API_CALL
-clCreateProgramWithBuiltInKernels(cl_context            context,
-                                  cl_uint               num_devices,
-                                  const cl_device_id *  device_list,
-                                  const char *          kernel_names,
-                                  cl_int *              errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+clCreateProgramWithBuiltInKernels(cl_context          context,
+                                  cl_uint             num_devices,
+                                  const cl_device_id* device_list,
+                                  const char*         kernel_names,
+                                  cl_int*             errcode_ret)
+  CL_API_SUFFIX__VERSION_1_2;
 
 #endif
 
 #ifdef CL_VERSION_2_1
 
 extern CL_API_ENTRY cl_program CL_API_CALL
-clCreateProgramWithIL(cl_context    context,
-                     const void*    il,
-                     size_t         length,
-                     cl_int*        errcode_ret) CL_API_SUFFIX__VERSION_2_1;
+clCreateProgramWithIL(cl_context  context,
+                      const void* il,
+                      size_t      length,
+                      cl_int*     errcode_ret) CL_API_SUFFIX__VERSION_2_1;
 
 #endif
 
@@ -1280,55 +1295,56 @@ extern CL_API_ENTRY cl_int CL_API_CALL
 clReleaseProgram(cl_program program) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clBuildProgram(cl_program           program,
-               cl_uint              num_devices,
-               const cl_device_id * device_list,
-               const char *         options,
-               void (CL_CALLBACK *  pfn_notify)(cl_program program,
-                                                void * user_data),
-               void *               user_data) CL_API_SUFFIX__VERSION_1_0;
+clBuildProgram(cl_program          program,
+               cl_uint             num_devices,
+               const cl_device_id* device_list,
+               const char*         options,
+               void(CL_CALLBACK* pfn_notify)(cl_program program,
+                                             void*      user_data),
+               void* user_data) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCompileProgram(cl_program           program,
-                 cl_uint              num_devices,
-                 const cl_device_id * device_list,
-                 const char *         options,
-                 cl_uint              num_input_headers,
-                 const cl_program *   input_headers,
-                 const char **        header_include_names,
-                 void (CL_CALLBACK *  pfn_notify)(cl_program program,
-                                                  void * user_data),
-                 void *               user_data) CL_API_SUFFIX__VERSION_1_2;
+clCompileProgram(cl_program          program,
+                 cl_uint             num_devices,
+                 const cl_device_id* device_list,
+                 const char*         options,
+                 cl_uint             num_input_headers,
+                 const cl_program*   input_headers,
+                 const char**        header_include_names,
+                 void(CL_CALLBACK* pfn_notify)(cl_program program,
+                                               void*      user_data),
+                 void* user_data) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_program CL_API_CALL
-clLinkProgram(cl_context           context,
-              cl_uint              num_devices,
-              const cl_device_id * device_list,
-              const char *         options,
-              cl_uint              num_input_programs,
-              const cl_program *   input_programs,
-              void (CL_CALLBACK *  pfn_notify)(cl_program program,
-                                               void * user_data),
-              void *               user_data,
-              cl_int *             errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+clLinkProgram(cl_context          context,
+              cl_uint             num_devices,
+              const cl_device_id* device_list,
+              const char*         options,
+              cl_uint             num_input_programs,
+              const cl_program*   input_programs,
+              void(CL_CALLBACK* pfn_notify)(cl_program program,
+                                            void*      user_data),
+              void*   user_data,
+              cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 #endif
 
 #ifdef CL_VERSION_2_2
 
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_2_2_DEPRECATED cl_int CL_API_CALL
-clSetProgramReleaseCallback(cl_program          program,
-                            void (CL_CALLBACK * pfn_notify)(cl_program program,
-                                                            void * user_data),
-                            void *              user_data) CL_API_SUFFIX__VERSION_2_2_DEPRECATED;
+clSetProgramReleaseCallback(
+  cl_program program,
+  void(CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+  void* user_data) CL_API_SUFFIX__VERSION_2_2_DEPRECATED;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clSetProgramSpecializationConstant(cl_program  program,
                                    cl_uint     spec_id,
                                    size_t      spec_size,
-                                   const void* spec_value) CL_API_SUFFIX__VERSION_2_2;
+                                   const void* spec_value)
+  CL_API_SUFFIX__VERSION_2_2;
 
 #endif
 
@@ -1340,125 +1356,127 @@ clUnloadPlatformCompiler(cl_platform_id platform) CL_API_SUFFIX__VERSION_1_2;
 #endif
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetProgramInfo(cl_program         program,
-                 cl_program_info    param_name,
-                 size_t             param_value_size,
-                 void *             param_value,
-                 size_t *           param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetProgramInfo(cl_program      program,
+                 cl_program_info param_name,
+                 size_t          param_value_size,
+                 void*           param_value,
+                 size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clGetProgramBuildInfo(cl_program            program,
                       cl_device_id          device,
                       cl_program_build_info param_name,
                       size_t                param_value_size,
-                      void *                param_value,
-                      size_t *              param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+                      void*                 param_value,
+                      size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 /* Kernel Object APIs */
 extern CL_API_ENTRY cl_kernel CL_API_CALL
-clCreateKernel(cl_program      program,
-               const char *    kernel_name,
-               cl_int *        errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+clCreateKernel(cl_program  program,
+               const char* kernel_name,
+               cl_int*     errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCreateKernelsInProgram(cl_program     program,
-                         cl_uint        num_kernels,
-                         cl_kernel *    kernels,
-                         cl_uint *      num_kernels_ret) CL_API_SUFFIX__VERSION_1_0;
+clCreateKernelsInProgram(cl_program program,
+                         cl_uint    num_kernels,
+                         cl_kernel* kernels,
+                         cl_uint*   num_kernels_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_2_1
 
 extern CL_API_ENTRY cl_kernel CL_API_CALL
-clCloneKernel(cl_kernel     source_kernel,
-              cl_int*       errcode_ret) CL_API_SUFFIX__VERSION_2_1;
+clCloneKernel(cl_kernel source_kernel,
+              cl_int*   errcode_ret) CL_API_SUFFIX__VERSION_2_1;
 
 #endif
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clRetainKernel(cl_kernel    kernel) CL_API_SUFFIX__VERSION_1_0;
+clRetainKernel(cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clReleaseKernel(cl_kernel   kernel) CL_API_SUFFIX__VERSION_1_0;
+clReleaseKernel(cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clSetKernelArg(cl_kernel    kernel,
-               cl_uint      arg_index,
-               size_t       arg_size,
-               const void * arg_value) CL_API_SUFFIX__VERSION_1_0;
+clSetKernelArg(cl_kernel   kernel,
+               cl_uint     arg_index,
+               size_t      arg_size,
+               const void* arg_value) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_2_0
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clSetKernelArgSVMPointer(cl_kernel    kernel,
-                         cl_uint      arg_index,
-                         const void * arg_value) CL_API_SUFFIX__VERSION_2_0;
+clSetKernelArgSVMPointer(cl_kernel   kernel,
+                         cl_uint     arg_index,
+                         const void* arg_value) CL_API_SUFFIX__VERSION_2_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clSetKernelExecInfo(cl_kernel            kernel,
-                    cl_kernel_exec_info  param_name,
-                    size_t               param_value_size,
-                    const void *         param_value) CL_API_SUFFIX__VERSION_2_0;
+clSetKernelExecInfo(cl_kernel           kernel,
+                    cl_kernel_exec_info param_name,
+                    size_t              param_value_size,
+                    const void*         param_value) CL_API_SUFFIX__VERSION_2_0;
 
 #endif
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetKernelInfo(cl_kernel       kernel,
-                cl_kernel_info  param_name,
-                size_t          param_value_size,
-                void *          param_value,
-                size_t *        param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetKernelInfo(cl_kernel      kernel,
+                cl_kernel_info param_name,
+                size_t         param_value_size,
+                void*          param_value,
+                size_t*        param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetKernelArgInfo(cl_kernel       kernel,
-                   cl_uint         arg_indx,
-                   cl_kernel_arg_info  param_name,
-                   size_t          param_value_size,
-                   void *          param_value,
-                   size_t *        param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
+clGetKernelArgInfo(cl_kernel          kernel,
+                   cl_uint            arg_indx,
+                   cl_kernel_arg_info param_name,
+                   size_t             param_value_size,
+                   void*              param_value,
+                   size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
 
 #endif
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetKernelWorkGroupInfo(cl_kernel                  kernel,
-                         cl_device_id               device,
-                         cl_kernel_work_group_info  param_name,
-                         size_t                     param_value_size,
-                         void *                     param_value,
-                         size_t *                   param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetKernelWorkGroupInfo(cl_kernel                 kernel,
+                         cl_device_id              device,
+                         cl_kernel_work_group_info param_name,
+                         size_t                    param_value_size,
+                         void*                     param_value,
+                         size_t*                   param_value_size_ret)
+  CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_2_1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetKernelSubGroupInfo(cl_kernel                   kernel,
-                        cl_device_id                device,
-                        cl_kernel_sub_group_info    param_name,
-                        size_t                      input_value_size,
-                        const void*                 input_value,
-                        size_t                      param_value_size,
-                        void*                       param_value,
-                        size_t*                     param_value_size_ret) CL_API_SUFFIX__VERSION_2_1;
+clGetKernelSubGroupInfo(cl_kernel                kernel,
+                        cl_device_id             device,
+                        cl_kernel_sub_group_info param_name,
+                        size_t                   input_value_size,
+                        const void*              input_value,
+                        size_t                   param_value_size,
+                        void*                    param_value,
+                        size_t*                  param_value_size_ret)
+  CL_API_SUFFIX__VERSION_2_1;
 
 #endif
 
 /* Event Object APIs */
 extern CL_API_ENTRY cl_int CL_API_CALL
-clWaitForEvents(cl_uint             num_events,
-                const cl_event *    event_list) CL_API_SUFFIX__VERSION_1_0;
+clWaitForEvents(cl_uint         num_events,
+                const cl_event* event_list) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetEventInfo(cl_event         event,
-               cl_event_info    param_name,
-               size_t           param_value_size,
-               void *           param_value,
-               size_t *         param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetEventInfo(cl_event      event,
+               cl_event_info param_name,
+               size_t        param_value_size,
+               void*         param_value,
+               size_t*       param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_1
 
 extern CL_API_ENTRY cl_event CL_API_CALL
-clCreateUserEvent(cl_context    context,
-                  cl_int *      errcode_ret) CL_API_SUFFIX__VERSION_1_1;
+clCreateUserEvent(cl_context context,
+                  cl_int*    errcode_ret) CL_API_SUFFIX__VERSION_1_1;
 
 #endif
 
@@ -1471,26 +1489,27 @@ clReleaseEvent(cl_event event) CL_API_SUFFIX__VERSION_1_0;
 #ifdef CL_VERSION_1_1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clSetUserEventStatus(cl_event   event,
-                     cl_int     execution_status) CL_API_SUFFIX__VERSION_1_1;
+clSetUserEventStatus(cl_event event,
+                     cl_int   execution_status) CL_API_SUFFIX__VERSION_1_1;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clSetEventCallback(cl_event    event,
-                   cl_int      command_exec_callback_type,
-                   void (CL_CALLBACK * pfn_notify)(cl_event event,
-                                                   cl_int   event_command_status,
-                                                   void *   user_data),
-                   void *      user_data) CL_API_SUFFIX__VERSION_1_1;
+clSetEventCallback(cl_event event,
+                   cl_int   command_exec_callback_type,
+                   void(CL_CALLBACK* pfn_notify)(cl_event event,
+                                                 cl_int   event_command_status,
+                                                 void*    user_data),
+                   void* user_data) CL_API_SUFFIX__VERSION_1_1;
 
 #endif
 
 /* Profiling APIs */
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetEventProfilingInfo(cl_event            event,
-                        cl_profiling_info   param_name,
-                        size_t              param_value_size,
-                        void *              param_value,
-                        size_t *            param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetEventProfilingInfo(cl_event          event,
+                        cl_profiling_info param_name,
+                        size_t            param_value_size,
+                        void*             param_value,
+                        size_t*           param_value_size_ret)
+  CL_API_SUFFIX__VERSION_1_0;
 
 /* Flush and Finish APIs */
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -1501,186 +1520,186 @@ clFinish(cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0;
 
 /* Enqueued Commands APIs */
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueReadBuffer(cl_command_queue    command_queue,
-                    cl_mem              buffer,
-                    cl_bool             blocking_read,
-                    size_t              offset,
-                    size_t              size,
-                    void *              ptr,
-                    cl_uint             num_events_in_wait_list,
-                    const cl_event *    event_wait_list,
-                    cl_event *          event) CL_API_SUFFIX__VERSION_1_0;
+clEnqueueReadBuffer(cl_command_queue command_queue,
+                    cl_mem           buffer,
+                    cl_bool          blocking_read,
+                    size_t           offset,
+                    size_t           size,
+                    void*            ptr,
+                    cl_uint          num_events_in_wait_list,
+                    const cl_event*  event_wait_list,
+                    cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueReadBufferRect(cl_command_queue    command_queue,
-                        cl_mem              buffer,
-                        cl_bool             blocking_read,
-                        const size_t *      buffer_origin,
-                        const size_t *      host_origin,
-                        const size_t *      region,
-                        size_t              buffer_row_pitch,
-                        size_t              buffer_slice_pitch,
-                        size_t              host_row_pitch,
-                        size_t              host_slice_pitch,
-                        void *              ptr,
-                        cl_uint             num_events_in_wait_list,
-                        const cl_event *    event_wait_list,
-                        cl_event *          event) CL_API_SUFFIX__VERSION_1_1;
+clEnqueueReadBufferRect(cl_command_queue command_queue,
+                        cl_mem           buffer,
+                        cl_bool          blocking_read,
+                        const size_t*    buffer_origin,
+                        const size_t*    host_origin,
+                        const size_t*    region,
+                        size_t           buffer_row_pitch,
+                        size_t           buffer_slice_pitch,
+                        size_t           host_row_pitch,
+                        size_t           host_slice_pitch,
+                        void*            ptr,
+                        cl_uint          num_events_in_wait_list,
+                        const cl_event*  event_wait_list,
+                        cl_event*        event) CL_API_SUFFIX__VERSION_1_1;
 
 #endif
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueWriteBuffer(cl_command_queue   command_queue,
-                     cl_mem             buffer,
-                     cl_bool            blocking_write,
-                     size_t             offset,
-                     size_t             size,
-                     const void *       ptr,
-                     cl_uint            num_events_in_wait_list,
-                     const cl_event *   event_wait_list,
-                     cl_event *         event) CL_API_SUFFIX__VERSION_1_0;
+clEnqueueWriteBuffer(cl_command_queue command_queue,
+                     cl_mem           buffer,
+                     cl_bool          blocking_write,
+                     size_t           offset,
+                     size_t           size,
+                     const void*      ptr,
+                     cl_uint          num_events_in_wait_list,
+                     const cl_event*  event_wait_list,
+                     cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueWriteBufferRect(cl_command_queue    command_queue,
-                         cl_mem              buffer,
-                         cl_bool             blocking_write,
-                         const size_t *      buffer_origin,
-                         const size_t *      host_origin,
-                         const size_t *      region,
-                         size_t              buffer_row_pitch,
-                         size_t              buffer_slice_pitch,
-                         size_t              host_row_pitch,
-                         size_t              host_slice_pitch,
-                         const void *        ptr,
-                         cl_uint             num_events_in_wait_list,
-                         const cl_event *    event_wait_list,
-                         cl_event *          event) CL_API_SUFFIX__VERSION_1_1;
+clEnqueueWriteBufferRect(cl_command_queue command_queue,
+                         cl_mem           buffer,
+                         cl_bool          blocking_write,
+                         const size_t*    buffer_origin,
+                         const size_t*    host_origin,
+                         const size_t*    region,
+                         size_t           buffer_row_pitch,
+                         size_t           buffer_slice_pitch,
+                         size_t           host_row_pitch,
+                         size_t           host_slice_pitch,
+                         const void*      ptr,
+                         cl_uint          num_events_in_wait_list,
+                         const cl_event*  event_wait_list,
+                         cl_event*        event) CL_API_SUFFIX__VERSION_1_1;
 
 #endif
 
 #ifdef CL_VERSION_1_2
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueFillBuffer(cl_command_queue   command_queue,
-                    cl_mem             buffer,
-                    const void *       pattern,
-                    size_t             pattern_size,
-                    size_t             offset,
-                    size_t             size,
-                    cl_uint            num_events_in_wait_list,
-                    const cl_event *   event_wait_list,
-                    cl_event *         event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueFillBuffer(cl_command_queue command_queue,
+                    cl_mem           buffer,
+                    const void*      pattern,
+                    size_t           pattern_size,
+                    size_t           offset,
+                    size_t           size,
+                    cl_uint          num_events_in_wait_list,
+                    const cl_event*  event_wait_list,
+                    cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 #endif
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueCopyBuffer(cl_command_queue    command_queue,
-                    cl_mem              src_buffer,
-                    cl_mem              dst_buffer,
-                    size_t              src_offset,
-                    size_t              dst_offset,
-                    size_t              size,
-                    cl_uint             num_events_in_wait_list,
-                    const cl_event *    event_wait_list,
-                    cl_event *          event) CL_API_SUFFIX__VERSION_1_0;
+clEnqueueCopyBuffer(cl_command_queue command_queue,
+                    cl_mem           src_buffer,
+                    cl_mem           dst_buffer,
+                    size_t           src_offset,
+                    size_t           dst_offset,
+                    size_t           size,
+                    cl_uint          num_events_in_wait_list,
+                    const cl_event*  event_wait_list,
+                    cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueCopyBufferRect(cl_command_queue    command_queue,
-                        cl_mem              src_buffer,
-                        cl_mem              dst_buffer,
-                        const size_t *      src_origin,
-                        const size_t *      dst_origin,
-                        const size_t *      region,
-                        size_t              src_row_pitch,
-                        size_t              src_slice_pitch,
-                        size_t              dst_row_pitch,
-                        size_t              dst_slice_pitch,
-                        cl_uint             num_events_in_wait_list,
-                        const cl_event *    event_wait_list,
-                        cl_event *          event) CL_API_SUFFIX__VERSION_1_1;
+clEnqueueCopyBufferRect(cl_command_queue command_queue,
+                        cl_mem           src_buffer,
+                        cl_mem           dst_buffer,
+                        const size_t*    src_origin,
+                        const size_t*    dst_origin,
+                        const size_t*    region,
+                        size_t           src_row_pitch,
+                        size_t           src_slice_pitch,
+                        size_t           dst_row_pitch,
+                        size_t           dst_slice_pitch,
+                        cl_uint          num_events_in_wait_list,
+                        const cl_event*  event_wait_list,
+                        cl_event*        event) CL_API_SUFFIX__VERSION_1_1;
 
 #endif
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueReadImage(cl_command_queue     command_queue,
-                   cl_mem               image,
-                   cl_bool              blocking_read,
-                   const size_t *       origin,
-                   const size_t *       region,
-                   size_t               row_pitch,
-                   size_t               slice_pitch,
-                   void *               ptr,
-                   cl_uint              num_events_in_wait_list,
-                   const cl_event *     event_wait_list,
-                   cl_event *           event) CL_API_SUFFIX__VERSION_1_0;
+clEnqueueReadImage(cl_command_queue command_queue,
+                   cl_mem           image,
+                   cl_bool          blocking_read,
+                   const size_t*    origin,
+                   const size_t*    region,
+                   size_t           row_pitch,
+                   size_t           slice_pitch,
+                   void*            ptr,
+                   cl_uint          num_events_in_wait_list,
+                   const cl_event*  event_wait_list,
+                   cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueWriteImage(cl_command_queue    command_queue,
-                    cl_mem              image,
-                    cl_bool             blocking_write,
-                    const size_t *      origin,
-                    const size_t *      region,
-                    size_t              input_row_pitch,
-                    size_t              input_slice_pitch,
-                    const void *        ptr,
-                    cl_uint             num_events_in_wait_list,
-                    const cl_event *    event_wait_list,
-                    cl_event *          event) CL_API_SUFFIX__VERSION_1_0;
+clEnqueueWriteImage(cl_command_queue command_queue,
+                    cl_mem           image,
+                    cl_bool          blocking_write,
+                    const size_t*    origin,
+                    const size_t*    region,
+                    size_t           input_row_pitch,
+                    size_t           input_slice_pitch,
+                    const void*      ptr,
+                    cl_uint          num_events_in_wait_list,
+                    const cl_event*  event_wait_list,
+                    cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueFillImage(cl_command_queue   command_queue,
-                   cl_mem             image,
-                   const void *       fill_color,
-                   const size_t *     origin,
-                   const size_t *     region,
-                   cl_uint            num_events_in_wait_list,
-                   const cl_event *   event_wait_list,
-                   cl_event *         event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueFillImage(cl_command_queue command_queue,
+                   cl_mem           image,
+                   const void*      fill_color,
+                   const size_t*    origin,
+                   const size_t*    region,
+                   cl_uint          num_events_in_wait_list,
+                   const cl_event*  event_wait_list,
+                   cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 #endif
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueCopyImage(cl_command_queue     command_queue,
-                   cl_mem               src_image,
-                   cl_mem               dst_image,
-                   const size_t *       src_origin,
-                   const size_t *       dst_origin,
-                   const size_t *       region,
-                   cl_uint              num_events_in_wait_list,
-                   const cl_event *     event_wait_list,
-                   cl_event *           event) CL_API_SUFFIX__VERSION_1_0;
+clEnqueueCopyImage(cl_command_queue command_queue,
+                   cl_mem           src_image,
+                   cl_mem           dst_image,
+                   const size_t*    src_origin,
+                   const size_t*    dst_origin,
+                   const size_t*    region,
+                   cl_uint          num_events_in_wait_list,
+                   const cl_event*  event_wait_list,
+                   cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueCopyImageToBuffer(cl_command_queue command_queue,
                            cl_mem           src_image,
                            cl_mem           dst_buffer,
-                           const size_t *   src_origin,
-                           const size_t *   region,
+                           const size_t*    src_origin,
+                           const size_t*    region,
                            size_t           dst_offset,
                            cl_uint          num_events_in_wait_list,
-                           const cl_event * event_wait_list,
-                           cl_event *       event) CL_API_SUFFIX__VERSION_1_0;
+                           const cl_event*  event_wait_list,
+                           cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueCopyBufferToImage(cl_command_queue command_queue,
                            cl_mem           src_buffer,
                            cl_mem           dst_image,
                            size_t           src_offset,
-                           const size_t *   dst_origin,
-                           const size_t *   region,
+                           const size_t*    dst_origin,
+                           const size_t*    region,
                            cl_uint          num_events_in_wait_list,
-                           const cl_event * event_wait_list,
-                           cl_event *       event) CL_API_SUFFIX__VERSION_1_0;
+                           const cl_event*  event_wait_list,
+                           cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-extern CL_API_ENTRY void * CL_API_CALL
+extern CL_API_ENTRY void* CL_API_CALL
 clEnqueueMapBuffer(cl_command_queue command_queue,
                    cl_mem           buffer,
                    cl_bool          blocking_map,
@@ -1688,42 +1707,42 @@ clEnqueueMapBuffer(cl_command_queue command_queue,
                    size_t           offset,
                    size_t           size,
                    cl_uint          num_events_in_wait_list,
-                   const cl_event * event_wait_list,
-                   cl_event *       event,
-                   cl_int *         errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+                   const cl_event*  event_wait_list,
+                   cl_event*        event,
+                   cl_int*          errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-extern CL_API_ENTRY void * CL_API_CALL
-clEnqueueMapImage(cl_command_queue  command_queue,
-                  cl_mem            image,
-                  cl_bool           blocking_map,
-                  cl_map_flags      map_flags,
-                  const size_t *    origin,
-                  const size_t *    region,
-                  size_t *          image_row_pitch,
-                  size_t *          image_slice_pitch,
-                  cl_uint           num_events_in_wait_list,
-                  const cl_event *  event_wait_list,
-                  cl_event *        event,
-                  cl_int *          errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+extern CL_API_ENTRY void* CL_API_CALL
+clEnqueueMapImage(cl_command_queue command_queue,
+                  cl_mem           image,
+                  cl_bool          blocking_map,
+                  cl_map_flags     map_flags,
+                  const size_t*    origin,
+                  const size_t*    region,
+                  size_t*          image_row_pitch,
+                  size_t*          image_slice_pitch,
+                  cl_uint          num_events_in_wait_list,
+                  const cl_event*  event_wait_list,
+                  cl_event*        event,
+                  cl_int*          errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueUnmapMemObject(cl_command_queue command_queue,
                         cl_mem           memobj,
-                        void *           mapped_ptr,
+                        void*            mapped_ptr,
                         cl_uint          num_events_in_wait_list,
-                        const cl_event * event_wait_list,
-                        cl_event *       event) CL_API_SUFFIX__VERSION_1_0;
+                        const cl_event*  event_wait_list,
+                        cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueMigrateMemObjects(cl_command_queue       command_queue,
                            cl_uint                num_mem_objects,
-                           const cl_mem *         mem_objects,
+                           const cl_mem*          mem_objects,
                            cl_mem_migration_flags flags,
                            cl_uint                num_events_in_wait_list,
-                           const cl_event *       event_wait_list,
-                           cl_event *             event) CL_API_SUFFIX__VERSION_1_2;
+                           const cl_event*        event_wait_list,
+                           cl_event* event) CL_API_SUFFIX__VERSION_1_2;
 
 #endif
 
@@ -1731,106 +1750,106 @@ extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueNDRangeKernel(cl_command_queue command_queue,
                        cl_kernel        kernel,
                        cl_uint          work_dim,
-                       const size_t *   global_work_offset,
-                       const size_t *   global_work_size,
-                       const size_t *   local_work_size,
+                       const size_t*    global_work_offset,
+                       const size_t*    global_work_size,
+                       const size_t*    local_work_size,
                        cl_uint          num_events_in_wait_list,
-                       const cl_event * event_wait_list,
-                       cl_event *       event) CL_API_SUFFIX__VERSION_1_0;
+                       const cl_event*  event_wait_list,
+                       cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueNativeKernel(cl_command_queue  command_queue,
-                      void (CL_CALLBACK * user_func)(void *),
-                      void *            args,
-                      size_t            cb_args,
-                      cl_uint           num_mem_objects,
-                      const cl_mem *    mem_list,
-                      const void **     args_mem_loc,
-                      cl_uint           num_events_in_wait_list,
-                      const cl_event *  event_wait_list,
-                      cl_event *        event) CL_API_SUFFIX__VERSION_1_0;
+clEnqueueNativeKernel(cl_command_queue command_queue,
+                      void(CL_CALLBACK* user_func)(void*),
+                      void*           args,
+                      size_t          cb_args,
+                      cl_uint         num_mem_objects,
+                      const cl_mem*   mem_list,
+                      const void**    args_mem_loc,
+                      cl_uint         num_events_in_wait_list,
+                      const cl_event* event_wait_list,
+                      cl_event*       event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueMarkerWithWaitList(cl_command_queue  command_queue,
-                            cl_uint           num_events_in_wait_list,
-                            const cl_event *  event_wait_list,
-                            cl_event *        event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueMarkerWithWaitList(cl_command_queue command_queue,
+                            cl_uint          num_events_in_wait_list,
+                            const cl_event*  event_wait_list,
+                            cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueBarrierWithWaitList(cl_command_queue  command_queue,
-                             cl_uint           num_events_in_wait_list,
-                             const cl_event *  event_wait_list,
-                             cl_event *        event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueBarrierWithWaitList(cl_command_queue command_queue,
+                             cl_uint          num_events_in_wait_list,
+                             const cl_event*  event_wait_list,
+                             cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 #endif
 
 #ifdef CL_VERSION_2_0
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMFree(cl_command_queue  command_queue,
-                 cl_uint           num_svm_pointers,
-                 void *            svm_pointers[],
-                 void (CL_CALLBACK * pfn_free_func)(cl_command_queue queue,
-                                                    cl_uint          num_svm_pointers,
-                                                    void *           svm_pointers[],
-                                                    void *           user_data),
-                 void *            user_data,
-                 cl_uint           num_events_in_wait_list,
-                 const cl_event *  event_wait_list,
-                 cl_event *        event) CL_API_SUFFIX__VERSION_2_0;
+clEnqueueSVMFree(cl_command_queue command_queue,
+                 cl_uint          num_svm_pointers,
+                 void*            svm_pointers[],
+                 void(CL_CALLBACK* pfn_free_func)(cl_command_queue queue,
+                                                  cl_uint num_svm_pointers,
+                                                  void*   svm_pointers[],
+                                                  void*   user_data),
+                 void*           user_data,
+                 cl_uint         num_events_in_wait_list,
+                 const cl_event* event_wait_list,
+                 cl_event*       event) CL_API_SUFFIX__VERSION_2_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMMemcpy(cl_command_queue  command_queue,
-                   cl_bool           blocking_copy,
-                   void *            dst_ptr,
-                   const void *      src_ptr,
-                   size_t            size,
-                   cl_uint           num_events_in_wait_list,
-                   const cl_event *  event_wait_list,
-                   cl_event *        event) CL_API_SUFFIX__VERSION_2_0;
+clEnqueueSVMMemcpy(cl_command_queue command_queue,
+                   cl_bool          blocking_copy,
+                   void*            dst_ptr,
+                   const void*      src_ptr,
+                   size_t           size,
+                   cl_uint          num_events_in_wait_list,
+                   const cl_event*  event_wait_list,
+                   cl_event*        event) CL_API_SUFFIX__VERSION_2_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMMemFill(cl_command_queue  command_queue,
-                    void *            svm_ptr,
-                    const void *      pattern,
-                    size_t            pattern_size,
-                    size_t            size,
-                    cl_uint           num_events_in_wait_list,
-                    const cl_event *  event_wait_list,
-                    cl_event *        event) CL_API_SUFFIX__VERSION_2_0;
+clEnqueueSVMMemFill(cl_command_queue command_queue,
+                    void*            svm_ptr,
+                    const void*      pattern,
+                    size_t           pattern_size,
+                    size_t           size,
+                    cl_uint          num_events_in_wait_list,
+                    const cl_event*  event_wait_list,
+                    cl_event*        event) CL_API_SUFFIX__VERSION_2_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMMap(cl_command_queue  command_queue,
-                cl_bool           blocking_map,
-                cl_map_flags      flags,
-                void *            svm_ptr,
-                size_t            size,
-                cl_uint           num_events_in_wait_list,
-                const cl_event *  event_wait_list,
-                cl_event *        event) CL_API_SUFFIX__VERSION_2_0;
+clEnqueueSVMMap(cl_command_queue command_queue,
+                cl_bool          blocking_map,
+                cl_map_flags     flags,
+                void*            svm_ptr,
+                size_t           size,
+                cl_uint          num_events_in_wait_list,
+                const cl_event*  event_wait_list,
+                cl_event*        event) CL_API_SUFFIX__VERSION_2_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMUnmap(cl_command_queue  command_queue,
-                  void *            svm_ptr,
-                  cl_uint           num_events_in_wait_list,
-                  const cl_event *  event_wait_list,
-                  cl_event *        event) CL_API_SUFFIX__VERSION_2_0;
+clEnqueueSVMUnmap(cl_command_queue command_queue,
+                  void*            svm_ptr,
+                  cl_uint          num_events_in_wait_list,
+                  const cl_event*  event_wait_list,
+                  cl_event*        event) CL_API_SUFFIX__VERSION_2_0;
 
 #endif
 
 #ifdef CL_VERSION_2_1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMMigrateMem(cl_command_queue         command_queue,
-                       cl_uint                  num_svm_pointers,
-                       const void **            svm_pointers,
-                       const size_t *           sizes,
-                       cl_mem_migration_flags   flags,
-                       cl_uint                  num_events_in_wait_list,
-                       const cl_event *         event_wait_list,
-                       cl_event *               event) CL_API_SUFFIX__VERSION_2_1;
+clEnqueueSVMMigrateMem(cl_command_queue       command_queue,
+                       cl_uint                num_svm_pointers,
+                       const void**           svm_pointers,
+                       const size_t*          sizes,
+                       cl_mem_migration_flags flags,
+                       cl_uint                num_events_in_wait_list,
+                       const cl_event*        event_wait_list,
+                       cl_event*              event) CL_API_SUFFIX__VERSION_2_1;
 
 #endif
 
@@ -1843,94 +1862,102 @@ clEnqueueSVMMigrateMem(cl_command_queue         command_queue,
  * check to make sure the address is not NULL, before using or
  * calling the returned function address.
  */
-extern CL_API_ENTRY void * CL_API_CALL
+extern CL_API_ENTRY void* CL_API_CALL
 clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
-                                         const char *   func_name) CL_API_SUFFIX__VERSION_1_2;
+                                         const char*    func_name)
+  CL_API_SUFFIX__VERSION_1_2;
 
 #endif
 
 #ifdef CL_USE_DEPRECATED_OPENCL_1_0_APIS
-    /*
-     *  WARNING:
-     *     This API introduces mutable state into the OpenCL implementation. It has been REMOVED
-     *  to better facilitate thread safety.  The 1.0 API is not thread safe. It is not tested by the
-     *  OpenCL 1.1 conformance test, and consequently may not work or may not work dependably.
-     *  It is likely to be non-performant. Use of this API is not advised. Use at your own risk.
-     *
-     *  Software developers previously relying on this API are instructed to set the command queue
-     *  properties when creating the queue, instead.
-     */
-    extern CL_API_ENTRY cl_int CL_API_CALL
-    clSetCommandQueueProperty(cl_command_queue              command_queue,
-                              cl_command_queue_properties   properties,
-                              cl_bool                       enable,
-                              cl_command_queue_properties * old_properties) CL_API_SUFFIX__VERSION_1_0_DEPRECATED;
+/*
+ *  WARNING:
+ *     This API introduces mutable state into the OpenCL implementation. It has
+ * been REMOVED to better facilitate thread safety.  The 1.0 API is not thread
+ * safe. It is not tested by the OpenCL 1.1 conformance test, and consequently
+ * may not work or may not work dependably. It is likely to be non-performant.
+ * Use of this API is not advised. Use at your own risk.
+ *
+ *  Software developers previously relying on this API are instructed to set the
+ * command queue properties when creating the queue, instead.
+ */
+extern CL_API_ENTRY cl_int CL_API_CALL
+clSetCommandQueueProperty(cl_command_queue             command_queue,
+                          cl_command_queue_properties  properties,
+                          cl_bool                      enable,
+                          cl_command_queue_properties* old_properties)
+  CL_API_SUFFIX__VERSION_1_0_DEPRECATED;
 #endif /* CL_USE_DEPRECATED_OPENCL_1_0_APIS */
 
 /* Deprecated OpenCL 1.1 APIs */
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED cl_mem CL_API_CALL
-clCreateImage2D(cl_context              context,
-                cl_mem_flags            flags,
-                const cl_image_format * image_format,
-                size_t                  image_width,
-                size_t                  image_height,
-                size_t                  image_row_pitch,
-                void *                  host_ptr,
-                cl_int *                errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+clCreateImage2D(cl_context             context,
+                cl_mem_flags           flags,
+                const cl_image_format* image_format,
+                size_t                 image_width,
+                size_t                 image_height,
+                size_t                 image_row_pitch,
+                void*                  host_ptr,
+                cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED cl_mem CL_API_CALL
-clCreateImage3D(cl_context              context,
-                cl_mem_flags            flags,
-                const cl_image_format * image_format,
-                size_t                  image_width,
-                size_t                  image_height,
-                size_t                  image_depth,
-                size_t                  image_row_pitch,
-                size_t                  image_slice_pitch,
-                void *                  host_ptr,
-                cl_int *                errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+clCreateImage3D(cl_context             context,
+                cl_mem_flags           flags,
+                const cl_image_format* image_format,
+                size_t                 image_width,
+                size_t                 image_height,
+                size_t                 image_depth,
+                size_t                 image_row_pitch,
+                size_t                 image_slice_pitch,
+                void*                  host_ptr,
+                cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED cl_int CL_API_CALL
-clEnqueueMarker(cl_command_queue    command_queue,
-                cl_event *          event) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+clEnqueueMarker(cl_command_queue command_queue,
+                cl_event*        event) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED cl_int CL_API_CALL
-clEnqueueWaitForEvents(cl_command_queue  command_queue,
-                        cl_uint          num_events,
-                        const cl_event * event_list) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+clEnqueueWaitForEvents(cl_command_queue command_queue,
+                       cl_uint          num_events,
+                       const cl_event*  event_list)
+  CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED cl_int CL_API_CALL
-clEnqueueBarrier(cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+clEnqueueBarrier(cl_command_queue command_queue)
+  CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED cl_int CL_API_CALL
 clUnloadCompiler(void) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
-extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED void * CL_API_CALL
-clGetExtensionFunctionAddress(const char * func_name) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED void* CL_API_CALL
+clGetExtensionFunctionAddress(const char* func_name)
+  CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
 /* Deprecated OpenCL 2.0 APIs */
-extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_2_DEPRECATED cl_command_queue CL_API_CALL
-clCreateCommandQueue(cl_context                     context,
-                     cl_device_id                   device,
-                     cl_command_queue_properties    properties,
-                     cl_int *                       errcode_ret) CL_API_SUFFIX__VERSION_1_2_DEPRECATED;
+extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_2_DEPRECATED cl_command_queue
+  CL_API_CALL
+  clCreateCommandQueue(cl_context                  context,
+                       cl_device_id                device,
+                       cl_command_queue_properties properties,
+                       cl_int*                     errcode_ret)
+    CL_API_SUFFIX__VERSION_1_2_DEPRECATED;
 
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_2_DEPRECATED cl_sampler CL_API_CALL
-clCreateSampler(cl_context          context,
-                cl_bool             normalized_coords,
-                cl_addressing_mode  addressing_mode,
-                cl_filter_mode      filter_mode,
-                cl_int *            errcode_ret) CL_API_SUFFIX__VERSION_1_2_DEPRECATED;
+clCreateSampler(cl_context         context,
+                cl_bool            normalized_coords,
+                cl_addressing_mode addressing_mode,
+                cl_filter_mode     filter_mode,
+                cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2_DEPRECATED;
 
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_2_DEPRECATED cl_int CL_API_CALL
-clEnqueueTask(cl_command_queue  command_queue,
-              cl_kernel         kernel,
-              cl_uint           num_events_in_wait_list,
-              const cl_event *  event_wait_list,
-              cl_event *        event) CL_API_SUFFIX__VERSION_1_2_DEPRECATED;
+clEnqueueTask(cl_command_queue command_queue,
+              cl_kernel        kernel,
+              cl_uint          num_events_in_wait_list,
+              const cl_event*  event_wait_list,
+              cl_event*        event) CL_API_SUFFIX__VERSION_1_2_DEPRECATED;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  /* __OPENCL_CL_H */
+#endif /* __OPENCL_CL_H */

--- a/CL/cl_d3d10.h
+++ b/CL/cl_d3d10.h
@@ -18,16 +18,16 @@
 #define __OPENCL_CL_D3D10_H
 
 #if defined(_MSC_VER)
-#if _MSC_VER >=1500
-#pragma warning( push )
-#pragma warning( disable : 4201 )
-#pragma warning( disable : 5105 )
+#if _MSC_VER >= 1500
+#pragma warning(push)
+#pragma warning(disable : 4201)
+#pragma warning(disable : 5105)
 #endif
 #endif
 #include <d3d10.h>
 #if defined(_MSC_VER)
-#if _MSC_VER >=1500
-#pragma warning( pop )
+#if _MSC_VER >= 1500
+#pragma warning(pop)
 #endif
 #endif
 #include <CL/cl.h>
@@ -76,79 +76,76 @@ typedef cl_uint cl_d3d10_device_set_khr;
 
 /******************************************************************************/
 
-typedef cl_int (CL_API_CALL *clGetDeviceIDsFromD3D10KHR_fn)(
-    cl_platform_id             platform,
-    cl_d3d10_device_source_khr d3d_device_source,
-    void *                     d3d_object,
-    cl_d3d10_device_set_khr    d3d_device_set,
-    cl_uint                    num_entries,
-    cl_device_id *             devices,
-    cl_uint *                  num_devices) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* clGetDeviceIDsFromD3D10KHR_fn)(
+  cl_platform_id             platform,
+  cl_d3d10_device_source_khr d3d_device_source,
+  void*                      d3d_object,
+  cl_d3d10_device_set_khr    d3d_device_set,
+  cl_uint                    num_entries,
+  cl_device_id*              devices,
+  cl_uint*                   num_devices) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem (CL_API_CALL *clCreateFromD3D10BufferKHR_fn)(
-    cl_context     context,
-    cl_mem_flags   flags,
-    ID3D10Buffer * resource,
-    cl_int *       errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* clCreateFromD3D10BufferKHR_fn)(
+  cl_context    context,
+  cl_mem_flags  flags,
+  ID3D10Buffer* resource,
+  cl_int*       errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem (CL_API_CALL *clCreateFromD3D10Texture2DKHR_fn)(
-    cl_context        context,
-    cl_mem_flags      flags,
-    ID3D10Texture2D * resource,
-    UINT              subresource,
-    cl_int *          errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* clCreateFromD3D10Texture2DKHR_fn)(
+  cl_context       context,
+  cl_mem_flags     flags,
+  ID3D10Texture2D* resource,
+  UINT             subresource,
+  cl_int*          errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem (CL_API_CALL *clCreateFromD3D10Texture3DKHR_fn)(
-    cl_context        context,
-    cl_mem_flags      flags,
-    ID3D10Texture3D * resource,
-    UINT              subresource,
-    cl_int *          errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* clCreateFromD3D10Texture3DKHR_fn)(
+  cl_context       context,
+  cl_mem_flags     flags,
+  ID3D10Texture3D* resource,
+  UINT             subresource,
+  cl_int*          errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int (CL_API_CALL *clEnqueueAcquireD3D10ObjectsKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint          num_objects,
-    const cl_mem *   mem_objects,
-    cl_uint          num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event *       event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* clEnqueueAcquireD3D10ObjectsKHR_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int (CL_API_CALL *clEnqueueReleaseD3D10ObjectsKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint          num_objects,
-    const cl_mem *   mem_objects,
-    cl_uint          num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event *       event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* clEnqueueReleaseD3D10ObjectsKHR_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 /***************************************************************
-* cl_intel_sharing_format_query_d3d10
-***************************************************************/
+ * cl_intel_sharing_format_query_d3d10
+ ***************************************************************/
 #define cl_intel_sharing_format_query_d3d10 1
 
 /* when cl_khr_d3d10_sharing is supported */
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetSupportedD3D10TextureFormatsINTEL(
-    cl_context context,
-    cl_mem_flags flags,
-    cl_mem_object_type image_type,
-    cl_uint num_entries,
-    DXGI_FORMAT* d3d10_formats,
-    cl_uint* num_texture_formats) ;
+clGetSupportedD3D10TextureFormatsINTEL(cl_context         context,
+                                       cl_mem_flags       flags,
+                                       cl_mem_object_type image_type,
+                                       cl_uint            num_entries,
+                                       DXGI_FORMAT*       d3d10_formats,
+                                       cl_uint*           num_texture_formats);
 
-typedef cl_int (CL_API_CALL *
-clGetSupportedD3D10TextureFormatsINTEL_fn)(
-    cl_context context,
-    cl_mem_flags flags,
-    cl_mem_object_type image_type,
-    cl_uint num_entries,
-    DXGI_FORMAT* d3d10_formats,
-    cl_uint* num_texture_formats) ;
+typedef cl_int(CL_API_CALL* clGetSupportedD3D10TextureFormatsINTEL_fn)(
+  cl_context         context,
+  cl_mem_flags       flags,
+  cl_mem_object_type image_type,
+  cl_uint            num_entries,
+  DXGI_FORMAT*       d3d10_formats,
+  cl_uint*           num_texture_formats);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  /* __OPENCL_CL_D3D10_H */
-
+#endif /* __OPENCL_CL_D3D10_H */

--- a/CL/cl_d3d11.h
+++ b/CL/cl_d3d11.h
@@ -18,16 +18,16 @@
 #define __OPENCL_CL_D3D11_H
 
 #if defined(_MSC_VER)
-#if _MSC_VER >=1500
-#pragma warning( push )
-#pragma warning( disable : 4201 )
-#pragma warning( disable : 5105 )
+#if _MSC_VER >= 1500
+#pragma warning(push)
+#pragma warning(disable : 4201)
+#pragma warning(disable : 5105)
 #endif
 #endif
 #include <d3d11.h>
 #if defined(_MSC_VER)
-#if _MSC_VER >=1500
-#pragma warning( pop )
+#if _MSC_VER >= 1500
+#pragma warning(pop)
 #endif
 #endif
 #include <CL/cl.h>
@@ -76,81 +76,78 @@ typedef cl_uint cl_d3d11_device_set_khr;
 
 /******************************************************************************/
 
-typedef cl_int (CL_API_CALL *clGetDeviceIDsFromD3D11KHR_fn)(
-    cl_platform_id             platform,
-    cl_d3d11_device_source_khr d3d_device_source,
-    void *                     d3d_object,
-    cl_d3d11_device_set_khr    d3d_device_set,
-    cl_uint                    num_entries,
-    cl_device_id *             devices,
-    cl_uint *                  num_devices) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clGetDeviceIDsFromD3D11KHR_fn)(
+  cl_platform_id             platform,
+  cl_d3d11_device_source_khr d3d_device_source,
+  void*                      d3d_object,
+  cl_d3d11_device_set_khr    d3d_device_set,
+  cl_uint                    num_entries,
+  cl_device_id*              devices,
+  cl_uint*                   num_devices) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_mem (CL_API_CALL *clCreateFromD3D11BufferKHR_fn)(
-    cl_context     context,
-    cl_mem_flags   flags,
-    ID3D11Buffer * resource,
-    cl_int *       errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_mem(CL_API_CALL* clCreateFromD3D11BufferKHR_fn)(
+  cl_context    context,
+  cl_mem_flags  flags,
+  ID3D11Buffer* resource,
+  cl_int*       errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_mem (CL_API_CALL *clCreateFromD3D11Texture2DKHR_fn)(
-    cl_context        context,
-    cl_mem_flags      flags,
-    ID3D11Texture2D * resource,
-    UINT              subresource,
-    cl_int *          errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_mem(CL_API_CALL* clCreateFromD3D11Texture2DKHR_fn)(
+  cl_context       context,
+  cl_mem_flags     flags,
+  ID3D11Texture2D* resource,
+  UINT             subresource,
+  cl_int*          errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_mem (CL_API_CALL *clCreateFromD3D11Texture3DKHR_fn)(
-    cl_context        context,
-    cl_mem_flags      flags,
-    ID3D11Texture3D * resource,
-    UINT              subresource,
-    cl_int *          errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_mem(CL_API_CALL* clCreateFromD3D11Texture3DKHR_fn)(
+  cl_context       context,
+  cl_mem_flags     flags,
+  ID3D11Texture3D* resource,
+  UINT             subresource,
+  cl_int*          errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *clEnqueueAcquireD3D11ObjectsKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint          num_objects,
-    const cl_mem *   mem_objects,
-    cl_uint          num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event *       event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clEnqueueAcquireD3D11ObjectsKHR_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *clEnqueueReleaseD3D11ObjectsKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint          num_objects,
-    const cl_mem *   mem_objects,
-    cl_uint          num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event *       event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clEnqueueReleaseD3D11ObjectsKHR_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 /***************************************************************
-* cl_intel_sharing_format_query_d3d11
-***************************************************************/
+ * cl_intel_sharing_format_query_d3d11
+ ***************************************************************/
 #define cl_intel_sharing_format_query_d3d11 1
 
 /* when cl_khr_d3d11_sharing is supported */
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetSupportedD3D11TextureFormatsINTEL(
-    cl_context context,
-    cl_mem_flags flags,
-    cl_mem_object_type image_type,
-    cl_uint plane,
-    cl_uint num_entries,
-    DXGI_FORMAT* d3d11_formats,
-    cl_uint* num_texture_formats) ;
+clGetSupportedD3D11TextureFormatsINTEL(cl_context         context,
+                                       cl_mem_flags       flags,
+                                       cl_mem_object_type image_type,
+                                       cl_uint            plane,
+                                       cl_uint            num_entries,
+                                       DXGI_FORMAT*       d3d11_formats,
+                                       cl_uint*           num_texture_formats);
 
-typedef cl_int (CL_API_CALL *
-clGetSupportedD3D11TextureFormatsINTEL_fn)(
-    cl_context context,
-    cl_mem_flags flags,
-    cl_mem_object_type image_type,
-    cl_uint plane,
-    cl_uint num_entries,
-    DXGI_FORMAT* d3d11_formats,
-    cl_uint* num_texture_formats) ;
+typedef cl_int(CL_API_CALL* clGetSupportedD3D11TextureFormatsINTEL_fn)(
+  cl_context         context,
+  cl_mem_flags       flags,
+  cl_mem_object_type image_type,
+  cl_uint            plane,
+  cl_uint            num_entries,
+  DXGI_FORMAT*       d3d11_formats,
+  cl_uint*           num_texture_formats);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  /* __OPENCL_CL_D3D11_H */
-
+#endif /* __OPENCL_CL_D3D11_H */

--- a/CL/cl_dx9_media_sharing.h
+++ b/CL/cl_dx9_media_sharing.h
@@ -28,103 +28,102 @@ extern "C" {
 /* cl_khr_dx9_media_sharing                                                   */
 #define cl_khr_dx9_media_sharing 1
 
-typedef cl_uint             cl_dx9_media_adapter_type_khr;
-typedef cl_uint             cl_dx9_media_adapter_set_khr;
-    
+typedef cl_uint cl_dx9_media_adapter_type_khr;
+typedef cl_uint cl_dx9_media_adapter_set_khr;
+
 #if defined(_WIN32)
 #if defined(_MSC_VER)
-#if _MSC_VER >=1500
-#pragma warning( push )
-#pragma warning( disable : 4201 )
-#pragma warning( disable : 5105 )
+#if _MSC_VER >= 1500
+#pragma warning(push)
+#pragma warning(disable : 4201)
+#pragma warning(disable : 5105)
 #endif
 #endif
 #include <d3d9.h>
 #if defined(_MSC_VER)
-#if _MSC_VER >=1500
-#pragma warning( pop )
+#if _MSC_VER >= 1500
+#pragma warning(pop)
 #endif
 #endif
 typedef struct _cl_dx9_surface_info_khr
 {
-    IDirect3DSurface9 *resource;
-    HANDLE shared_handle;
+  IDirect3DSurface9* resource;
+  HANDLE             shared_handle;
 } cl_dx9_surface_info_khr;
 #endif
-
 
 /******************************************************************************/
 
 /* Error Codes */
-#define CL_INVALID_DX9_MEDIA_ADAPTER_KHR                -1010
-#define CL_INVALID_DX9_MEDIA_SURFACE_KHR                -1011
-#define CL_DX9_MEDIA_SURFACE_ALREADY_ACQUIRED_KHR       -1012
-#define CL_DX9_MEDIA_SURFACE_NOT_ACQUIRED_KHR           -1013
+#define CL_INVALID_DX9_MEDIA_ADAPTER_KHR               -1010
+#define CL_INVALID_DX9_MEDIA_SURFACE_KHR               -1011
+#define CL_DX9_MEDIA_SURFACE_ALREADY_ACQUIRED_KHR      -1012
+#define CL_DX9_MEDIA_SURFACE_NOT_ACQUIRED_KHR          -1013
 
 /* cl_media_adapter_type_khr */
-#define CL_ADAPTER_D3D9_KHR                              0x2020
-#define CL_ADAPTER_D3D9EX_KHR                            0x2021
-#define CL_ADAPTER_DXVA_KHR                              0x2022
+#define CL_ADAPTER_D3D9_KHR                            0x2020
+#define CL_ADAPTER_D3D9EX_KHR                          0x2021
+#define CL_ADAPTER_DXVA_KHR                            0x2022
 
 /* cl_media_adapter_set_khr */
-#define CL_PREFERRED_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR   0x2023
-#define CL_ALL_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR         0x2024
+#define CL_PREFERRED_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR 0x2023
+#define CL_ALL_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR       0x2024
 
 /* cl_context_info */
-#define CL_CONTEXT_ADAPTER_D3D9_KHR                      0x2025
-#define CL_CONTEXT_ADAPTER_D3D9EX_KHR                    0x2026
-#define CL_CONTEXT_ADAPTER_DXVA_KHR                      0x2027
+#define CL_CONTEXT_ADAPTER_D3D9_KHR                    0x2025
+#define CL_CONTEXT_ADAPTER_D3D9EX_KHR                  0x2026
+#define CL_CONTEXT_ADAPTER_DXVA_KHR                    0x2027
 
 /* cl_mem_info */
-#define CL_MEM_DX9_MEDIA_ADAPTER_TYPE_KHR                0x2028
-#define CL_MEM_DX9_MEDIA_SURFACE_INFO_KHR                0x2029
+#define CL_MEM_DX9_MEDIA_ADAPTER_TYPE_KHR              0x2028
+#define CL_MEM_DX9_MEDIA_SURFACE_INFO_KHR              0x2029
 
 /* cl_image_info */
-#define CL_IMAGE_DX9_MEDIA_PLANE_KHR                     0x202A
+#define CL_IMAGE_DX9_MEDIA_PLANE_KHR                   0x202A
 
 /* cl_command_type */
-#define CL_COMMAND_ACQUIRE_DX9_MEDIA_SURFACES_KHR        0x202B
-#define CL_COMMAND_RELEASE_DX9_MEDIA_SURFACES_KHR        0x202C
+#define CL_COMMAND_ACQUIRE_DX9_MEDIA_SURFACES_KHR      0x202B
+#define CL_COMMAND_RELEASE_DX9_MEDIA_SURFACES_KHR      0x202C
 
 /******************************************************************************/
 
-typedef cl_int (CL_API_CALL *clGetDeviceIDsFromDX9MediaAdapterKHR_fn)(
-    cl_platform_id                   platform,
-    cl_uint                          num_media_adapters,
-    cl_dx9_media_adapter_type_khr *  media_adapter_type,
-    void *                           media_adapters,
-    cl_dx9_media_adapter_set_khr     media_adapter_set,
-    cl_uint                          num_entries,
-    cl_device_id *                   devices,
-    cl_uint *                        num_devices) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clGetDeviceIDsFromDX9MediaAdapterKHR_fn)(
+  cl_platform_id                 platform,
+  cl_uint                        num_media_adapters,
+  cl_dx9_media_adapter_type_khr* media_adapter_type,
+  void*                          media_adapters,
+  cl_dx9_media_adapter_set_khr   media_adapter_set,
+  cl_uint                        num_entries,
+  cl_device_id*                  devices,
+  cl_uint*                       num_devices) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_mem (CL_API_CALL *clCreateFromDX9MediaSurfaceKHR_fn)(
-    cl_context                    context,
-    cl_mem_flags                  flags,
-    cl_dx9_media_adapter_type_khr adapter_type,
-    void *                        surface_info,
-    cl_uint                       plane,                                                                          
-    cl_int *                      errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_mem(CL_API_CALL* clCreateFromDX9MediaSurfaceKHR_fn)(
+  cl_context                    context,
+  cl_mem_flags                  flags,
+  cl_dx9_media_adapter_type_khr adapter_type,
+  void*                         surface_info,
+  cl_uint                       plane,
+  cl_int*                       errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *clEnqueueAcquireDX9MediaSurfacesKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint          num_objects,
-    const cl_mem *   mem_objects,
-    cl_uint          num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event *       event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clEnqueueAcquireDX9MediaSurfacesKHR_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *clEnqueueReleaseDX9MediaSurfacesKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint          num_objects,
-    const cl_mem *   mem_objects,
-    cl_uint          num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event *       event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clEnqueueReleaseDX9MediaSurfacesKHR_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 /***************************************
-* cl_intel_dx9_media_sharing extension *
-****************************************/
+ * cl_intel_dx9_media_sharing extension *
+ ****************************************/
 
 #define cl_intel_dx9_media_sharing 1
 
@@ -132,137 +131,131 @@ typedef cl_uint cl_dx9_device_source_intel;
 typedef cl_uint cl_dx9_device_set_intel;
 
 /* error codes */
-#define CL_INVALID_DX9_DEVICE_INTEL                   -1010
-#define CL_INVALID_DX9_RESOURCE_INTEL                 -1011
-#define CL_DX9_RESOURCE_ALREADY_ACQUIRED_INTEL        -1012
-#define CL_DX9_RESOURCE_NOT_ACQUIRED_INTEL            -1013
+#define CL_INVALID_DX9_DEVICE_INTEL            -1010
+#define CL_INVALID_DX9_RESOURCE_INTEL          -1011
+#define CL_DX9_RESOURCE_ALREADY_ACQUIRED_INTEL -1012
+#define CL_DX9_RESOURCE_NOT_ACQUIRED_INTEL     -1013
 
 /* cl_dx9_device_source_intel */
-#define CL_D3D9_DEVICE_INTEL                          0x4022
-#define CL_D3D9EX_DEVICE_INTEL                        0x4070
-#define CL_DXVA_DEVICE_INTEL                          0x4071
+#define CL_D3D9_DEVICE_INTEL                   0x4022
+#define CL_D3D9EX_DEVICE_INTEL                 0x4070
+#define CL_DXVA_DEVICE_INTEL                   0x4071
 
 /* cl_dx9_device_set_intel */
-#define CL_PREFERRED_DEVICES_FOR_DX9_INTEL            0x4024
-#define CL_ALL_DEVICES_FOR_DX9_INTEL                  0x4025
+#define CL_PREFERRED_DEVICES_FOR_DX9_INTEL     0x4024
+#define CL_ALL_DEVICES_FOR_DX9_INTEL           0x4025
 
 /* cl_context_info */
-#define CL_CONTEXT_D3D9_DEVICE_INTEL                  0x4026
-#define CL_CONTEXT_D3D9EX_DEVICE_INTEL                0x4072
-#define CL_CONTEXT_DXVA_DEVICE_INTEL                  0x4073
+#define CL_CONTEXT_D3D9_DEVICE_INTEL           0x4026
+#define CL_CONTEXT_D3D9EX_DEVICE_INTEL         0x4072
+#define CL_CONTEXT_DXVA_DEVICE_INTEL           0x4073
 
 /* cl_mem_info */
-#define CL_MEM_DX9_RESOURCE_INTEL                     0x4027
-#define CL_MEM_DX9_SHARED_HANDLE_INTEL                0x4074
+#define CL_MEM_DX9_RESOURCE_INTEL              0x4027
+#define CL_MEM_DX9_SHARED_HANDLE_INTEL         0x4074
 
 /* cl_image_info */
-#define CL_IMAGE_DX9_PLANE_INTEL                      0x4075
+#define CL_IMAGE_DX9_PLANE_INTEL               0x4075
 
 /* cl_command_type */
-#define CL_COMMAND_ACQUIRE_DX9_OBJECTS_INTEL          0x402A
-#define CL_COMMAND_RELEASE_DX9_OBJECTS_INTEL          0x402B
+#define CL_COMMAND_ACQUIRE_DX9_OBJECTS_INTEL   0x402A
+#define CL_COMMAND_RELEASE_DX9_OBJECTS_INTEL   0x402B
 /******************************************************************************/
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetDeviceIDsFromDX9INTEL(
-    cl_platform_id              platform,
-    cl_dx9_device_source_intel  dx9_device_source,
-    void*                       dx9_object,
-    cl_dx9_device_set_intel     dx9_device_set,
-    cl_uint                     num_entries,
-    cl_device_id*               devices,
-    cl_uint*                    num_devices) CL_API_SUFFIX__VERSION_1_1;
+clGetDeviceIDsFromDX9INTEL(cl_platform_id             platform,
+                           cl_dx9_device_source_intel dx9_device_source,
+                           void*                      dx9_object,
+                           cl_dx9_device_set_intel    dx9_device_set,
+                           cl_uint                    num_entries,
+                           cl_device_id*              devices,
+                           cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_1;
 
-typedef cl_int (CL_API_CALL* clGetDeviceIDsFromDX9INTEL_fn)(
-    cl_platform_id              platform,
-    cl_dx9_device_source_intel  dx9_device_source,
-    void*                       dx9_object,
-    cl_dx9_device_set_intel     dx9_device_set,
-    cl_uint                     num_entries,
-    cl_device_id*               devices,
-    cl_uint*                    num_devices) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* clGetDeviceIDsFromDX9INTEL_fn)(
+  cl_platform_id             platform,
+  cl_dx9_device_source_intel dx9_device_source,
+  void*                      dx9_object,
+  cl_dx9_device_set_intel    dx9_device_set,
+  cl_uint                    num_entries,
+  cl_device_id*              devices,
+  cl_uint*                   num_devices) CL_API_SUFFIX__VERSION_1_1;
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateFromDX9MediaSurfaceINTEL(
-    cl_context                  context,
-    cl_mem_flags                flags,
-    IDirect3DSurface9*          resource,
-    HANDLE                      sharedHandle,
-    UINT                        plane,
-    cl_int*                     errcode_ret) CL_API_SUFFIX__VERSION_1_1;
+clCreateFromDX9MediaSurfaceINTEL(cl_context         context,
+                                 cl_mem_flags       flags,
+                                 IDirect3DSurface9* resource,
+                                 HANDLE             sharedHandle,
+                                 UINT               plane,
+                                 cl_int*            errcode_ret)
+  CL_API_SUFFIX__VERSION_1_1;
 
-typedef cl_mem (CL_API_CALL *clCreateFromDX9MediaSurfaceINTEL_fn)(
-    cl_context                  context,
-    cl_mem_flags                flags,
-    IDirect3DSurface9*          resource,
-    HANDLE                      sharedHandle,
-    UINT                        plane,
-    cl_int*                     errcode_ret) CL_API_SUFFIX__VERSION_1_1;
-
-extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueAcquireDX9ObjectsINTEL(
-    cl_command_queue            command_queue,
-    cl_uint                     num_objects,
-    const cl_mem*               mem_objects,
-    cl_uint                     num_events_in_wait_list,
-    const cl_event*             event_wait_list,
-    cl_event*                   event) CL_API_SUFFIX__VERSION_1_1;
-
-typedef cl_int (CL_API_CALL *clEnqueueAcquireDX9ObjectsINTEL_fn)(
-    cl_command_queue            command_queue,
-    cl_uint                     num_objects,
-    const cl_mem*               mem_objects,
-    cl_uint                     num_events_in_wait_list,
-    const cl_event*             event_wait_list,
-    cl_event*                   event) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_mem(CL_API_CALL* clCreateFromDX9MediaSurfaceINTEL_fn)(
+  cl_context         context,
+  cl_mem_flags       flags,
+  IDirect3DSurface9* resource,
+  HANDLE             sharedHandle,
+  UINT               plane,
+  cl_int*            errcode_ret) CL_API_SUFFIX__VERSION_1_1;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueReleaseDX9ObjectsINTEL(
-    cl_command_queue            command_queue,
-    cl_uint                     num_objects,
-    cl_mem*                     mem_objects,
-    cl_uint                     num_events_in_wait_list,
-    const cl_event*             event_wait_list,
-    cl_event*                   event) CL_API_SUFFIX__VERSION_1_1;
+clEnqueueAcquireDX9ObjectsINTEL(cl_command_queue command_queue,
+                                cl_uint          num_objects,
+                                const cl_mem*    mem_objects,
+                                cl_uint          num_events_in_wait_list,
+                                const cl_event*  event_wait_list,
+                                cl_event* event) CL_API_SUFFIX__VERSION_1_1;
 
-typedef cl_int (CL_API_CALL *clEnqueueReleaseDX9ObjectsINTEL_fn)(
-    cl_command_queue            command_queue,
-    cl_uint                     num_objects,
-    cl_mem*                     mem_objects,
-    cl_uint                     num_events_in_wait_list,
-    const cl_event*             event_wait_list,
-    cl_event*                   event) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* clEnqueueAcquireDX9ObjectsINTEL_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_1;
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueReleaseDX9ObjectsINTEL(cl_command_queue command_queue,
+                                cl_uint          num_objects,
+                                cl_mem*          mem_objects,
+                                cl_uint          num_events_in_wait_list,
+                                const cl_event*  event_wait_list,
+                                cl_event* event) CL_API_SUFFIX__VERSION_1_1;
+
+typedef cl_int(CL_API_CALL* clEnqueueReleaseDX9ObjectsINTEL_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  cl_mem*          mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_1;
 
 /***************************************************************
-* cl_intel_sharing_format_query_dx9
-***************************************************************/
+ * cl_intel_sharing_format_query_dx9
+ ***************************************************************/
 #define cl_intel_sharing_format_query_dx9 1
 
 /* when cl_khr_dx9_media_sharing or cl_intel_dx9_media_sharing is supported */
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetSupportedDX9MediaSurfaceFormatsINTEL(
-    cl_context context,
-    cl_mem_flags flags,
-    cl_mem_object_type image_type,
-    cl_uint plane,
-    cl_uint num_entries,
-    D3DFORMAT* dx9_formats,
-    cl_uint* num_surface_formats) ;
+clGetSupportedDX9MediaSurfaceFormatsINTEL(cl_context         context,
+                                          cl_mem_flags       flags,
+                                          cl_mem_object_type image_type,
+                                          cl_uint            plane,
+                                          cl_uint            num_entries,
+                                          D3DFORMAT*         dx9_formats,
+                                          cl_uint* num_surface_formats);
 
-typedef cl_int (CL_API_CALL *
-clGetSupportedDX9MediaSurfaceFormatsINTEL_fn)(
-    cl_context context,
-    cl_mem_flags flags,
-    cl_mem_object_type image_type,
-    cl_uint plane,
-    cl_uint num_entries,
-    D3DFORMAT* dx9_formats,
-    cl_uint* num_surface_formats) ;
+typedef cl_int(CL_API_CALL* clGetSupportedDX9MediaSurfaceFormatsINTEL_fn)(
+  cl_context         context,
+  cl_mem_flags       flags,
+  cl_mem_object_type image_type,
+  cl_uint            plane,
+  cl_uint            num_entries,
+  D3DFORMAT*         dx9_formats,
+  cl_uint*           num_surface_formats);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  /* __OPENCL_CL_DX9_MEDIA_SHARING_H */
-
+#endif /* __OPENCL_CL_DX9_MEDIA_SHARING_H */

--- a/CL/cl_dx9_media_sharing_intel.h
+++ b/CL/cl_dx9_media_sharing_intel.h
@@ -15,4 +15,5 @@
  ******************************************************************************/
 
 #include <CL/cl_dx9_media_sharing.h>
-#pragma message("The Intel DX9 media sharing extensions have been moved into cl_dx9_media_sharing.h.  Please include cl_dx9_media_sharing.h directly.")
+#pragma message(                                                               \
+  "The Intel DX9 media sharing extensions have been moved into cl_dx9_media_sharing.h.  Please include cl_dx9_media_sharing.h directly.")

--- a/CL/cl_egl.h
+++ b/CL/cl_egl.h
@@ -23,81 +23,76 @@
 extern "C" {
 #endif
 
-
 /* Command type for events created with clEnqueueAcquireEGLObjectsKHR */
-#define CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR  0x202F
-#define CL_COMMAND_ACQUIRE_EGL_OBJECTS_KHR    0x202D
-#define CL_COMMAND_RELEASE_EGL_OBJECTS_KHR    0x202E
+#define CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR 0x202F
+#define CL_COMMAND_ACQUIRE_EGL_OBJECTS_KHR   0x202D
+#define CL_COMMAND_RELEASE_EGL_OBJECTS_KHR   0x202E
 
 /* Error type for clCreateFromEGLImageKHR */
-#define CL_INVALID_EGL_OBJECT_KHR             -1093
-#define CL_EGL_RESOURCE_NOT_ACQUIRED_KHR      -1092
+#define CL_INVALID_EGL_OBJECT_KHR            -1093
+#define CL_EGL_RESOURCE_NOT_ACQUIRED_KHR     -1092
 
 /* CLeglImageKHR is an opaque handle to an EGLImage */
-typedef void* CLeglImageKHR;
+typedef void*    CLeglImageKHR;
 
 /* CLeglDisplayKHR is an opaque handle to an EGLDisplay */
-typedef void* CLeglDisplayKHR;
+typedef void*    CLeglDisplayKHR;
 
 /* CLeglSyncKHR is an opaque handle to an EGLSync object */
-typedef void* CLeglSyncKHR;
+typedef void*    CLeglSyncKHR;
 
 /* properties passed to clCreateFromEGLImageKHR */
 typedef intptr_t cl_egl_image_properties_khr;
 
-
 #define cl_khr_egl_image 1
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateFromEGLImageKHR(cl_context                  context,
-                        CLeglDisplayKHR             egldisplay,
-                        CLeglImageKHR               eglimage,
-                        cl_mem_flags                flags,
-                        const cl_egl_image_properties_khr * properties,
-                        cl_int *                    errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+clCreateFromEGLImageKHR(cl_context                         context,
+                        CLeglDisplayKHR                    egldisplay,
+                        CLeglImageKHR                      eglimage,
+                        cl_mem_flags                       flags,
+                        const cl_egl_image_properties_khr* properties,
+                        cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem (CL_API_CALL *clCreateFromEGLImageKHR_fn)(
-    cl_context                  context,
-    CLeglDisplayKHR             egldisplay,
-    CLeglImageKHR               eglimage,
-    cl_mem_flags                flags,
-    const cl_egl_image_properties_khr * properties,
-    cl_int *                    errcode_ret);
-
+typedef cl_mem(CL_API_CALL* clCreateFromEGLImageKHR_fn)(
+  cl_context                         context,
+  CLeglDisplayKHR                    egldisplay,
+  CLeglImageKHR                      eglimage,
+  cl_mem_flags                       flags,
+  const cl_egl_image_properties_khr* properties,
+  cl_int*                            errcode_ret);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueAcquireEGLObjectsKHR(cl_command_queue command_queue,
                               cl_uint          num_objects,
-                              const cl_mem *   mem_objects,
+                              const cl_mem*    mem_objects,
                               cl_uint          num_events_in_wait_list,
-                              const cl_event * event_wait_list,
-                              cl_event *       event) CL_API_SUFFIX__VERSION_1_0;
+                              const cl_event*  event_wait_list,
+                              cl_event* event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int (CL_API_CALL *clEnqueueAcquireEGLObjectsKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint          num_objects,
-    const cl_mem *   mem_objects,
-    cl_uint          num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event *       event);
-
+typedef cl_int(CL_API_CALL* clEnqueueAcquireEGLObjectsKHR_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueReleaseEGLObjectsKHR(cl_command_queue command_queue,
                               cl_uint          num_objects,
-                              const cl_mem *   mem_objects,
+                              const cl_mem*    mem_objects,
                               cl_uint          num_events_in_wait_list,
-                              const cl_event * event_wait_list,
-                              cl_event *       event) CL_API_SUFFIX__VERSION_1_0;
+                              const cl_event*  event_wait_list,
+                              cl_event* event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int (CL_API_CALL *clEnqueueReleaseEGLObjectsKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint          num_objects,
-    const cl_mem *   mem_objects,
-    cl_uint          num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event *       event);
-
+typedef cl_int(CL_API_CALL* clEnqueueReleaseEGLObjectsKHR_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event);
 
 #define cl_khr_egl_event 1
 
@@ -105,13 +100,13 @@ extern CL_API_ENTRY cl_event CL_API_CALL
 clCreateEventFromEGLSyncKHR(cl_context      context,
                             CLeglSyncKHR    sync,
                             CLeglDisplayKHR display,
-                            cl_int *        errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+                            cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_event (CL_API_CALL *clCreateEventFromEGLSyncKHR_fn)(
-    cl_context      context,
-    CLeglSyncKHR    sync,
-    CLeglDisplayKHR display,
-    cl_int *        errcode_ret);
+typedef cl_event(CL_API_CALL* clCreateEventFromEGLSyncKHR_fn)(
+  cl_context      context,
+  CLeglSyncKHR    sync,
+  CLeglDisplayKHR display,
+  cl_int*         errcode_ret);
 
 #ifdef __cplusplus
 }

--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -27,490 +27,458 @@ extern "C" {
 #include <CL/cl.h>
 
 /***************************************************************
-* cl_khr_command_buffer
-***************************************************************/
-#define cl_khr_command_buffer 1
-#define CL_KHR_COMMAND_BUFFER_EXTENSION_NAME \
-    "cl_khr_command_buffer"
+ * cl_khr_command_buffer
+ ***************************************************************/
+#define cl_khr_command_buffer                1
+#define CL_KHR_COMMAND_BUFFER_EXTENSION_NAME "cl_khr_command_buffer"
 
-typedef cl_bitfield         cl_device_command_buffer_capabilities_khr;
+typedef cl_bitfield cl_device_command_buffer_capabilities_khr;
 typedef struct _cl_command_buffer_khr* cl_command_buffer_khr;
-typedef cl_uint             cl_sync_point_khr;
-typedef cl_uint             cl_command_buffer_info_khr;
-typedef cl_uint             cl_command_buffer_state_khr;
-typedef cl_properties       cl_command_buffer_properties_khr;
-typedef cl_bitfield         cl_command_buffer_flags_khr;
-typedef cl_properties       cl_ndrange_kernel_command_properties_khr;
+typedef cl_uint                        cl_sync_point_khr;
+typedef cl_uint                        cl_command_buffer_info_khr;
+typedef cl_uint                        cl_command_buffer_state_khr;
+typedef cl_properties                  cl_command_buffer_properties_khr;
+typedef cl_bitfield                    cl_command_buffer_flags_khr;
+typedef cl_properties                  cl_ndrange_kernel_command_properties_khr;
 typedef struct _cl_mutable_command_khr* cl_mutable_command_khr;
 
 /* cl_device_info */
-#define CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR           0x12A9
+#define CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR              0x12A9
 #define CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR 0x12AA
 
 /* cl_device_command_buffer_capabilities_khr - bitfield */
-#define CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR      (1 << 0)
-#define CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR (1 << 1)
-#define CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR   (1 << 2)
-#define CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR       (1 << 3)
+#define CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR         (1 << 0)
+#define CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR   (1 << 1)
+#define CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR      (1 << 2)
+#define CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR          (1 << 3)
 
 /* cl_command_buffer_properties_khr */
-#define CL_COMMAND_BUFFER_FLAGS_KHR                         0x1293
+#define CL_COMMAND_BUFFER_FLAGS_KHR                            0x1293
 
 /* cl_command_buffer_flags_khr */
-#define CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR              (1 << 0)
+#define CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR                 (1 << 0)
 
 /* Error codes */
-#define CL_INVALID_COMMAND_BUFFER_KHR                       -1138
-#define CL_INVALID_SYNC_POINT_WAIT_LIST_KHR                 -1139
-#define CL_INCOMPATIBLE_COMMAND_QUEUE_KHR                   -1140
+#define CL_INVALID_COMMAND_BUFFER_KHR                          -1138
+#define CL_INVALID_SYNC_POINT_WAIT_LIST_KHR                    -1139
+#define CL_INCOMPATIBLE_COMMAND_QUEUE_KHR                      -1140
 
 /* cl_command_buffer_info_khr */
-#define CL_COMMAND_BUFFER_QUEUES_KHR                        0x1294
-#define CL_COMMAND_BUFFER_NUM_QUEUES_KHR                    0x1295
-#define CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR               0x1296
-#define CL_COMMAND_BUFFER_STATE_KHR                         0x1297
-#define CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR              0x1298
+#define CL_COMMAND_BUFFER_QUEUES_KHR                           0x1294
+#define CL_COMMAND_BUFFER_NUM_QUEUES_KHR                       0x1295
+#define CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR                  0x1296
+#define CL_COMMAND_BUFFER_STATE_KHR                            0x1297
+#define CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR                 0x1298
 
 /* cl_command_buffer_state_khr */
-#define CL_COMMAND_BUFFER_STATE_RECORDING_KHR               0
-#define CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR              1
-#define CL_COMMAND_BUFFER_STATE_PENDING_KHR                 2
-#define CL_COMMAND_BUFFER_STATE_INVALID_KHR                 3
+#define CL_COMMAND_BUFFER_STATE_RECORDING_KHR                  0
+#define CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR                 1
+#define CL_COMMAND_BUFFER_STATE_PENDING_KHR                    2
+#define CL_COMMAND_BUFFER_STATE_INVALID_KHR                    3
 
 /* cl_command_type */
-#define CL_COMMAND_COMMAND_BUFFER_KHR                       0x12A8
+#define CL_COMMAND_COMMAND_BUFFER_KHR                          0x12A8
 
+typedef cl_command_buffer_khr(CL_API_CALL* clCreateCommandBufferKHR_fn)(
+  cl_uint                                 num_queues,
+  const cl_command_queue*                 queues,
+  const cl_command_buffer_properties_khr* properties,
+  cl_int*                                 errcode_ret);
 
-typedef cl_command_buffer_khr (CL_API_CALL *
-clCreateCommandBufferKHR_fn)(
-    cl_uint num_queues,
-    const cl_command_queue* queues,
-    const cl_command_buffer_properties_khr* properties,
-    cl_int* errcode_ret) ;
+typedef cl_int(CL_API_CALL* clFinalizeCommandBufferKHR_fn)(
+  cl_command_buffer_khr command_buffer);
 
-typedef cl_int (CL_API_CALL *
-clFinalizeCommandBufferKHR_fn)(
-    cl_command_buffer_khr command_buffer) ;
+typedef cl_int(CL_API_CALL* clRetainCommandBufferKHR_fn)(
+  cl_command_buffer_khr command_buffer);
 
-typedef cl_int (CL_API_CALL *
-clRetainCommandBufferKHR_fn)(
-    cl_command_buffer_khr command_buffer) ;
+typedef cl_int(CL_API_CALL* clReleaseCommandBufferKHR_fn)(
+  cl_command_buffer_khr command_buffer);
 
-typedef cl_int (CL_API_CALL *
-clReleaseCommandBufferKHR_fn)(
-    cl_command_buffer_khr command_buffer) ;
+typedef cl_int(CL_API_CALL* clEnqueueCommandBufferKHR_fn)(
+  cl_uint               num_queues,
+  cl_command_queue*     queues,
+  cl_command_buffer_khr command_buffer,
+  cl_uint               num_events_in_wait_list,
+  const cl_event*       event_wait_list,
+  cl_event*             event);
 
-typedef cl_int (CL_API_CALL *
-clEnqueueCommandBufferKHR_fn)(
-    cl_uint num_queues,
-    cl_command_queue* queues,
-    cl_command_buffer_khr command_buffer,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+typedef cl_int(CL_API_CALL* clCommandBarrierWithWaitListKHR_fn)(
+  cl_command_buffer_khr    command_buffer,
+  cl_command_queue         command_queue,
+  cl_uint                  num_sync_points_in_wait_list,
+  const cl_sync_point_khr* sync_point_wait_list,
+  cl_sync_point_khr*       sync_point,
+  cl_mutable_command_khr*  mutable_handle);
 
-typedef cl_int (CL_API_CALL *
-clCommandBarrierWithWaitListKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+typedef cl_int(CL_API_CALL* clCommandCopyBufferKHR_fn)(
+  cl_command_buffer_khr    command_buffer,
+  cl_command_queue         command_queue,
+  cl_mem                   src_buffer,
+  cl_mem                   dst_buffer,
+  size_t                   src_offset,
+  size_t                   dst_offset,
+  size_t                   size,
+  cl_uint                  num_sync_points_in_wait_list,
+  const cl_sync_point_khr* sync_point_wait_list,
+  cl_sync_point_khr*       sync_point,
+  cl_mutable_command_khr*  mutable_handle);
 
-typedef cl_int (CL_API_CALL *
-clCommandCopyBufferKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem src_buffer,
-    cl_mem dst_buffer,
-    size_t src_offset,
-    size_t dst_offset,
-    size_t size,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+typedef cl_int(CL_API_CALL* clCommandCopyBufferRectKHR_fn)(
+  cl_command_buffer_khr    command_buffer,
+  cl_command_queue         command_queue,
+  cl_mem                   src_buffer,
+  cl_mem                   dst_buffer,
+  const size_t*            src_origin,
+  const size_t*            dst_origin,
+  const size_t*            region,
+  size_t                   src_row_pitch,
+  size_t                   src_slice_pitch,
+  size_t                   dst_row_pitch,
+  size_t                   dst_slice_pitch,
+  cl_uint                  num_sync_points_in_wait_list,
+  const cl_sync_point_khr* sync_point_wait_list,
+  cl_sync_point_khr*       sync_point,
+  cl_mutable_command_khr*  mutable_handle);
 
-typedef cl_int (CL_API_CALL *
-clCommandCopyBufferRectKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem src_buffer,
-    cl_mem dst_buffer,
-    const size_t* src_origin,
-    const size_t* dst_origin,
-    const size_t* region,
-    size_t src_row_pitch,
-    size_t src_slice_pitch,
-    size_t dst_row_pitch,
-    size_t dst_slice_pitch,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+typedef cl_int(CL_API_CALL* clCommandCopyBufferToImageKHR_fn)(
+  cl_command_buffer_khr    command_buffer,
+  cl_command_queue         command_queue,
+  cl_mem                   src_buffer,
+  cl_mem                   dst_image,
+  size_t                   src_offset,
+  const size_t*            dst_origin,
+  const size_t*            region,
+  cl_uint                  num_sync_points_in_wait_list,
+  const cl_sync_point_khr* sync_point_wait_list,
+  cl_sync_point_khr*       sync_point,
+  cl_mutable_command_khr*  mutable_handle);
 
-typedef cl_int (CL_API_CALL *
-clCommandCopyBufferToImageKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem src_buffer,
-    cl_mem dst_image,
-    size_t src_offset,
-    const size_t* dst_origin,
-    const size_t* region,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+typedef cl_int(CL_API_CALL* clCommandCopyImageKHR_fn)(
+  cl_command_buffer_khr    command_buffer,
+  cl_command_queue         command_queue,
+  cl_mem                   src_image,
+  cl_mem                   dst_image,
+  const size_t*            src_origin,
+  const size_t*            dst_origin,
+  const size_t*            region,
+  cl_uint                  num_sync_points_in_wait_list,
+  const cl_sync_point_khr* sync_point_wait_list,
+  cl_sync_point_khr*       sync_point,
+  cl_mutable_command_khr*  mutable_handle);
 
-typedef cl_int (CL_API_CALL *
-clCommandCopyImageKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem src_image,
-    cl_mem dst_image,
-    const size_t* src_origin,
-    const size_t* dst_origin,
-    const size_t* region,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+typedef cl_int(CL_API_CALL* clCommandCopyImageToBufferKHR_fn)(
+  cl_command_buffer_khr    command_buffer,
+  cl_command_queue         command_queue,
+  cl_mem                   src_image,
+  cl_mem                   dst_buffer,
+  const size_t*            src_origin,
+  const size_t*            region,
+  size_t                   dst_offset,
+  cl_uint                  num_sync_points_in_wait_list,
+  const cl_sync_point_khr* sync_point_wait_list,
+  cl_sync_point_khr*       sync_point,
+  cl_mutable_command_khr*  mutable_handle);
 
-typedef cl_int (CL_API_CALL *
-clCommandCopyImageToBufferKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem src_image,
-    cl_mem dst_buffer,
-    const size_t* src_origin,
-    const size_t* region,
-    size_t dst_offset,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+typedef cl_int(CL_API_CALL* clCommandFillBufferKHR_fn)(
+  cl_command_buffer_khr    command_buffer,
+  cl_command_queue         command_queue,
+  cl_mem                   buffer,
+  const void*              pattern,
+  size_t                   pattern_size,
+  size_t                   offset,
+  size_t                   size,
+  cl_uint                  num_sync_points_in_wait_list,
+  const cl_sync_point_khr* sync_point_wait_list,
+  cl_sync_point_khr*       sync_point,
+  cl_mutable_command_khr*  mutable_handle);
 
-typedef cl_int (CL_API_CALL *
-clCommandFillBufferKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem buffer,
-    const void* pattern,
-    size_t pattern_size,
-    size_t offset,
-    size_t size,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+typedef cl_int(CL_API_CALL* clCommandFillImageKHR_fn)(
+  cl_command_buffer_khr    command_buffer,
+  cl_command_queue         command_queue,
+  cl_mem                   image,
+  const void*              fill_color,
+  const size_t*            origin,
+  const size_t*            region,
+  cl_uint                  num_sync_points_in_wait_list,
+  const cl_sync_point_khr* sync_point_wait_list,
+  cl_sync_point_khr*       sync_point,
+  cl_mutable_command_khr*  mutable_handle);
 
-typedef cl_int (CL_API_CALL *
-clCommandFillImageKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem image,
-    const void* fill_color,
-    const size_t* origin,
-    const size_t* region,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+typedef cl_int(CL_API_CALL* clCommandNDRangeKernelKHR_fn)(
+  cl_command_buffer_khr                           command_buffer,
+  cl_command_queue                                command_queue,
+  const cl_ndrange_kernel_command_properties_khr* properties,
+  cl_kernel                                       kernel,
+  cl_uint                                         work_dim,
+  const size_t*                                   global_work_offset,
+  const size_t*                                   global_work_size,
+  const size_t*                                   local_work_size,
+  cl_uint                                         num_sync_points_in_wait_list,
+  const cl_sync_point_khr*                        sync_point_wait_list,
+  cl_sync_point_khr*                              sync_point,
+  cl_mutable_command_khr*                         mutable_handle);
 
-typedef cl_int (CL_API_CALL *
-clCommandNDRangeKernelKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    const cl_ndrange_kernel_command_properties_khr* properties,
-    cl_kernel kernel,
-    cl_uint work_dim,
-    const size_t* global_work_offset,
-    const size_t* global_work_size,
-    const size_t* local_work_size,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
-
-typedef cl_int (CL_API_CALL *
-clGetCommandBufferInfoKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    cl_command_buffer_info_khr param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret) ;
+typedef cl_int(CL_API_CALL* clGetCommandBufferInfoKHR_fn)(
+  cl_command_buffer_khr      command_buffer,
+  cl_command_buffer_info_khr param_name,
+  size_t                     param_value_size,
+  void*                      param_value,
+  size_t*                    param_value_size_ret);
 
 #ifndef CL_NO_PROTOTYPES
 
 extern CL_API_ENTRY cl_command_buffer_khr CL_API_CALL
-clCreateCommandBufferKHR(
-    cl_uint num_queues,
-    const cl_command_queue* queues,
-    const cl_command_buffer_properties_khr* properties,
-    cl_int* errcode_ret) ;
+clCreateCommandBufferKHR(cl_uint                                 num_queues,
+                         const cl_command_queue*                 queues,
+                         const cl_command_buffer_properties_khr* properties,
+                         cl_int*                                 errcode_ret);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clFinalizeCommandBufferKHR(
-    cl_command_buffer_khr command_buffer) ;
+clFinalizeCommandBufferKHR(cl_command_buffer_khr command_buffer);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clRetainCommandBufferKHR(
-    cl_command_buffer_khr command_buffer) ;
+clRetainCommandBufferKHR(cl_command_buffer_khr command_buffer);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clReleaseCommandBufferKHR(
-    cl_command_buffer_khr command_buffer) ;
+clReleaseCommandBufferKHR(cl_command_buffer_khr command_buffer);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueCommandBufferKHR(
-    cl_uint num_queues,
-    cl_command_queue* queues,
-    cl_command_buffer_khr command_buffer,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+clEnqueueCommandBufferKHR(cl_uint               num_queues,
+                          cl_command_queue*     queues,
+                          cl_command_buffer_khr command_buffer,
+                          cl_uint               num_events_in_wait_list,
+                          const cl_event*       event_wait_list,
+                          cl_event*             event);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCommandBarrierWithWaitListKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+clCommandBarrierWithWaitListKHR(cl_command_buffer_khr command_buffer,
+                                cl_command_queue      command_queue,
+                                cl_uint num_sync_points_in_wait_list,
+                                const cl_sync_point_khr* sync_point_wait_list,
+                                cl_sync_point_khr*       sync_point,
+                                cl_mutable_command_khr*  mutable_handle);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCommandCopyBufferKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem src_buffer,
-    cl_mem dst_buffer,
-    size_t src_offset,
-    size_t dst_offset,
-    size_t size,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+clCommandCopyBufferKHR(cl_command_buffer_khr    command_buffer,
+                       cl_command_queue         command_queue,
+                       cl_mem                   src_buffer,
+                       cl_mem                   dst_buffer,
+                       size_t                   src_offset,
+                       size_t                   dst_offset,
+                       size_t                   size,
+                       cl_uint                  num_sync_points_in_wait_list,
+                       const cl_sync_point_khr* sync_point_wait_list,
+                       cl_sync_point_khr*       sync_point,
+                       cl_mutable_command_khr*  mutable_handle);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCommandCopyBufferRectKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem src_buffer,
-    cl_mem dst_buffer,
-    const size_t* src_origin,
-    const size_t* dst_origin,
-    const size_t* region,
-    size_t src_row_pitch,
-    size_t src_slice_pitch,
-    size_t dst_row_pitch,
-    size_t dst_slice_pitch,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+clCommandCopyBufferRectKHR(cl_command_buffer_khr command_buffer,
+                           cl_command_queue      command_queue,
+                           cl_mem                src_buffer,
+                           cl_mem                dst_buffer,
+                           const size_t*         src_origin,
+                           const size_t*         dst_origin,
+                           const size_t*         region,
+                           size_t                src_row_pitch,
+                           size_t                src_slice_pitch,
+                           size_t                dst_row_pitch,
+                           size_t                dst_slice_pitch,
+                           cl_uint               num_sync_points_in_wait_list,
+                           const cl_sync_point_khr* sync_point_wait_list,
+                           cl_sync_point_khr*       sync_point,
+                           cl_mutable_command_khr*  mutable_handle);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCommandCopyBufferToImageKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem src_buffer,
-    cl_mem dst_image,
-    size_t src_offset,
-    const size_t* dst_origin,
-    const size_t* region,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+clCommandCopyBufferToImageKHR(cl_command_buffer_khr command_buffer,
+                              cl_command_queue      command_queue,
+                              cl_mem                src_buffer,
+                              cl_mem                dst_image,
+                              size_t                src_offset,
+                              const size_t*         dst_origin,
+                              const size_t*         region,
+                              cl_uint num_sync_points_in_wait_list,
+                              const cl_sync_point_khr* sync_point_wait_list,
+                              cl_sync_point_khr*       sync_point,
+                              cl_mutable_command_khr*  mutable_handle);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCommandCopyImageKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem src_image,
-    cl_mem dst_image,
-    const size_t* src_origin,
-    const size_t* dst_origin,
-    const size_t* region,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+clCommandCopyImageKHR(cl_command_buffer_khr    command_buffer,
+                      cl_command_queue         command_queue,
+                      cl_mem                   src_image,
+                      cl_mem                   dst_image,
+                      const size_t*            src_origin,
+                      const size_t*            dst_origin,
+                      const size_t*            region,
+                      cl_uint                  num_sync_points_in_wait_list,
+                      const cl_sync_point_khr* sync_point_wait_list,
+                      cl_sync_point_khr*       sync_point,
+                      cl_mutable_command_khr*  mutable_handle);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCommandCopyImageToBufferKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem src_image,
-    cl_mem dst_buffer,
-    const size_t* src_origin,
-    const size_t* region,
-    size_t dst_offset,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+clCommandCopyImageToBufferKHR(cl_command_buffer_khr command_buffer,
+                              cl_command_queue      command_queue,
+                              cl_mem                src_image,
+                              cl_mem                dst_buffer,
+                              const size_t*         src_origin,
+                              const size_t*         region,
+                              size_t                dst_offset,
+                              cl_uint num_sync_points_in_wait_list,
+                              const cl_sync_point_khr* sync_point_wait_list,
+                              cl_sync_point_khr*       sync_point,
+                              cl_mutable_command_khr*  mutable_handle);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCommandFillBufferKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem buffer,
-    const void* pattern,
-    size_t pattern_size,
-    size_t offset,
-    size_t size,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+clCommandFillBufferKHR(cl_command_buffer_khr    command_buffer,
+                       cl_command_queue         command_queue,
+                       cl_mem                   buffer,
+                       const void*              pattern,
+                       size_t                   pattern_size,
+                       size_t                   offset,
+                       size_t                   size,
+                       cl_uint                  num_sync_points_in_wait_list,
+                       const cl_sync_point_khr* sync_point_wait_list,
+                       cl_sync_point_khr*       sync_point,
+                       cl_mutable_command_khr*  mutable_handle);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCommandFillImageKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    cl_mem image,
-    const void* fill_color,
-    const size_t* origin,
-    const size_t* region,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+clCommandFillImageKHR(cl_command_buffer_khr    command_buffer,
+                      cl_command_queue         command_queue,
+                      cl_mem                   image,
+                      const void*              fill_color,
+                      const size_t*            origin,
+                      const size_t*            region,
+                      cl_uint                  num_sync_points_in_wait_list,
+                      const cl_sync_point_khr* sync_point_wait_list,
+                      cl_sync_point_khr*       sync_point,
+                      cl_mutable_command_khr*  mutable_handle);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clCommandNDRangeKernelKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    const cl_ndrange_kernel_command_properties_khr* properties,
-    cl_kernel kernel,
-    cl_uint work_dim,
-    const size_t* global_work_offset,
-    const size_t* global_work_size,
-    const size_t* local_work_size,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle) ;
+  cl_command_buffer_khr                           command_buffer,
+  cl_command_queue                                command_queue,
+  const cl_ndrange_kernel_command_properties_khr* properties,
+  cl_kernel                                       kernel,
+  cl_uint                                         work_dim,
+  const size_t*                                   global_work_offset,
+  const size_t*                                   global_work_size,
+  const size_t*                                   local_work_size,
+  cl_uint                                         num_sync_points_in_wait_list,
+  const cl_sync_point_khr*                        sync_point_wait_list,
+  cl_sync_point_khr*                              sync_point,
+  cl_mutable_command_khr*                         mutable_handle);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetCommandBufferInfoKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_buffer_info_khr param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret) ;
+clGetCommandBufferInfoKHR(cl_command_buffer_khr      command_buffer,
+                          cl_command_buffer_info_khr param_name,
+                          size_t                     param_value_size,
+                          void*                      param_value,
+                          size_t*                    param_value_size_ret);
 
 #endif /* CL_NO_PROTOTYPES */
 
 /***************************************************************
-* cl_khr_command_buffer_mutable_dispatch
-***************************************************************/
+ * cl_khr_command_buffer_mutable_dispatch
+ ***************************************************************/
 #define cl_khr_command_buffer_mutable_dispatch 1
-#define CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_NAME \
-    "cl_khr_command_buffer_mutable_dispatch"
+#define CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_NAME                  \
+  "cl_khr_command_buffer_mutable_dispatch"
 
-typedef cl_uint             cl_command_buffer_structure_type_khr;
-typedef cl_bitfield         cl_mutable_dispatch_fields_khr;
-typedef cl_uint             cl_mutable_command_info_khr;
-typedef struct _cl_mutable_dispatch_arg_khr {
-    cl_uint arg_index;
-    size_t arg_size;
-    const void* arg_value;
+typedef cl_uint     cl_command_buffer_structure_type_khr;
+typedef cl_bitfield cl_mutable_dispatch_fields_khr;
+typedef cl_uint     cl_mutable_command_info_khr;
+typedef struct _cl_mutable_dispatch_arg_khr
+{
+  cl_uint     arg_index;
+  size_t      arg_size;
+  const void* arg_value;
 } cl_mutable_dispatch_arg_khr;
-typedef struct _cl_mutable_dispatch_exec_info_khr {
-    cl_uint param_name;
-    size_t param_value_size;
-    const void* param_value;
+typedef struct _cl_mutable_dispatch_exec_info_khr
+{
+  cl_uint     param_name;
+  size_t      param_value_size;
+  const void* param_value;
 } cl_mutable_dispatch_exec_info_khr;
-typedef struct _cl_mutable_dispatch_config_khr {
-    cl_command_buffer_structure_type_khr type;
-    const void* next;
-    cl_mutable_command_khr command;
-    cl_uint num_args;
-    cl_uint num_svm_args;
-    cl_uint num_exec_infos;
-    cl_uint work_dim;
-    const cl_mutable_dispatch_arg_khr* arg_list;
-    const cl_mutable_dispatch_arg_khr* arg_svm_list;
-    const cl_mutable_dispatch_exec_info_khr* exec_info_list;
-    const size_t* global_work_offset;
-    const size_t* global_work_size;
-    const size_t* local_work_size;
+typedef struct _cl_mutable_dispatch_config_khr
+{
+  cl_command_buffer_structure_type_khr     type;
+  const void*                              next;
+  cl_mutable_command_khr                   command;
+  cl_uint                                  num_args;
+  cl_uint                                  num_svm_args;
+  cl_uint                                  num_exec_infos;
+  cl_uint                                  work_dim;
+  const cl_mutable_dispatch_arg_khr*       arg_list;
+  const cl_mutable_dispatch_arg_khr*       arg_svm_list;
+  const cl_mutable_dispatch_exec_info_khr* exec_info_list;
+  const size_t*                            global_work_offset;
+  const size_t*                            global_work_size;
+  const size_t*                            local_work_size;
 } cl_mutable_dispatch_config_khr;
-typedef struct _cl_mutable_base_config_khr {
-    cl_command_buffer_structure_type_khr type;
-    const void* next;
-    cl_uint num_mutable_dispatch;
-    const cl_mutable_dispatch_config_khr* mutable_dispatch_list;
+typedef struct _cl_mutable_base_config_khr
+{
+  cl_command_buffer_structure_type_khr  type;
+  const void*                           next;
+  cl_uint                               num_mutable_dispatch;
+  const cl_mutable_dispatch_config_khr* mutable_dispatch_list;
 } cl_mutable_base_config_khr;
 
 /* cl_command_buffer_flags_khr - bitfield */
-#define CL_COMMAND_BUFFER_MUTABLE_KHR                       (1 << 1)
+#define CL_COMMAND_BUFFER_MUTABLE_KHR                 (1 << 1)
 
 /* Error codes */
-#define CL_INVALID_MUTABLE_COMMAND_KHR                      -1141
+#define CL_INVALID_MUTABLE_COMMAND_KHR                -1141
 
 /* cl_device_info */
-#define CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR         0x12B0
+#define CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR   0x12B0
 
 /* cl_ndrange_kernel_command_properties_khr */
-#define CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR            0x12B1
+#define CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR      0x12B1
 
 /* cl_mutable_dispatch_fields_khr - bitfield */
-#define CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR               (1 << 0)
-#define CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR                 (1 << 1)
-#define CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR                  (1 << 2)
-#define CL_MUTABLE_DISPATCH_ARGUMENTS_KHR                   (1 << 3)
-#define CL_MUTABLE_DISPATCH_EXEC_INFO_KHR                   (1 << 4)
+#define CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR         (1 << 0)
+#define CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR           (1 << 1)
+#define CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR            (1 << 2)
+#define CL_MUTABLE_DISPATCH_ARGUMENTS_KHR             (1 << 3)
+#define CL_MUTABLE_DISPATCH_EXEC_INFO_KHR             (1 << 4)
 
 /* cl_mutable_command_info_khr */
-#define CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR                0x12A0
-#define CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR               0x12A1
-#define CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR                 0x12AD
-#define CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR            0x12A2
-#define CL_MUTABLE_DISPATCH_KERNEL_KHR                      0x12A3
-#define CL_MUTABLE_DISPATCH_DIMENSIONS_KHR                  0x12A4
-#define CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR          0x12A5
-#define CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR            0x12A6
-#define CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR             0x12A7
+#define CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR          0x12A0
+#define CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR         0x12A1
+#define CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR           0x12AD
+#define CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR      0x12A2
+#define CL_MUTABLE_DISPATCH_KERNEL_KHR                0x12A3
+#define CL_MUTABLE_DISPATCH_DIMENSIONS_KHR            0x12A4
+#define CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR    0x12A5
+#define CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR      0x12A6
+#define CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR       0x12A7
 
 /* cl_command_buffer_structure_type_khr */
-#define CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR           0
-#define CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR       1
+#define CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR     0
+#define CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR 1
 
+typedef cl_int(CL_API_CALL* clUpdateMutableCommandsKHR_fn)(
+  cl_command_buffer_khr             command_buffer,
+  const cl_mutable_base_config_khr* mutable_config);
 
-typedef cl_int (CL_API_CALL *
-clUpdateMutableCommandsKHR_fn)(
-    cl_command_buffer_khr command_buffer,
-    const cl_mutable_base_config_khr* mutable_config) ;
-
-typedef cl_int (CL_API_CALL *
-clGetMutableCommandInfoKHR_fn)(
-    cl_mutable_command_khr command,
-    cl_mutable_command_info_khr param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret) ;
+typedef cl_int(CL_API_CALL* clGetMutableCommandInfoKHR_fn)(
+  cl_mutable_command_khr      command,
+  cl_mutable_command_info_khr param_name,
+  size_t                      param_value_size,
+  void*                       param_value,
+  size_t*                     param_value_size_ret);
 
 #ifndef CL_NO_PROTOTYPES
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clUpdateMutableCommandsKHR(
-    cl_command_buffer_khr command_buffer,
-    const cl_mutable_base_config_khr* mutable_config) ;
+clUpdateMutableCommandsKHR(cl_command_buffer_khr             command_buffer,
+                           const cl_mutable_base_config_khr* mutable_config);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetMutableCommandInfoKHR(
-    cl_mutable_command_khr command,
-    cl_mutable_command_info_khr param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret) ;
+clGetMutableCommandInfoKHR(cl_mutable_command_khr      command,
+                           cl_mutable_command_info_khr param_name,
+                           size_t                      param_value_size,
+                           void*                       param_value,
+                           size_t*                     param_value_size_ret);
 
 #endif /* CL_NO_PROTOTYPES */
 
@@ -518,110 +486,119 @@ clGetMutableCommandInfoKHR(
 /* CL_DEVICE_DOUBLE_FP_CONFIG is defined in CL.h for OpenCL >= 120 */
 
 #if CL_TARGET_OPENCL_VERSION <= 110
-#define CL_DEVICE_DOUBLE_FP_CONFIG                       0x1032
+#define CL_DEVICE_DOUBLE_FP_CONFIG 0x1032
 #endif
 
 /* cl_khr_fp16 extension - no extension #define since it has no functions  */
-#define CL_DEVICE_HALF_FP_CONFIG                    0x1033
+#define CL_DEVICE_HALF_FP_CONFIG        0x1033
 
 /* Memory object destruction
  *
- * Apple extension for use to manage externally allocated buffers used with cl_mem objects with CL_MEM_USE_HOST_PTR
+ * Apple extension for use to manage externally allocated buffers used with
+ * cl_mem objects with CL_MEM_USE_HOST_PTR
  *
- * Registers a user callback function that will be called when the memory object is deleted and its resources
- * freed. Each call to clSetMemObjectCallbackFn registers the specified user callback function on a callback
- * stack associated with memobj. The registered user callback functions are called in the reverse order in
- * which they were registered. The user callback functions are called and then the memory object is deleted
- * and its resources freed. This provides a mechanism for the application (and libraries) using memobj to be
- * notified when the memory referenced by host_ptr, specified when the memory object is created and used as
- * the storage bits for the memory object, can be reused or freed.
+ * Registers a user callback function that will be called when the memory object
+ * is deleted and its resources freed. Each call to clSetMemObjectCallbackFn
+ * registers the specified user callback function on a callback stack associated
+ * with memobj. The registered user callback functions are called in the reverse
+ * order in which they were registered. The user callback functions are called
+ * and then the memory object is deleted and its resources freed. This provides
+ * a mechanism for the application (and libraries) using memobj to be notified
+ * when the memory referenced by host_ptr, specified when the memory object is
+ * created and used as the storage bits for the memory object, can be reused or
+ * freed.
  *
- * The application may not call CL api's with the cl_mem object passed to the pfn_notify.
+ * The application may not call CL api's with the cl_mem object passed to the
+ * pfn_notify.
  *
- * Please check for the "cl_APPLE_SetMemObjectDestructor" extension using clGetDeviceInfo(CL_DEVICE_EXTENSIONS)
- * before using.
+ * Please check for the "cl_APPLE_SetMemObjectDestructor" extension using
+ * clGetDeviceInfo(CL_DEVICE_EXTENSIONS) before using.
  */
 #define cl_APPLE_SetMemObjectDestructor 1
-extern CL_API_ENTRY cl_int CL_API_CALL clSetMemObjectDestructorAPPLE(  cl_mem memobj,
-                                        void (* pfn_notify)(cl_mem memobj, void * user_data),
-                                        void * user_data)             CL_API_SUFFIX__VERSION_1_0;
-
+extern CL_API_ENTRY cl_int CL_API_CALL
+clSetMemObjectDestructorAPPLE(cl_mem memobj,
+                              void (*pfn_notify)(cl_mem memobj,
+                                                 void*  user_data),
+                              void* user_data) CL_API_SUFFIX__VERSION_1_0;
 
 /* Context Logging Functions
  *
- * The next three convenience functions are intended to be used as the pfn_notify parameter to clCreateContext().
- * Please check for the "cl_APPLE_ContextLoggingFunctions" extension using clGetDeviceInfo(CL_DEVICE_EXTENSIONS)
- * before using.
+ * The next three convenience functions are intended to be used as the
+ * pfn_notify parameter to clCreateContext(). Please check for the
+ * "cl_APPLE_ContextLoggingFunctions" extension using
+ * clGetDeviceInfo(CL_DEVICE_EXTENSIONS) before using.
  *
- * clLogMessagesToSystemLog forwards on all log messages to the Apple System Logger
+ * clLogMessagesToSystemLog forwards on all log messages to the Apple System
+ * Logger
  */
 #define cl_APPLE_ContextLoggingFunctions 1
-extern CL_API_ENTRY void CL_API_CALL clLogMessagesToSystemLogAPPLE(  const char * errstr,
-                                            const void * private_info,
-                                            size_t       cb,
-                                            void *       user_data)  CL_API_SUFFIX__VERSION_1_0;
+extern CL_API_ENTRY void CL_API_CALL
+clLogMessagesToSystemLogAPPLE(const char* errstr,
+                              const void* private_info,
+                              size_t      cb,
+                              void*       user_data) CL_API_SUFFIX__VERSION_1_0;
 
 /* clLogMessagesToStdout sends all log messages to the file descriptor stdout */
-extern CL_API_ENTRY void CL_API_CALL clLogMessagesToStdoutAPPLE(   const char * errstr,
-                                          const void * private_info,
-                                          size_t       cb,
-                                          void *       user_data)    CL_API_SUFFIX__VERSION_1_0;
+extern CL_API_ENTRY void CL_API_CALL
+clLogMessagesToStdoutAPPLE(const char* errstr,
+                           const void* private_info,
+                           size_t      cb,
+                           void*       user_data) CL_API_SUFFIX__VERSION_1_0;
 
 /* clLogMessagesToStderr sends all log messages to the file descriptor stderr */
-extern CL_API_ENTRY void CL_API_CALL clLogMessagesToStderrAPPLE(   const char * errstr,
-                                          const void * private_info,
-                                          size_t       cb,
-                                          void *       user_data)    CL_API_SUFFIX__VERSION_1_0;
-
+extern CL_API_ENTRY void CL_API_CALL
+clLogMessagesToStderrAPPLE(const char* errstr,
+                           const void* private_info,
+                           size_t      cb,
+                           void*       user_data) CL_API_SUFFIX__VERSION_1_0;
 
 /************************
-* cl_khr_icd extension *
-************************/
-#define cl_khr_icd 1
+ * cl_khr_icd extension *
+ ************************/
+#define cl_khr_icd                 1
 
 /* cl_platform_info                                                        */
-#define CL_PLATFORM_ICD_SUFFIX_KHR                  0x0920
+#define CL_PLATFORM_ICD_SUFFIX_KHR 0x0920
 
 /* Additional Error Codes                                                  */
-#define CL_PLATFORM_NOT_FOUND_KHR                   -1001
+#define CL_PLATFORM_NOT_FOUND_KHR  -1001
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clIcdGetPlatformIDsKHR(cl_uint          num_entries,
-                       cl_platform_id * platforms,
-                       cl_uint *        num_platforms);
+clIcdGetPlatformIDsKHR(cl_uint         num_entries,
+                       cl_platform_id* platforms,
+                       cl_uint*        num_platforms);
 
-typedef cl_int
-(CL_API_CALL *clIcdGetPlatformIDsKHR_fn)(cl_uint          num_entries,
-                                         cl_platform_id * platforms,
-                                         cl_uint *        num_platforms);
-
+typedef cl_int(CL_API_CALL* clIcdGetPlatformIDsKHR_fn)(
+  cl_uint         num_entries,
+  cl_platform_id* platforms,
+  cl_uint*        num_platforms);
 
 /*******************************
  * cl_khr_il_program extension *
  *******************************/
-#define cl_khr_il_program 1
+#define cl_khr_il_program        1
 
 /* New property to clGetDeviceInfo for retrieving supported intermediate
  * languages
  */
-#define CL_DEVICE_IL_VERSION_KHR                    0x105B
+#define CL_DEVICE_IL_VERSION_KHR 0x105B
 
 /* New property to clGetProgramInfo for retrieving for retrieving the IL of a
  * program
  */
-#define CL_PROGRAM_IL_KHR                           0x1169
+#define CL_PROGRAM_IL_KHR        0x1169
 
 extern CL_API_ENTRY cl_program CL_API_CALL
-clCreateProgramWithILKHR(cl_context   context,
-                         const void * il,
-                         size_t       length,
-                         cl_int *     errcode_ret);
+clCreateProgramWithILKHR(cl_context  context,
+                         const void* il,
+                         size_t      length,
+                         cl_int*     errcode_ret);
 
-typedef cl_program
-(CL_API_CALL *clCreateProgramWithILKHR_fn)(cl_context   context,
-                                           const void * il,
-                                           size_t       length,
-                                           cl_int *     errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_program(CL_API_CALL* clCreateProgramWithILKHR_fn)(
+  cl_context  context,
+  const void* il,
+  size_t      length,
+  cl_int*     errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 /* Extension: cl_khr_image2d_from_buffer
  *
@@ -642,33 +619,30 @@ typedef cl_program
  * CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_KHR pixels.
  */
 
-#define CL_DEVICE_IMAGE_PITCH_ALIGNMENT_KHR              0x104A
-#define CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_KHR       0x104B
-
+#define CL_DEVICE_IMAGE_PITCH_ALIGNMENT_KHR        0x104A
+#define CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_KHR 0x104B
 
 /**************************************
  * cl_khr_initialize_memory extension *
  **************************************/
 
-#define CL_CONTEXT_MEMORY_INITIALIZE_KHR            0x2030
-
+#define CL_CONTEXT_MEMORY_INITIALIZE_KHR           0x2030
 
 /**************************************
  * cl_khr_terminate_context extension *
  **************************************/
 
-#define CL_CONTEXT_TERMINATED_KHR                   -1121
+#define CL_CONTEXT_TERMINATED_KHR                  -1121
 
-#define CL_DEVICE_TERMINATE_CAPABILITY_KHR          0x2031
-#define CL_CONTEXT_TERMINATE_KHR                    0x2032
+#define CL_DEVICE_TERMINATE_CAPABILITY_KHR         0x2031
+#define CL_CONTEXT_TERMINATE_KHR                   0x2032
 
-#define cl_khr_terminate_context 1
+#define cl_khr_terminate_context                   1
 extern CL_API_ENTRY cl_int CL_API_CALL
 clTerminateContextKHR(cl_context context) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int
-(CL_API_CALL *clTerminateContextKHR_fn)(cl_context context) CL_API_SUFFIX__VERSION_1_2;
-
+typedef cl_int(CL_API_CALL* clTerminateContextKHR_fn)(cl_context context)
+  CL_API_SUFFIX__VERSION_1_2;
 
 /*
  * Extension: cl_khr_spir
@@ -677,142 +651,140 @@ typedef cl_int
  * Standard Portable Intermediate Representation (SPIR) instance
  */
 
-#define CL_DEVICE_SPIR_VERSIONS                     0x40E0
-#define CL_PROGRAM_BINARY_TYPE_INTERMEDIATE         0x40E1
-
+#define CL_DEVICE_SPIR_VERSIONS             0x40E0
+#define CL_PROGRAM_BINARY_TYPE_INTERMEDIATE 0x40E1
 
 /*****************************************
  * cl_khr_create_command_queue extension *
  *****************************************/
-#define cl_khr_create_command_queue 1
+#define cl_khr_create_command_queue         1
 
 typedef cl_properties cl_queue_properties_khr;
 
 extern CL_API_ENTRY cl_command_queue CL_API_CALL
-clCreateCommandQueueWithPropertiesKHR(cl_context context,
-                                      cl_device_id device,
+clCreateCommandQueueWithPropertiesKHR(cl_context                     context,
+                                      cl_device_id                   device,
                                       const cl_queue_properties_khr* properties,
-                                      cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+                                      cl_int* errcode_ret)
+  CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_command_queue
-(CL_API_CALL *clCreateCommandQueueWithPropertiesKHR_fn)(cl_context context,
-                                                        cl_device_id device,
-                                                        const cl_queue_properties_khr* properties,
-                                                        cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2;
-
+typedef cl_command_queue(CL_API_CALL* clCreateCommandQueueWithPropertiesKHR_fn)(
+  cl_context                     context,
+  cl_device_id                   device,
+  const cl_queue_properties_khr* properties,
+  cl_int*                        errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 /******************************************
-* cl_nv_device_attribute_query extension *
-******************************************/
+ * cl_nv_device_attribute_query extension *
+ ******************************************/
 
-/* cl_nv_device_attribute_query extension - no extension #define since it has no functions */
-#define CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV       0x4000
-#define CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV       0x4001
-#define CL_DEVICE_REGISTERS_PER_BLOCK_NV            0x4002
-#define CL_DEVICE_WARP_SIZE_NV                      0x4003
-#define CL_DEVICE_GPU_OVERLAP_NV                    0x4004
-#define CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV            0x4005
-#define CL_DEVICE_INTEGRATED_MEMORY_NV              0x4006
-
-
-/*********************************
-* cl_amd_device_attribute_query *
-*********************************/
-
-#define CL_DEVICE_PROFILING_TIMER_OFFSET_AMD            0x4036
-#define CL_DEVICE_TOPOLOGY_AMD                          0x4037
-#define CL_DEVICE_BOARD_NAME_AMD                        0x4038
-#define CL_DEVICE_GLOBAL_FREE_MEMORY_AMD                0x4039
-#define CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD             0x4040
-#define CL_DEVICE_SIMD_WIDTH_AMD                        0x4041
-#define CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD            0x4042
-#define CL_DEVICE_WAVEFRONT_WIDTH_AMD                   0x4043
-#define CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD               0x4044
-#define CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD          0x4045
-#define CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD     0x4046
-#define CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD   0x4047
-#define CL_DEVICE_LOCAL_MEM_BANKS_AMD                   0x4048
-#define CL_DEVICE_THREAD_TRACE_SUPPORTED_AMD            0x4049
-#define CL_DEVICE_GFXIP_MAJOR_AMD                       0x404A
-#define CL_DEVICE_GFXIP_MINOR_AMD                       0x404B
-#define CL_DEVICE_AVAILABLE_ASYNC_QUEUES_AMD            0x404C
-#define CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_AMD         0x4030
-#define CL_DEVICE_MAX_WORK_GROUP_SIZE_AMD               0x4031
-#define CL_DEVICE_PREFERRED_CONSTANT_BUFFER_SIZE_AMD    0x4033
-#define CL_DEVICE_PCIE_ID_AMD                           0x4034
-
+/* cl_nv_device_attribute_query extension - no extension #define since it has no
+ * functions */
+#define CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV         0x4000
+#define CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV         0x4001
+#define CL_DEVICE_REGISTERS_PER_BLOCK_NV              0x4002
+#define CL_DEVICE_WARP_SIZE_NV                        0x4003
+#define CL_DEVICE_GPU_OVERLAP_NV                      0x4004
+#define CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV              0x4005
+#define CL_DEVICE_INTEGRATED_MEMORY_NV                0x4006
 
 /*********************************
-* cl_arm_printf extension
-*********************************/
+ * cl_amd_device_attribute_query *
+ *********************************/
 
-#define CL_PRINTF_CALLBACK_ARM                      0x40B0
-#define CL_PRINTF_BUFFERSIZE_ARM                    0x40B1
+#define CL_DEVICE_PROFILING_TIMER_OFFSET_AMD          0x4036
+#define CL_DEVICE_TOPOLOGY_AMD                        0x4037
+#define CL_DEVICE_BOARD_NAME_AMD                      0x4038
+#define CL_DEVICE_GLOBAL_FREE_MEMORY_AMD              0x4039
+#define CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD           0x4040
+#define CL_DEVICE_SIMD_WIDTH_AMD                      0x4041
+#define CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD          0x4042
+#define CL_DEVICE_WAVEFRONT_WIDTH_AMD                 0x4043
+#define CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD             0x4044
+#define CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD        0x4045
+#define CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD   0x4046
+#define CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD 0x4047
+#define CL_DEVICE_LOCAL_MEM_BANKS_AMD                 0x4048
+#define CL_DEVICE_THREAD_TRACE_SUPPORTED_AMD          0x4049
+#define CL_DEVICE_GFXIP_MAJOR_AMD                     0x404A
+#define CL_DEVICE_GFXIP_MINOR_AMD                     0x404B
+#define CL_DEVICE_AVAILABLE_ASYNC_QUEUES_AMD          0x404C
+#define CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_AMD       0x4030
+#define CL_DEVICE_MAX_WORK_GROUP_SIZE_AMD             0x4031
+#define CL_DEVICE_PREFERRED_CONSTANT_BUFFER_SIZE_AMD  0x4033
+#define CL_DEVICE_PCIE_ID_AMD                         0x4034
 
+/*********************************
+ * cl_arm_printf extension
+ *********************************/
+
+#define CL_PRINTF_CALLBACK_ARM                        0x40B0
+#define CL_PRINTF_BUFFERSIZE_ARM                      0x40B1
 
 /***********************************
-* cl_ext_device_fission extension
-***********************************/
-#define cl_ext_device_fission   1
+ * cl_ext_device_fission extension
+ ***********************************/
+#define cl_ext_device_fission                         1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clReleaseDeviceEXT(cl_device_id device) CL_API_SUFFIX__VERSION_1_1;
 
-typedef cl_int
-(CL_API_CALL *clReleaseDeviceEXT_fn)(cl_device_id device) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* clReleaseDeviceEXT_fn)(cl_device_id device)
+  CL_API_SUFFIX__VERSION_1_1;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clRetainDeviceEXT(cl_device_id device) CL_API_SUFFIX__VERSION_1_1;
 
-typedef cl_int
-(CL_API_CALL *clRetainDeviceEXT_fn)(cl_device_id device) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* clRetainDeviceEXT_fn)(cl_device_id device)
+  CL_API_SUFFIX__VERSION_1_1;
 
-typedef cl_ulong  cl_device_partition_property_ext;
+typedef cl_ulong cl_device_partition_property_ext;
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCreateSubDevicesEXT(cl_device_id   in_device,
-                      const cl_device_partition_property_ext * properties,
-                      cl_uint        num_entries,
-                      cl_device_id * out_devices,
-                      cl_uint *      num_devices) CL_API_SUFFIX__VERSION_1_1;
+clCreateSubDevicesEXT(cl_device_id                            in_device,
+                      const cl_device_partition_property_ext* properties,
+                      cl_uint                                 num_entries,
+                      cl_device_id*                           out_devices,
+                      cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_1;
 
-typedef cl_int
-(CL_API_CALL * clCreateSubDevicesEXT_fn)(cl_device_id   in_device,
-                                         const cl_device_partition_property_ext * properties,
-                                         cl_uint        num_entries,
-                                         cl_device_id * out_devices,
-                                         cl_uint *      num_devices) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* clCreateSubDevicesEXT_fn)(
+  cl_device_id                            in_device,
+  const cl_device_partition_property_ext* properties,
+  cl_uint                                 num_entries,
+  cl_device_id*                           out_devices,
+  cl_uint* num_devices) CL_API_SUFFIX__VERSION_1_1;
 
 /* cl_device_partition_property_ext */
-#define CL_DEVICE_PARTITION_EQUALLY_EXT             0x4050
-#define CL_DEVICE_PARTITION_BY_COUNTS_EXT           0x4051
-#define CL_DEVICE_PARTITION_BY_NAMES_EXT            0x4052
-#define CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT  0x4053
+#define CL_DEVICE_PARTITION_EQUALLY_EXT            0x4050
+#define CL_DEVICE_PARTITION_BY_COUNTS_EXT          0x4051
+#define CL_DEVICE_PARTITION_BY_NAMES_EXT           0x4052
+#define CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT 0x4053
 
 /* clDeviceGetInfo selectors */
-#define CL_DEVICE_PARENT_DEVICE_EXT                 0x4054
-#define CL_DEVICE_PARTITION_TYPES_EXT               0x4055
-#define CL_DEVICE_AFFINITY_DOMAINS_EXT              0x4056
-#define CL_DEVICE_REFERENCE_COUNT_EXT               0x4057
-#define CL_DEVICE_PARTITION_STYLE_EXT               0x4058
+#define CL_DEVICE_PARENT_DEVICE_EXT                0x4054
+#define CL_DEVICE_PARTITION_TYPES_EXT              0x4055
+#define CL_DEVICE_AFFINITY_DOMAINS_EXT             0x4056
+#define CL_DEVICE_REFERENCE_COUNT_EXT              0x4057
+#define CL_DEVICE_PARTITION_STYLE_EXT              0x4058
 
 /* error codes */
-#define CL_DEVICE_PARTITION_FAILED_EXT              -1057
-#define CL_INVALID_PARTITION_COUNT_EXT              -1058
-#define CL_INVALID_PARTITION_NAME_EXT               -1059
+#define CL_DEVICE_PARTITION_FAILED_EXT             -1057
+#define CL_INVALID_PARTITION_COUNT_EXT             -1058
+#define CL_INVALID_PARTITION_NAME_EXT              -1059
 
 /* CL_AFFINITY_DOMAINs */
-#define CL_AFFINITY_DOMAIN_L1_CACHE_EXT             0x1
-#define CL_AFFINITY_DOMAIN_L2_CACHE_EXT             0x2
-#define CL_AFFINITY_DOMAIN_L3_CACHE_EXT             0x3
-#define CL_AFFINITY_DOMAIN_L4_CACHE_EXT             0x4
-#define CL_AFFINITY_DOMAIN_NUMA_EXT                 0x10
-#define CL_AFFINITY_DOMAIN_NEXT_FISSIONABLE_EXT     0x100
+#define CL_AFFINITY_DOMAIN_L1_CACHE_EXT            0x1
+#define CL_AFFINITY_DOMAIN_L2_CACHE_EXT            0x2
+#define CL_AFFINITY_DOMAIN_L3_CACHE_EXT            0x3
+#define CL_AFFINITY_DOMAIN_L4_CACHE_EXT            0x4
+#define CL_AFFINITY_DOMAIN_NUMA_EXT                0x10
+#define CL_AFFINITY_DOMAIN_NEXT_FISSIONABLE_EXT    0x100
 
 /* cl_device_partition_property_ext list terminators */
-#define CL_PROPERTIES_LIST_END_EXT                  ((cl_device_partition_property_ext) 0)
-#define CL_PARTITION_BY_COUNTS_LIST_END_EXT         ((cl_device_partition_property_ext) 0)
-#define CL_PARTITION_BY_NAMES_LIST_END_EXT          ((cl_device_partition_property_ext) 0 - 1)
-
+#define CL_PROPERTIES_LIST_END_EXT                 ((cl_device_partition_property_ext)0)
+#define CL_PARTITION_BY_COUNTS_LIST_END_EXT                                    \
+  ((cl_device_partition_property_ext)0)
+#define CL_PARTITION_BY_NAMES_LIST_END_EXT                                     \
+  ((cl_device_partition_property_ext)0 - 1)
 
 /***********************************
  * cl_ext_migrate_memobject extension definitions
@@ -821,172 +793,167 @@ typedef cl_int
 
 typedef cl_bitfield cl_mem_migration_flags_ext;
 
-#define CL_MIGRATE_MEM_OBJECT_HOST_EXT              0x1
+#define CL_MIGRATE_MEM_OBJECT_HOST_EXT    0x1
 
-#define CL_COMMAND_MIGRATE_MEM_OBJECT_EXT           0x4040
+#define CL_COMMAND_MIGRATE_MEM_OBJECT_EXT 0x4040
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueMigrateMemObjectEXT(cl_command_queue command_queue,
-                             cl_uint          num_mem_objects,
-                             const cl_mem *   mem_objects,
+clEnqueueMigrateMemObjectEXT(cl_command_queue           command_queue,
+                             cl_uint                    num_mem_objects,
+                             const cl_mem*              mem_objects,
                              cl_mem_migration_flags_ext flags,
-                             cl_uint          num_events_in_wait_list,
-                             const cl_event * event_wait_list,
-                             cl_event *       event);
+                             cl_uint                    num_events_in_wait_list,
+                             const cl_event*            event_wait_list,
+                             cl_event*                  event);
 
-typedef cl_int
-(CL_API_CALL *clEnqueueMigrateMemObjectEXT_fn)(cl_command_queue command_queue,
-                                               cl_uint          num_mem_objects,
-                                               const cl_mem *   mem_objects,
-                                               cl_mem_migration_flags_ext flags,
-                                               cl_uint          num_events_in_wait_list,
-                                               const cl_event * event_wait_list,
-                                               cl_event *       event);
-
+typedef cl_int(CL_API_CALL* clEnqueueMigrateMemObjectEXT_fn)(
+  cl_command_queue           command_queue,
+  cl_uint                    num_mem_objects,
+  const cl_mem*              mem_objects,
+  cl_mem_migration_flags_ext flags,
+  cl_uint                    num_events_in_wait_list,
+  const cl_event*            event_wait_list,
+  cl_event*                  event);
 
 /*********************************
-* cl_ext_cxx_for_opencl extension
-*********************************/
-#define cl_ext_cxx_for_opencl 1
+ * cl_ext_cxx_for_opencl extension
+ *********************************/
+#define cl_ext_cxx_for_opencl                        1
 
 #define CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT 0x4230
 
 /*********************************
-* cl_qcom_ext_host_ptr extension
-*********************************/
-#define cl_qcom_ext_host_ptr 1
+ * cl_qcom_ext_host_ptr extension
+ *********************************/
+#define cl_qcom_ext_host_ptr                         1
 
-#define CL_MEM_EXT_HOST_PTR_QCOM                  (1 << 29)
+#define CL_MEM_EXT_HOST_PTR_QCOM                     (1 << 29)
 
-#define CL_DEVICE_EXT_MEM_PADDING_IN_BYTES_QCOM   0x40A0
-#define CL_DEVICE_PAGE_SIZE_QCOM                  0x40A1
-#define CL_IMAGE_ROW_ALIGNMENT_QCOM               0x40A2
-#define CL_IMAGE_SLICE_ALIGNMENT_QCOM             0x40A3
-#define CL_MEM_HOST_UNCACHED_QCOM                 0x40A4
-#define CL_MEM_HOST_WRITEBACK_QCOM                0x40A5
-#define CL_MEM_HOST_WRITETHROUGH_QCOM             0x40A6
-#define CL_MEM_HOST_WRITE_COMBINING_QCOM          0x40A7
+#define CL_DEVICE_EXT_MEM_PADDING_IN_BYTES_QCOM      0x40A0
+#define CL_DEVICE_PAGE_SIZE_QCOM                     0x40A1
+#define CL_IMAGE_ROW_ALIGNMENT_QCOM                  0x40A2
+#define CL_IMAGE_SLICE_ALIGNMENT_QCOM                0x40A3
+#define CL_MEM_HOST_UNCACHED_QCOM                    0x40A4
+#define CL_MEM_HOST_WRITEBACK_QCOM                   0x40A5
+#define CL_MEM_HOST_WRITETHROUGH_QCOM                0x40A6
+#define CL_MEM_HOST_WRITE_COMBINING_QCOM             0x40A7
 
-typedef cl_uint                                   cl_image_pitch_info_qcom;
+typedef cl_uint cl_image_pitch_info_qcom;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clGetDeviceImageInfoQCOM(cl_device_id             device,
                          size_t                   image_width,
                          size_t                   image_height,
-                         const cl_image_format   *image_format,
+                         const cl_image_format*   image_format,
                          cl_image_pitch_info_qcom param_name,
                          size_t                   param_value_size,
-                         void                    *param_value,
-                         size_t                  *param_value_size_ret);
+                         void*                    param_value,
+                         size_t*                  param_value_size_ret);
 
 typedef struct _cl_mem_ext_host_ptr
 {
-    /* Type of external memory allocation. */
-    /* Legal values will be defined in layered extensions. */
-    cl_uint  allocation_type;
+  /* Type of external memory allocation. */
+  /* Legal values will be defined in layered extensions. */
+  cl_uint allocation_type;
 
-    /* Host cache policy for this external memory allocation. */
-    cl_uint  host_cache_policy;
+  /* Host cache policy for this external memory allocation. */
+  cl_uint host_cache_policy;
 
 } cl_mem_ext_host_ptr;
 
-
 /*******************************************
-* cl_qcom_ext_host_ptr_iocoherent extension
-********************************************/
+ * cl_qcom_ext_host_ptr_iocoherent extension
+ ********************************************/
 
 /* Cache policy specifying io-coherence */
-#define CL_MEM_HOST_IOCOHERENT_QCOM               0x40A9
-
+#define CL_MEM_HOST_IOCOHERENT_QCOM 0x40A9
 
 /*********************************
-* cl_qcom_ion_host_ptr extension
-*********************************/
+ * cl_qcom_ion_host_ptr extension
+ *********************************/
 
-#define CL_MEM_ION_HOST_PTR_QCOM                  0x40A8
+#define CL_MEM_ION_HOST_PTR_QCOM    0x40A8
 
 typedef struct _cl_mem_ion_host_ptr
 {
-    /* Type of external memory allocation. */
-    /* Must be CL_MEM_ION_HOST_PTR_QCOM for ION allocations. */
-    cl_mem_ext_host_ptr  ext_host_ptr;
+  /* Type of external memory allocation. */
+  /* Must be CL_MEM_ION_HOST_PTR_QCOM for ION allocations. */
+  cl_mem_ext_host_ptr ext_host_ptr;
 
-    /* ION file descriptor */
-    int                  ion_filedesc;
+  /* ION file descriptor */
+  int                 ion_filedesc;
 
-    /* Host pointer to the ION allocated memory */
-    void*                ion_hostptr;
+  /* Host pointer to the ION allocated memory */
+  void*               ion_hostptr;
 
 } cl_mem_ion_host_ptr;
 
-
 /*********************************
-* cl_qcom_android_native_buffer_host_ptr extension
-*********************************/
+ * cl_qcom_android_native_buffer_host_ptr extension
+ *********************************/
 
-#define CL_MEM_ANDROID_NATIVE_BUFFER_HOST_PTR_QCOM                  0x40C6
+#define CL_MEM_ANDROID_NATIVE_BUFFER_HOST_PTR_QCOM 0x40C6
 
 typedef struct _cl_mem_android_native_buffer_host_ptr
 {
-    /* Type of external memory allocation. */
-    /* Must be CL_MEM_ANDROID_NATIVE_BUFFER_HOST_PTR_QCOM for Android native buffers. */
-    cl_mem_ext_host_ptr  ext_host_ptr;
+  /* Type of external memory allocation. */
+  /* Must be CL_MEM_ANDROID_NATIVE_BUFFER_HOST_PTR_QCOM for Android native
+   * buffers. */
+  cl_mem_ext_host_ptr ext_host_ptr;
 
-    /* Virtual pointer to the android native buffer */
-    void*                anb_ptr;
+  /* Virtual pointer to the android native buffer */
+  void*               anb_ptr;
 
 } cl_mem_android_native_buffer_host_ptr;
-
 
 /******************************************
  * cl_img_yuv_image extension *
  ******************************************/
 
 /* Image formats used in clCreateImage */
-#define CL_NV21_IMG                                 0x40D0
-#define CL_YV12_IMG                                 0x40D1
-
+#define CL_NV21_IMG                            0x40D0
+#define CL_YV12_IMG                            0x40D1
 
 /******************************************
  * cl_img_cached_allocations extension *
  ******************************************/
 
 /* Flag values used by clCreateBuffer */
-#define CL_MEM_USE_UNCACHED_CPU_MEMORY_IMG          (1 << 26)
-#define CL_MEM_USE_CACHED_CPU_MEMORY_IMG            (1 << 27)
-
+#define CL_MEM_USE_UNCACHED_CPU_MEMORY_IMG     (1 << 26)
+#define CL_MEM_USE_CACHED_CPU_MEMORY_IMG       (1 << 27)
 
 /******************************************
  * cl_img_use_gralloc_ptr extension *
  ******************************************/
-#define cl_img_use_gralloc_ptr 1
+#define cl_img_use_gralloc_ptr                 1
 
 /* Flag values used by clCreateBuffer */
-#define CL_MEM_USE_GRALLOC_PTR_IMG                  (1 << 28)
+#define CL_MEM_USE_GRALLOC_PTR_IMG             (1 << 28)
 
 /* To be used by clGetEventInfo: */
-#define CL_COMMAND_ACQUIRE_GRALLOC_OBJECTS_IMG      0x40D2
-#define CL_COMMAND_RELEASE_GRALLOC_OBJECTS_IMG      0x40D3
+#define CL_COMMAND_ACQUIRE_GRALLOC_OBJECTS_IMG 0x40D2
+#define CL_COMMAND_RELEASE_GRALLOC_OBJECTS_IMG 0x40D3
 
-/* Error codes from clEnqueueAcquireGrallocObjectsIMG and clEnqueueReleaseGrallocObjectsIMG */
-#define CL_GRALLOC_RESOURCE_NOT_ACQUIRED_IMG        0x40D4
-#define CL_INVALID_GRALLOC_OBJECT_IMG               0x40D5
-
-extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueAcquireGrallocObjectsIMG(cl_command_queue      command_queue,
-                                  cl_uint               num_objects,
-                                  const cl_mem *        mem_objects,
-                                  cl_uint               num_events_in_wait_list,
-                                  const cl_event *      event_wait_list,
-                                  cl_event *            event) CL_API_SUFFIX__VERSION_1_2;
+/* Error codes from clEnqueueAcquireGrallocObjectsIMG and
+ * clEnqueueReleaseGrallocObjectsIMG */
+#define CL_GRALLOC_RESOURCE_NOT_ACQUIRED_IMG   0x40D4
+#define CL_INVALID_GRALLOC_OBJECT_IMG          0x40D5
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueReleaseGrallocObjectsIMG(cl_command_queue      command_queue,
-                                  cl_uint               num_objects,
-                                  const cl_mem *        mem_objects,
-                                  cl_uint               num_events_in_wait_list,
-                                  const cl_event *      event_wait_list,
-                                  cl_event *            event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueAcquireGrallocObjectsIMG(cl_command_queue command_queue,
+                                  cl_uint          num_objects,
+                                  const cl_mem*    mem_objects,
+                                  cl_uint          num_events_in_wait_list,
+                                  const cl_event*  event_wait_list,
+                                  cl_event* event) CL_API_SUFFIX__VERSION_1_2;
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueReleaseGrallocObjectsIMG(cl_command_queue command_queue,
+                                  cl_uint          num_objects,
+                                  const cl_mem*    mem_objects,
+                                  cl_uint          num_events_in_wait_list,
+                                  const cl_event*  event_wait_list,
+                                  cl_event* event) CL_API_SUFFIX__VERSION_1_2;
 
 /******************************************
  * cl_img_generate_mipmap extension *
@@ -996,8 +963,8 @@ clEnqueueReleaseGrallocObjectsIMG(cl_command_queue      command_queue,
 typedef cl_uint cl_mipmap_filter_mode_img;
 
 /* To be used by clEnqueueGenerateMipmapIMG */
-#define CL_MIPMAP_FILTER_ANY_IMG 0x0
-#define CL_MIPMAP_FILTER_BOX_IMG 0x1
+#define CL_MIPMAP_FILTER_ANY_IMG       0x0
+#define CL_MIPMAP_FILTER_BOX_IMG       0x1
 
 /* To be used by clGetEventInfo */
 #define CL_COMMAND_GENERATE_MIPMAP_IMG 0x40D6
@@ -1007,16 +974,16 @@ clEnqueueGenerateMipmapIMG(cl_command_queue          command_queue,
                            cl_mem                    src_image,
                            cl_mem                    dst_image,
                            cl_mipmap_filter_mode_img mipmap_filter_mode,
-                           const size_t              *array_region,
-                           const size_t              *mip_region,
+                           const size_t*             array_region,
+                           const size_t*             mip_region,
                            cl_uint                   num_events_in_wait_list,
-                           const cl_event            *event_wait_list,
-                           cl_event *event) CL_API_SUFFIX__VERSION_1_2;
-  
+                           const cl_event*           event_wait_list,
+                           cl_event* event) CL_API_SUFFIX__VERSION_1_2;
+
 /******************************************
  * cl_img_mem_properties extension *
  ******************************************/
-#define cl_img_mem_properties 1
+#define cl_img_mem_properties  1
 
 /* To be used by clCreateBufferWithProperties */
 #define CL_MEM_ALLOC_FLAGS_IMG 0x40D7
@@ -1028,122 +995,121 @@ typedef cl_bitfield cl_mem_alloc_flags_img;
 #define CL_MEM_ALLOC_RELAX_REQUIREMENTS_IMG (1 << 0)
 
 /*********************************
-* cl_khr_subgroups extension
-*********************************/
-#define cl_khr_subgroups 1
+ * cl_khr_subgroups extension
+ *********************************/
+#define cl_khr_subgroups                    1
 
 #if !defined(CL_VERSION_2_1)
 /* For OpenCL 2.1 and newer, cl_kernel_sub_group_info is declared in CL.h.
    In hindsight, there should have been a khr suffix on this type for
    the extension, but keeping it un-suffixed to maintain backwards
    compatibility. */
-typedef cl_uint             cl_kernel_sub_group_info;
+typedef cl_uint cl_kernel_sub_group_info;
 #endif
 
 /* cl_kernel_sub_group_info */
-#define CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR    0x2033
-#define CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR       0x2034
+#define CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR 0x2033
+#define CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR    0x2034
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetKernelSubGroupInfoKHR(cl_kernel    in_kernel,
-                           cl_device_id in_device,
+clGetKernelSubGroupInfoKHR(cl_kernel                in_kernel,
+                           cl_device_id             in_device,
                            cl_kernel_sub_group_info param_name,
-                           size_t       input_value_size,
-                           const void * input_value,
-                           size_t       param_value_size,
-                           void *       param_value,
-                           size_t *     param_value_size_ret) CL_API_SUFFIX__VERSION_2_0_DEPRECATED;
+                           size_t                   input_value_size,
+                           const void*              input_value,
+                           size_t                   param_value_size,
+                           void*                    param_value,
+                           size_t*                  param_value_size_ret)
+  CL_API_SUFFIX__VERSION_2_0_DEPRECATED;
 
-typedef cl_int
-(CL_API_CALL * clGetKernelSubGroupInfoKHR_fn)(cl_kernel    in_kernel,
-                                              cl_device_id in_device,
-                                              cl_kernel_sub_group_info param_name,
-                                              size_t       input_value_size,
-                                              const void * input_value,
-                                              size_t       param_value_size,
-                                              void *       param_value,
-                                              size_t *     param_value_size_ret) CL_API_SUFFIX__VERSION_2_0_DEPRECATED;
-
+typedef cl_int(CL_API_CALL* clGetKernelSubGroupInfoKHR_fn)(
+  cl_kernel                in_kernel,
+  cl_device_id             in_device,
+  cl_kernel_sub_group_info param_name,
+  size_t                   input_value_size,
+  const void*              input_value,
+  size_t                   param_value_size,
+  void*                    param_value,
+  size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_2_0_DEPRECATED;
 
 /*********************************
-* cl_khr_mipmap_image extension
-*********************************/
+ * cl_khr_mipmap_image extension
+ *********************************/
 
 /* cl_sampler_properties */
-#define CL_SAMPLER_MIP_FILTER_MODE_KHR              0x1155
-#define CL_SAMPLER_LOD_MIN_KHR                      0x1156
-#define CL_SAMPLER_LOD_MAX_KHR                      0x1157
-
+#define CL_SAMPLER_MIP_FILTER_MODE_KHR 0x1155
+#define CL_SAMPLER_LOD_MIN_KHR         0x1156
+#define CL_SAMPLER_LOD_MAX_KHR         0x1157
 
 /*********************************
-* cl_khr_priority_hints extension
-*********************************/
+ * cl_khr_priority_hints extension
+ *********************************/
 /* This extension define is for backwards compatibility.
    It shouldn't be required since this extension has no new functions. */
-#define cl_khr_priority_hints 1
+#define cl_khr_priority_hints          1
 
-typedef cl_uint  cl_queue_priority_khr;
+typedef cl_uint cl_queue_priority_khr;
 
 /* cl_command_queue_properties */
-#define CL_QUEUE_PRIORITY_KHR 0x1096
+#define CL_QUEUE_PRIORITY_KHR      0x1096
 
 /* cl_queue_priority_khr */
-#define CL_QUEUE_PRIORITY_HIGH_KHR (1<<0)
-#define CL_QUEUE_PRIORITY_MED_KHR (1<<1)
-#define CL_QUEUE_PRIORITY_LOW_KHR (1<<2)
-
+#define CL_QUEUE_PRIORITY_HIGH_KHR (1 << 0)
+#define CL_QUEUE_PRIORITY_MED_KHR  (1 << 1)
+#define CL_QUEUE_PRIORITY_LOW_KHR  (1 << 2)
 
 /*********************************
-* cl_khr_throttle_hints extension
-*********************************/
+ * cl_khr_throttle_hints extension
+ *********************************/
 /* This extension define is for backwards compatibility.
    It shouldn't be required since this extension has no new functions. */
-#define cl_khr_throttle_hints 1
+#define cl_khr_throttle_hints      1
 
-typedef cl_uint  cl_queue_throttle_khr;
+typedef cl_uint cl_queue_throttle_khr;
 
 /* cl_command_queue_properties */
-#define CL_QUEUE_THROTTLE_KHR 0x1097
+#define CL_QUEUE_THROTTLE_KHR                 0x1097
 
 /* cl_queue_throttle_khr */
-#define CL_QUEUE_THROTTLE_HIGH_KHR (1<<0)
-#define CL_QUEUE_THROTTLE_MED_KHR (1<<1)
-#define CL_QUEUE_THROTTLE_LOW_KHR (1<<2)
-
+#define CL_QUEUE_THROTTLE_HIGH_KHR            (1 << 0)
+#define CL_QUEUE_THROTTLE_MED_KHR             (1 << 1)
+#define CL_QUEUE_THROTTLE_LOW_KHR             (1 << 2)
 
 /*********************************
-* cl_khr_subgroup_named_barrier
-*********************************/
+ * cl_khr_subgroup_named_barrier
+ *********************************/
 /* This extension define is for backwards compatibility.
    It shouldn't be required since this extension has no new functions. */
-#define cl_khr_subgroup_named_barrier 1
+#define cl_khr_subgroup_named_barrier         1
 
 /* cl_device_info */
-#define CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR       0x2035
-
+#define CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR 0x2035
 
 /*********************************
-* cl_khr_extended_versioning
-*********************************/
+ * cl_khr_extended_versioning
+ *********************************/
 
-#define cl_khr_extended_versioning 1
+#define cl_khr_extended_versioning            1
 
-#define CL_VERSION_MAJOR_BITS_KHR (10)
-#define CL_VERSION_MINOR_BITS_KHR (10)
-#define CL_VERSION_PATCH_BITS_KHR (12)
+#define CL_VERSION_MAJOR_BITS_KHR             (10)
+#define CL_VERSION_MINOR_BITS_KHR             (10)
+#define CL_VERSION_PATCH_BITS_KHR             (12)
 
-#define CL_VERSION_MAJOR_MASK_KHR ((1 << CL_VERSION_MAJOR_BITS_KHR) - 1)
-#define CL_VERSION_MINOR_MASK_KHR ((1 << CL_VERSION_MINOR_BITS_KHR) - 1)
-#define CL_VERSION_PATCH_MASK_KHR ((1 << CL_VERSION_PATCH_BITS_KHR) - 1)
+#define CL_VERSION_MAJOR_MASK_KHR             ((1 << CL_VERSION_MAJOR_BITS_KHR) - 1)
+#define CL_VERSION_MINOR_MASK_KHR             ((1 << CL_VERSION_MINOR_BITS_KHR) - 1)
+#define CL_VERSION_PATCH_MASK_KHR             ((1 << CL_VERSION_PATCH_BITS_KHR) - 1)
 
-#define CL_VERSION_MAJOR_KHR(version) ((version) >> (CL_VERSION_MINOR_BITS_KHR + CL_VERSION_PATCH_BITS_KHR))
-#define CL_VERSION_MINOR_KHR(version) (((version) >> CL_VERSION_PATCH_BITS_KHR) & CL_VERSION_MINOR_MASK_KHR)
-#define CL_VERSION_PATCH_KHR(version) ((version) & CL_VERSION_PATCH_MASK_KHR)
+#define CL_VERSION_MAJOR_KHR(version)                                          \
+  ((version) >> (CL_VERSION_MINOR_BITS_KHR + CL_VERSION_PATCH_BITS_KHR))
+#define CL_VERSION_MINOR_KHR(version)                                          \
+  (((version) >> CL_VERSION_PATCH_BITS_KHR) & CL_VERSION_MINOR_MASK_KHR)
+#define CL_VERSION_PATCH_KHR(version) ((version)&CL_VERSION_PATCH_MASK_KHR)
 
-#define CL_MAKE_VERSION_KHR(major, minor, patch) \
-    ((((major) & CL_VERSION_MAJOR_MASK_KHR) << (CL_VERSION_MINOR_BITS_KHR + CL_VERSION_PATCH_BITS_KHR)) | \
-    (((minor) &  CL_VERSION_MINOR_MASK_KHR) << CL_VERSION_PATCH_BITS_KHR) | \
-    ((patch) & CL_VERSION_PATCH_MASK_KHR))
+#define CL_MAKE_VERSION_KHR(major, minor, patch)                               \
+  ((((major)&CL_VERSION_MAJOR_MASK_KHR)                                        \
+    << (CL_VERSION_MINOR_BITS_KHR + CL_VERSION_PATCH_BITS_KHR)) |              \
+   (((minor)&CL_VERSION_MINOR_MASK_KHR) << CL_VERSION_PATCH_BITS_KHR) |        \
+   ((patch)&CL_VERSION_PATCH_MASK_KHR))
 
 typedef cl_uint cl_version_khr;
 
@@ -1151,109 +1117,106 @@ typedef cl_uint cl_version_khr;
 
 typedef struct _cl_name_version_khr
 {
-    cl_version_khr version;
-    char name[CL_NAME_VERSION_MAX_NAME_SIZE_KHR];
+  cl_version_khr version;
+  char           name[CL_NAME_VERSION_MAX_NAME_SIZE_KHR];
 } cl_name_version_khr;
 
 /* cl_platform_info */
-#define CL_PLATFORM_NUMERIC_VERSION_KHR                  0x0906
-#define CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR          0x0907
+#define CL_PLATFORM_NUMERIC_VERSION_KHR             0x0906
+#define CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR     0x0907
 
 /* cl_device_info */
-#define CL_DEVICE_NUMERIC_VERSION_KHR                    0x105E
-#define CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR           0x105F
-#define CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR            0x1060
-#define CL_DEVICE_ILS_WITH_VERSION_KHR                   0x1061
-#define CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR      0x1062
-
+#define CL_DEVICE_NUMERIC_VERSION_KHR               0x105E
+#define CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR      0x105F
+#define CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR       0x1060
+#define CL_DEVICE_ILS_WITH_VERSION_KHR              0x1061
+#define CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR 0x1062
 
 /*********************************
-* cl_khr_device_uuid extension
-*********************************/
-#define cl_khr_device_uuid 1
+ * cl_khr_device_uuid extension
+ *********************************/
+#define cl_khr_device_uuid                          1
 
-#define CL_UUID_SIZE_KHR 16
-#define CL_LUID_SIZE_KHR 8
+#define CL_UUID_SIZE_KHR                            16
+#define CL_LUID_SIZE_KHR                            8
 
-#define CL_DEVICE_UUID_KHR          0x106A
-#define CL_DRIVER_UUID_KHR          0x106B
-#define CL_DEVICE_LUID_VALID_KHR    0x106C
-#define CL_DEVICE_LUID_KHR          0x106D
-#define CL_DEVICE_NODE_MASK_KHR     0x106E
-
+#define CL_DEVICE_UUID_KHR                          0x106A
+#define CL_DRIVER_UUID_KHR                          0x106B
+#define CL_DEVICE_LUID_VALID_KHR                    0x106C
+#define CL_DEVICE_LUID_KHR                          0x106D
+#define CL_DEVICE_NODE_MASK_KHR                     0x106E
 
 /***************************************************************
-* cl_khr_pci_bus_info
-***************************************************************/
-#define cl_khr_pci_bus_info 1
+ * cl_khr_pci_bus_info
+ ***************************************************************/
+#define cl_khr_pci_bus_info                         1
 
-typedef struct _cl_device_pci_bus_info_khr {
-    cl_uint pci_domain;
-    cl_uint pci_bus;
-    cl_uint pci_device;
-    cl_uint pci_function;
+typedef struct _cl_device_pci_bus_info_khr
+{
+  cl_uint pci_domain;
+  cl_uint pci_bus;
+  cl_uint pci_device;
+  cl_uint pci_function;
 } cl_device_pci_bus_info_khr;
 
 /* cl_device_info */
-#define CL_DEVICE_PCI_BUS_INFO_KHR                          0x410F
-
+#define CL_DEVICE_PCI_BUS_INFO_KHR       0x410F
 
 /***************************************************************
-* cl_khr_suggested_local_work_size
-***************************************************************/
+ * cl_khr_suggested_local_work_size
+ ***************************************************************/
 #define cl_khr_suggested_local_work_size 1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetKernelSuggestedLocalWorkSizeKHR(
-    cl_command_queue command_queue,
-    cl_kernel kernel,
-    cl_uint work_dim,
-    const size_t* global_work_offset,
-    const size_t* global_work_size,
-    size_t* suggested_local_work_size) CL_API_SUFFIX__VERSION_3_0;
+clGetKernelSuggestedLocalWorkSizeKHR(cl_command_queue command_queue,
+                                     cl_kernel        kernel,
+                                     cl_uint          work_dim,
+                                     const size_t*    global_work_offset,
+                                     const size_t*    global_work_size,
+                                     size_t*          suggested_local_work_size)
+  CL_API_SUFFIX__VERSION_3_0;
 
-typedef cl_int (CL_API_CALL *
-clGetKernelSuggestedLocalWorkSizeKHR_fn)(
-    cl_command_queue command_queue,
-    cl_kernel kernel,
-    cl_uint work_dim,
-    const size_t* global_work_offset,
-    const size_t* global_work_size,
-    size_t* suggested_local_work_size) CL_API_SUFFIX__VERSION_3_0;
-
+typedef cl_int(CL_API_CALL* clGetKernelSuggestedLocalWorkSizeKHR_fn)(
+  cl_command_queue command_queue,
+  cl_kernel        kernel,
+  cl_uint          work_dim,
+  const size_t*    global_work_offset,
+  const size_t*    global_work_size,
+  size_t*          suggested_local_work_size) CL_API_SUFFIX__VERSION_3_0;
 
 /***************************************************************
-* cl_khr_integer_dot_product
-***************************************************************/
+ * cl_khr_integer_dot_product
+ ***************************************************************/
 #define cl_khr_integer_dot_product 1
 
-typedef cl_bitfield         cl_device_integer_dot_product_capabilities_khr;
+typedef cl_bitfield cl_device_integer_dot_product_capabilities_khr;
 
 /* cl_device_integer_dot_product_capabilities_khr */
 #define CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_PACKED_KHR (1 << 0)
-#define CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_KHR      (1 << 1)
+#define CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_KHR        (1 << 1)
 
-typedef struct _cl_device_integer_dot_product_acceleration_properties_khr {
-    cl_bool signed_accelerated;
-    cl_bool unsigned_accelerated;
-    cl_bool mixed_signedness_accelerated;
-    cl_bool accumulating_saturating_signed_accelerated;
-    cl_bool accumulating_saturating_unsigned_accelerated;
-    cl_bool accumulating_saturating_mixed_signedness_accelerated;
+typedef struct _cl_device_integer_dot_product_acceleration_properties_khr
+{
+  cl_bool signed_accelerated;
+  cl_bool unsigned_accelerated;
+  cl_bool mixed_signedness_accelerated;
+  cl_bool accumulating_saturating_signed_accelerated;
+  cl_bool accumulating_saturating_unsigned_accelerated;
+  cl_bool accumulating_saturating_mixed_signedness_accelerated;
 } cl_device_integer_dot_product_acceleration_properties_khr;
 
 /* cl_device_info */
-#define CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR                          0x1073
-#define CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_8BIT_KHR          0x1074
-#define CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_4x8BIT_PACKED_KHR 0x1075
-
+#define CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR                 0x1073
+#define CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_8BIT_KHR 0x1074
+#define CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_4x8BIT_PACKED_KHR \
+  0x1075
 
 /***************************************************************
-* cl_khr_external_memory
-***************************************************************/
+ * cl_khr_external_memory
+ ***************************************************************/
 #define cl_khr_external_memory 1
 
-typedef cl_uint             cl_external_memory_handle_type_khr;
+typedef cl_uint cl_external_memory_handle_type_khr;
 
 /* cl_platform_info */
 #define CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR 0x2044
@@ -1269,273 +1232,256 @@ typedef cl_uint             cl_external_memory_handle_type_khr;
 #define CL_COMMAND_ACQUIRE_EXTERNAL_MEM_OBJECTS_KHR         0x2047
 #define CL_COMMAND_RELEASE_EXTERNAL_MEM_OBJECTS_KHR         0x2048
 
+typedef cl_int(CL_API_CALL* clEnqueueAcquireExternalMemObjectsKHR_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_mem_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_3_0;
 
-typedef cl_int (CL_API_CALL *
-clEnqueueAcquireExternalMemObjectsKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint num_mem_objects,
-    const cl_mem* mem_objects,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_3_0;
-
-typedef cl_int (CL_API_CALL *
-clEnqueueReleaseExternalMemObjectsKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint num_mem_objects,
-    const cl_mem* mem_objects,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_3_0;
+typedef cl_int(CL_API_CALL* clEnqueueReleaseExternalMemObjectsKHR_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_mem_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_3_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueAcquireExternalMemObjectsKHR(
-    cl_command_queue command_queue,
-    cl_uint num_mem_objects,
-    const cl_mem* mem_objects,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_3_0;
+clEnqueueAcquireExternalMemObjectsKHR(cl_command_queue command_queue,
+                                      cl_uint          num_mem_objects,
+                                      const cl_mem*    mem_objects,
+                                      cl_uint          num_events_in_wait_list,
+                                      const cl_event*  event_wait_list,
+                                      cl_event*        event)
+  CL_API_SUFFIX__VERSION_3_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueReleaseExternalMemObjectsKHR(
-    cl_command_queue command_queue,
-    cl_uint num_mem_objects,
-    const cl_mem* mem_objects,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_3_0;
+clEnqueueReleaseExternalMemObjectsKHR(cl_command_queue command_queue,
+                                      cl_uint          num_mem_objects,
+                                      const cl_mem*    mem_objects,
+                                      cl_uint          num_events_in_wait_list,
+                                      const cl_event*  event_wait_list,
+                                      cl_event*        event)
+  CL_API_SUFFIX__VERSION_3_0;
 
 /***************************************************************
-* cl_khr_external_memory_dma_buf
-***************************************************************/
-#define cl_khr_external_memory_dma_buf 1
+ * cl_khr_external_memory_dma_buf
+ ***************************************************************/
+#define cl_khr_external_memory_dma_buf                  1
 
 /* cl_external_memory_handle_type_khr */
-#define CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR               0x2067
+#define CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR           0x2067
 
 /***************************************************************
-* cl_khr_external_memory_dx
-***************************************************************/
-#define cl_khr_external_memory_dx 1
+ * cl_khr_external_memory_dx
+ ***************************************************************/
+#define cl_khr_external_memory_dx                       1
 
 /* cl_external_memory_handle_type_khr */
-#define CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KHR         0x2063
-#define CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KMT_KHR     0x2064
-#define CL_EXTERNAL_MEMORY_HANDLE_D3D12_HEAP_KHR            0x2065
-#define CL_EXTERNAL_MEMORY_HANDLE_D3D12_RESOURCE_KHR        0x2066
+#define CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KHR     0x2063
+#define CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KMT_KHR 0x2064
+#define CL_EXTERNAL_MEMORY_HANDLE_D3D12_HEAP_KHR        0x2065
+#define CL_EXTERNAL_MEMORY_HANDLE_D3D12_RESOURCE_KHR    0x2066
 
 /***************************************************************
-* cl_khr_external_memory_opaque_fd
-***************************************************************/
-#define cl_khr_external_memory_opaque_fd 1
+ * cl_khr_external_memory_opaque_fd
+ ***************************************************************/
+#define cl_khr_external_memory_opaque_fd                1
 
 /* cl_external_memory_handle_type_khr */
-#define CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR             0x2060
+#define CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR         0x2060
 
 /***************************************************************
-* cl_khr_external_memory_win32
-***************************************************************/
-#define cl_khr_external_memory_win32 1
+ * cl_khr_external_memory_win32
+ ***************************************************************/
+#define cl_khr_external_memory_win32                    1
 
 /* cl_external_memory_handle_type_khr */
-#define CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR          0x2061
-#define CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR      0x2062
+#define CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR      0x2061
+#define CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR  0x2062
 
 /***************************************************************
-* cl_khr_external_semaphore
-***************************************************************/
-#define cl_khr_external_semaphore 1
+ * cl_khr_external_semaphore
+ ***************************************************************/
+#define cl_khr_external_semaphore                       1
 
-typedef struct _cl_semaphore_khr * cl_semaphore_khr;
-typedef cl_uint             cl_external_semaphore_handle_type_khr;
+typedef struct _cl_semaphore_khr* cl_semaphore_khr;
+typedef cl_uint                   cl_external_semaphore_handle_type_khr;
 
 /* cl_platform_info */
-#define CL_PLATFORM_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR       0x2037
-#define CL_PLATFORM_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR       0x2038
+#define CL_PLATFORM_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR 0x2037
+#define CL_PLATFORM_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR 0x2038
 
 /* cl_device_info */
-#define CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR         0x204D
-#define CL_DEVICE_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR         0x204E
+#define CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR   0x204D
+#define CL_DEVICE_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR   0x204E
 
 /* cl_semaphore_properties_khr */
-#define CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR                0x203F
-#define CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR       0
+#define CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR          0x203F
+#define CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR 0
 
-
-typedef cl_int (CL_API_CALL *
-clGetSemaphoreHandleForTypeKHR_fn)(
-    cl_semaphore_khr sema_object,
-    cl_device_id device,
-    cl_external_semaphore_handle_type_khr handle_type,
-    size_t handle_size,
-    void* handle_ptr,
-    size_t* handle_size_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clGetSemaphoreHandleForTypeKHR_fn)(
+  cl_semaphore_khr                      sema_object,
+  cl_device_id                          device,
+  cl_external_semaphore_handle_type_khr handle_type,
+  size_t                                handle_size,
+  void*                                 handle_ptr,
+  size_t* handle_size_ret) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clGetSemaphoreHandleForTypeKHR(
-    cl_semaphore_khr sema_object,
-    cl_device_id device,
-    cl_external_semaphore_handle_type_khr handle_type,
-    size_t handle_size,
-    void* handle_ptr,
-    size_t* handle_size_ret) CL_API_SUFFIX__VERSION_1_2;
+  cl_semaphore_khr                      sema_object,
+  cl_device_id                          device,
+  cl_external_semaphore_handle_type_khr handle_type,
+  size_t                                handle_size,
+  void*                                 handle_ptr,
+  size_t* handle_size_ret) CL_API_SUFFIX__VERSION_1_2;
 
 /***************************************************************
-* cl_khr_external_semaphore_dx_fence
-***************************************************************/
-#define cl_khr_external_semaphore_dx_fence 1
+ * cl_khr_external_semaphore_dx_fence
+ ***************************************************************/
+#define cl_khr_external_semaphore_dx_fence       1
 
 /* cl_external_semaphore_handle_type_khr */
-#define CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR                 0x2059
+#define CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR      0x2059
 
 /***************************************************************
-* cl_khr_external_semaphore_opaque_fd
-***************************************************************/
-#define cl_khr_external_semaphore_opaque_fd 1
+ * cl_khr_external_semaphore_opaque_fd
+ ***************************************************************/
+#define cl_khr_external_semaphore_opaque_fd      1
 
 /* cl_external_semaphore_handle_type_khr */
-#define CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR                   0x2055
+#define CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR        0x2055
 
 /***************************************************************
-* cl_khr_external_semaphore_sync_fd
-***************************************************************/
-#define cl_khr_external_semaphore_sync_fd 1
+ * cl_khr_external_semaphore_sync_fd
+ ***************************************************************/
+#define cl_khr_external_semaphore_sync_fd        1
 
 /* cl_external_semaphore_handle_type_khr */
-#define CL_SEMAPHORE_HANDLE_SYNC_FD_KHR                     0x2058
+#define CL_SEMAPHORE_HANDLE_SYNC_FD_KHR          0x2058
 
 /***************************************************************
-* cl_khr_external_semaphore_win32
-***************************************************************/
-#define cl_khr_external_semaphore_win32 1
+ * cl_khr_external_semaphore_win32
+ ***************************************************************/
+#define cl_khr_external_semaphore_win32          1
 
 /* cl_external_semaphore_handle_type_khr */
-#define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR                0x2056
-#define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR            0x2057
+#define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR     0x2056
+#define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR 0x2057
 
 /***************************************************************
-* cl_khr_semaphore
-***************************************************************/
-#define cl_khr_semaphore 1
+ * cl_khr_semaphore
+ ***************************************************************/
+#define cl_khr_semaphore                         1
 
 /* type cl_semaphore_khr */
-typedef cl_properties       cl_semaphore_properties_khr;
-typedef cl_uint             cl_semaphore_info_khr;
-typedef cl_uint             cl_semaphore_type_khr;
-typedef cl_ulong            cl_semaphore_payload_khr;
+typedef cl_properties cl_semaphore_properties_khr;
+typedef cl_uint       cl_semaphore_info_khr;
+typedef cl_uint       cl_semaphore_type_khr;
+typedef cl_ulong      cl_semaphore_payload_khr;
 
 /* cl_semaphore_type */
-#define CL_SEMAPHORE_TYPE_BINARY_KHR                        1
+#define CL_SEMAPHORE_TYPE_BINARY_KHR     1
 
 /* cl_platform_info */
-#define CL_PLATFORM_SEMAPHORE_TYPES_KHR                     0x2036
+#define CL_PLATFORM_SEMAPHORE_TYPES_KHR  0x2036
 
 /* cl_device_info */
-#define CL_DEVICE_SEMAPHORE_TYPES_KHR                       0x204C
+#define CL_DEVICE_SEMAPHORE_TYPES_KHR    0x204C
 
 /* cl_semaphore_info_khr */
-#define CL_SEMAPHORE_CONTEXT_KHR                            0x2039
-#define CL_SEMAPHORE_REFERENCE_COUNT_KHR                    0x203A
-#define CL_SEMAPHORE_PROPERTIES_KHR                         0x203B
-#define CL_SEMAPHORE_PAYLOAD_KHR                            0x203C
+#define CL_SEMAPHORE_CONTEXT_KHR         0x2039
+#define CL_SEMAPHORE_REFERENCE_COUNT_KHR 0x203A
+#define CL_SEMAPHORE_PROPERTIES_KHR      0x203B
+#define CL_SEMAPHORE_PAYLOAD_KHR         0x203C
 
 /* cl_semaphore_info_khr or cl_semaphore_properties_khr */
-#define CL_SEMAPHORE_TYPE_KHR                               0x203D
+#define CL_SEMAPHORE_TYPE_KHR            0x203D
 /* enum CL_DEVICE_HANDLE_LIST_KHR */
 /* enum CL_DEVICE_HANDLE_LIST_END_KHR */
 
 /* cl_command_type */
-#define CL_COMMAND_SEMAPHORE_WAIT_KHR                       0x2042
-#define CL_COMMAND_SEMAPHORE_SIGNAL_KHR                     0x2043
+#define CL_COMMAND_SEMAPHORE_WAIT_KHR    0x2042
+#define CL_COMMAND_SEMAPHORE_SIGNAL_KHR  0x2043
 
 /* Error codes */
-#define CL_INVALID_SEMAPHORE_KHR                            -1142
+#define CL_INVALID_SEMAPHORE_KHR         -1142
 
+typedef cl_semaphore_khr(CL_API_CALL* clCreateSemaphoreWithPropertiesKHR_fn)(
+  cl_context                         context,
+  const cl_semaphore_properties_khr* sema_props,
+  cl_int*                            errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_semaphore_khr (CL_API_CALL *
-clCreateSemaphoreWithPropertiesKHR_fn)(
-    cl_context context,
-    const cl_semaphore_properties_khr* sema_props,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clEnqueueWaitSemaphoresKHR_fn)(
+  cl_command_queue                command_queue,
+  cl_uint                         num_sema_objects,
+  const cl_semaphore_khr*         sema_objects,
+  const cl_semaphore_payload_khr* sema_payload_list,
+  cl_uint                         num_events_in_wait_list,
+  const cl_event*                 event_wait_list,
+  cl_event*                       event) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *
-clEnqueueWaitSemaphoresKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint num_sema_objects,
-    const cl_semaphore_khr* sema_objects,
-    const cl_semaphore_payload_khr* sema_payload_list,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clEnqueueSignalSemaphoresKHR_fn)(
+  cl_command_queue                command_queue,
+  cl_uint                         num_sema_objects,
+  const cl_semaphore_khr*         sema_objects,
+  const cl_semaphore_payload_khr* sema_payload_list,
+  cl_uint                         num_events_in_wait_list,
+  const cl_event*                 event_wait_list,
+  cl_event*                       event) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *
-clEnqueueSignalSemaphoresKHR_fn)(
-    cl_command_queue command_queue,
-    cl_uint num_sema_objects,
-    const cl_semaphore_khr* sema_objects,
-    const cl_semaphore_payload_khr* sema_payload_list,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clGetSemaphoreInfoKHR_fn)(
+  cl_semaphore_khr      sema_object,
+  cl_semaphore_info_khr param_name,
+  size_t                param_value_size,
+  void*                 param_value,
+  size_t*               param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *
-clGetSemaphoreInfoKHR_fn)(
-    cl_semaphore_khr sema_object,
-    cl_semaphore_info_khr param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clReleaseSemaphoreKHR_fn)(
+  cl_semaphore_khr sema_object) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *
-clReleaseSemaphoreKHR_fn)(
-    cl_semaphore_khr sema_object) CL_API_SUFFIX__VERSION_1_2;
-
-typedef cl_int (CL_API_CALL *
-clRetainSemaphoreKHR_fn)(
-    cl_semaphore_khr sema_object) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clRetainSemaphoreKHR_fn)(
+  cl_semaphore_khr sema_object) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_semaphore_khr CL_API_CALL
 clCreateSemaphoreWithPropertiesKHR(
-    cl_context context,
-    const cl_semaphore_properties_khr* sema_props,
-    cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+  cl_context                         context,
+  const cl_semaphore_properties_khr* sema_props,
+  cl_int*                            errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueWaitSemaphoresKHR(
-    cl_command_queue command_queue,
-    cl_uint num_sema_objects,
-    const cl_semaphore_khr* sema_objects,
-    const cl_semaphore_payload_khr* sema_payload_list,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueWaitSemaphoresKHR(cl_command_queue                command_queue,
+                           cl_uint                         num_sema_objects,
+                           const cl_semaphore_khr*         sema_objects,
+                           const cl_semaphore_payload_khr* sema_payload_list,
+                           cl_uint         num_events_in_wait_list,
+                           const cl_event* event_wait_list,
+                           cl_event*       event) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSignalSemaphoresKHR(
-    cl_command_queue command_queue,
-    cl_uint num_sema_objects,
-    const cl_semaphore_khr* sema_objects,
-    const cl_semaphore_payload_khr* sema_payload_list,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueSignalSemaphoresKHR(cl_command_queue                command_queue,
+                             cl_uint                         num_sema_objects,
+                             const cl_semaphore_khr*         sema_objects,
+                             const cl_semaphore_payload_khr* sema_payload_list,
+                             cl_uint         num_events_in_wait_list,
+                             const cl_event* event_wait_list,
+                             cl_event*       event) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetSemaphoreInfoKHR(
-    cl_semaphore_khr sema_object,
-    cl_semaphore_info_khr param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
+clGetSemaphoreInfoKHR(cl_semaphore_khr      sema_object,
+                      cl_semaphore_info_khr param_name,
+                      size_t                param_value_size,
+                      void*                 param_value,
+                      size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clReleaseSemaphoreKHR(
-    cl_semaphore_khr sema_object) CL_API_SUFFIX__VERSION_1_2;
+clReleaseSemaphoreKHR(cl_semaphore_khr sema_object) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clRetainSemaphoreKHR(
-    cl_semaphore_khr sema_object) CL_API_SUFFIX__VERSION_1_2;
+clRetainSemaphoreKHR(cl_semaphore_khr sema_object) CL_API_SUFFIX__VERSION_1_2;
 
 /**********************************
  * cl_arm_import_memory extension *
@@ -1545,22 +1491,22 @@ clRetainSemaphoreKHR(
 typedef intptr_t cl_import_properties_arm;
 
 /* Default and valid proporties name for cl_arm_import_memory */
-#define CL_IMPORT_TYPE_ARM                        0x40B2
+#define CL_IMPORT_TYPE_ARM                                0x40B2
 
 /* Host process memory type default value for CL_IMPORT_TYPE_ARM property */
-#define CL_IMPORT_TYPE_HOST_ARM                   0x40B3
+#define CL_IMPORT_TYPE_HOST_ARM                           0x40B3
 
 /* DMA BUF memory type value for CL_IMPORT_TYPE_ARM property */
-#define CL_IMPORT_TYPE_DMA_BUF_ARM                0x40B4
+#define CL_IMPORT_TYPE_DMA_BUF_ARM                        0x40B4
 
 /* Protected memory property */
-#define CL_IMPORT_TYPE_PROTECTED_ARM              0x40B5
+#define CL_IMPORT_TYPE_PROTECTED_ARM                      0x40B5
 
 /* Android hardware buffer type value for CL_IMPORT_TYPE_ARM property */
-#define CL_IMPORT_TYPE_ANDROID_HARDWARE_BUFFER_ARM 0x41E2
+#define CL_IMPORT_TYPE_ANDROID_HARDWARE_BUFFER_ARM        0x41E2
 
 /* Data consistency with host property */
-#define CL_IMPORT_DMA_BUF_DATA_CONSISTENCY_WITH_HOST_ARM 0x41E3
+#define CL_IMPORT_DMA_BUF_DATA_CONSISTENCY_WITH_HOST_ARM  0x41E3
 
 /* Index of plane in a multiplanar hardware buffer */
 #define CL_IMPORT_ANDROID_HARDWARE_BUFFER_PLANE_INDEX_ARM 0x41EF
@@ -1569,7 +1515,7 @@ typedef intptr_t cl_import_properties_arm;
 #define CL_IMPORT_ANDROID_HARDWARE_BUFFER_LAYER_INDEX_ARM 0x41F0
 
 /* Import memory size value to indicate a size for the whole buffer */
-#define CL_IMPORT_MEMORY_WHOLE_ALLOCATION_ARM SIZE_MAX
+#define CL_IMPORT_MEMORY_WHOLE_ALLOCATION_ARM             SIZE_MAX
 
 /* This extension adds a new function that allows for direct memory import into
  * OpenCL via the clImportMemoryARM function.
@@ -1581,127 +1527,126 @@ typedef intptr_t cl_import_properties_arm;
  * Types of memory supported for import are specified as additional extension
  * strings.
  *
- * This extension produces cl_mem allocations which are compatible with all other
- * users of cl_mem in the standard API.
+ * This extension produces cl_mem allocations which are compatible with all
+ * other users of cl_mem in the standard API.
  *
- * This extension maps pages with the same properties as the normal buffer creation
- * function clCreateBuffer.
+ * This extension maps pages with the same properties as the normal buffer
+ * creation function clCreateBuffer.
  */
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clImportMemoryARM( cl_context context,
-                   cl_mem_flags flags,
-                   const cl_import_properties_arm *properties,
-                   void *memory,
-                   size_t size,
-                   cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
-
+clImportMemoryARM(cl_context                      context,
+                  cl_mem_flags                    flags,
+                  const cl_import_properties_arm* properties,
+                  void*                           memory,
+                  size_t                          size,
+                  cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 /******************************************
  * cl_arm_shared_virtual_memory extension *
  ******************************************/
-#define cl_arm_shared_virtual_memory 1
+#define cl_arm_shared_virtual_memory                  1
 
 /* Used by clGetDeviceInfo */
-#define CL_DEVICE_SVM_CAPABILITIES_ARM                  0x40B6
+#define CL_DEVICE_SVM_CAPABILITIES_ARM                0x40B6
 
 /* Used by clGetMemObjectInfo */
-#define CL_MEM_USES_SVM_POINTER_ARM                     0x40B7
+#define CL_MEM_USES_SVM_POINTER_ARM                   0x40B7
 
 /* Used by clSetKernelExecInfoARM: */
-#define CL_KERNEL_EXEC_INFO_SVM_PTRS_ARM                0x40B8
-#define CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM_ARM   0x40B9
+#define CL_KERNEL_EXEC_INFO_SVM_PTRS_ARM              0x40B8
+#define CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM_ARM 0x40B9
 
 /* To be used by clGetEventInfo: */
-#define CL_COMMAND_SVM_FREE_ARM                         0x40BA
-#define CL_COMMAND_SVM_MEMCPY_ARM                       0x40BB
-#define CL_COMMAND_SVM_MEMFILL_ARM                      0x40BC
-#define CL_COMMAND_SVM_MAP_ARM                          0x40BD
-#define CL_COMMAND_SVM_UNMAP_ARM                        0x40BE
+#define CL_COMMAND_SVM_FREE_ARM                       0x40BA
+#define CL_COMMAND_SVM_MEMCPY_ARM                     0x40BB
+#define CL_COMMAND_SVM_MEMFILL_ARM                    0x40BC
+#define CL_COMMAND_SVM_MAP_ARM                        0x40BD
+#define CL_COMMAND_SVM_UNMAP_ARM                      0x40BE
 
-/* Flag values returned by clGetDeviceInfo with CL_DEVICE_SVM_CAPABILITIES_ARM as the param_name. */
-#define CL_DEVICE_SVM_COARSE_GRAIN_BUFFER_ARM           (1 << 0)
-#define CL_DEVICE_SVM_FINE_GRAIN_BUFFER_ARM             (1 << 1)
-#define CL_DEVICE_SVM_FINE_GRAIN_SYSTEM_ARM             (1 << 2)
-#define CL_DEVICE_SVM_ATOMICS_ARM                       (1 << 3)
+/* Flag values returned by clGetDeviceInfo with CL_DEVICE_SVM_CAPABILITIES_ARM
+ * as the param_name. */
+#define CL_DEVICE_SVM_COARSE_GRAIN_BUFFER_ARM         (1 << 0)
+#define CL_DEVICE_SVM_FINE_GRAIN_BUFFER_ARM           (1 << 1)
+#define CL_DEVICE_SVM_FINE_GRAIN_SYSTEM_ARM           (1 << 2)
+#define CL_DEVICE_SVM_ATOMICS_ARM                     (1 << 3)
 
 /* Flag values used by clSVMAllocARM: */
-#define CL_MEM_SVM_FINE_GRAIN_BUFFER_ARM                (1 << 10)
-#define CL_MEM_SVM_ATOMICS_ARM                          (1 << 11)
+#define CL_MEM_SVM_FINE_GRAIN_BUFFER_ARM              (1 << 10)
+#define CL_MEM_SVM_ATOMICS_ARM                        (1 << 11)
 
 typedef cl_bitfield cl_svm_mem_flags_arm;
 typedef cl_uint     cl_kernel_exec_info_arm;
 typedef cl_bitfield cl_device_svm_capabilities_arm;
 
-extern CL_API_ENTRY void * CL_API_CALL
-clSVMAllocARM(cl_context       context,
+extern CL_API_ENTRY void* CL_API_CALL
+clSVMAllocARM(cl_context           context,
               cl_svm_mem_flags_arm flags,
-              size_t           size,
-              cl_uint          alignment) CL_API_SUFFIX__VERSION_1_2;
+              size_t               size,
+              cl_uint              alignment) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY void CL_API_CALL
-clSVMFreeARM(cl_context        context,
-             void *            svm_pointer) CL_API_SUFFIX__VERSION_1_2;
+clSVMFreeARM(cl_context context, void* svm_pointer) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMFreeARM(cl_command_queue  command_queue,
-                    cl_uint           num_svm_pointers,
-                    void *            svm_pointers[],
-                    void (CL_CALLBACK * pfn_free_func)(cl_command_queue queue,
-                                                       cl_uint          num_svm_pointers,
-                                                       void *           svm_pointers[],
-                                                       void *           user_data),
-                    void *            user_data,
-                    cl_uint           num_events_in_wait_list,
-                    const cl_event *  event_wait_list,
-                    cl_event *        event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueSVMFreeARM(cl_command_queue command_queue,
+                    cl_uint          num_svm_pointers,
+                    void*            svm_pointers[],
+                    void(CL_CALLBACK* pfn_free_func)(cl_command_queue queue,
+                                                     cl_uint num_svm_pointers,
+                                                     void*   svm_pointers[],
+                                                     void*   user_data),
+                    void*           user_data,
+                    cl_uint         num_events_in_wait_list,
+                    const cl_event* event_wait_list,
+                    cl_event*       event) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMMemcpyARM(cl_command_queue  command_queue,
-                      cl_bool           blocking_copy,
-                      void *            dst_ptr,
-                      const void *      src_ptr,
-                      size_t            size,
-                      cl_uint           num_events_in_wait_list,
-                      const cl_event *  event_wait_list,
-                      cl_event *        event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueSVMMemcpyARM(cl_command_queue command_queue,
+                      cl_bool          blocking_copy,
+                      void*            dst_ptr,
+                      const void*      src_ptr,
+                      size_t           size,
+                      cl_uint          num_events_in_wait_list,
+                      const cl_event*  event_wait_list,
+                      cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMMemFillARM(cl_command_queue  command_queue,
-                       void *            svm_ptr,
-                       const void *      pattern,
-                       size_t            pattern_size,
-                       size_t            size,
-                       cl_uint           num_events_in_wait_list,
-                       const cl_event *  event_wait_list,
-                       cl_event *        event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueSVMMemFillARM(cl_command_queue command_queue,
+                       void*            svm_ptr,
+                       const void*      pattern,
+                       size_t           pattern_size,
+                       size_t           size,
+                       cl_uint          num_events_in_wait_list,
+                       const cl_event*  event_wait_list,
+                       cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMMapARM(cl_command_queue  command_queue,
-                   cl_bool           blocking_map,
-                   cl_map_flags      flags,
-                   void *            svm_ptr,
-                   size_t            size,
-                   cl_uint           num_events_in_wait_list,
-                   const cl_event *  event_wait_list,
-                   cl_event *        event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueSVMMapARM(cl_command_queue command_queue,
+                   cl_bool          blocking_map,
+                   cl_map_flags     flags,
+                   void*            svm_ptr,
+                   size_t           size,
+                   cl_uint          num_events_in_wait_list,
+                   const cl_event*  event_wait_list,
+                   cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueSVMUnmapARM(cl_command_queue  command_queue,
-                     void *            svm_ptr,
-                     cl_uint           num_events_in_wait_list,
-                     const cl_event *  event_wait_list,
-                     cl_event *        event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueSVMUnmapARM(cl_command_queue command_queue,
+                     void*            svm_ptr,
+                     cl_uint          num_events_in_wait_list,
+                     const cl_event*  event_wait_list,
+                     cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clSetKernelArgSVMPointerARM(cl_kernel    kernel,
-                            cl_uint      arg_index,
-                            const void * arg_value) CL_API_SUFFIX__VERSION_1_2;
+clSetKernelArgSVMPointerARM(cl_kernel   kernel,
+                            cl_uint     arg_index,
+                            const void* arg_value) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clSetKernelExecInfoARM(cl_kernel            kernel,
-                       cl_kernel_exec_info_arm  param_name,
-                       size_t               param_value_size,
-                       const void *         param_value) CL_API_SUFFIX__VERSION_1_2;
+clSetKernelExecInfoARM(cl_kernel               kernel,
+                       cl_kernel_exec_info_arm param_name,
+                       size_t                  param_value_size,
+                       const void* param_value) CL_API_SUFFIX__VERSION_1_2;
 
 /********************************
  * cl_arm_get_core_id extension *
@@ -1709,28 +1654,28 @@ clSetKernelExecInfoARM(cl_kernel            kernel,
 
 #ifdef CL_VERSION_1_2
 
-#define cl_arm_get_core_id 1
+#define cl_arm_get_core_id                   1
 
 /* Device info property for bitfield of cores present */
-#define CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM      0x40BF
+#define CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM 0x40BF
 
-#endif  /* CL_VERSION_1_2 */
+#endif /* CL_VERSION_1_2 */
 
 /*********************************
-* cl_arm_job_slot_selection
-*********************************/
+ * cl_arm_job_slot_selection
+ *********************************/
 
-#define cl_arm_job_slot_selection 1
+#define cl_arm_job_slot_selection  1
 
 /* cl_device_info */
-#define CL_DEVICE_JOB_SLOTS_ARM                   0x41E0
+#define CL_DEVICE_JOB_SLOTS_ARM    0x41E0
 
 /* cl_command_queue_properties */
-#define CL_QUEUE_JOB_SLOT_ARM                     0x41E1
+#define CL_QUEUE_JOB_SLOT_ARM      0x41E1
 
 /*********************************
-* cl_arm_scheduling_controls
-*********************************/
+ * cl_arm_scheduling_controls
+ *********************************/
 
 #define cl_arm_scheduling_controls 1
 
@@ -1739,13 +1684,13 @@ typedef cl_bitfield cl_device_scheduling_controls_capabilities_arm;
 /* cl_device_info */
 #define CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM          0x41E4
 
-#define CL_DEVICE_SCHEDULING_KERNEL_BATCHING_ARM               (1 << 0)
-#define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_ARM          (1 << 1)
-#define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_MODIFIER_ARM (1 << 2)
-#define CL_DEVICE_SCHEDULING_DEFERRED_FLUSH_ARM                (1 << 3)
-#define CL_DEVICE_SCHEDULING_REGISTER_ALLOCATION_ARM           (1 << 4)
-#define CL_DEVICE_SCHEDULING_WARP_THROTTLING_ARM               (1 << 5)
-#define CL_DEVICE_SCHEDULING_COMPUTE_UNIT_BATCH_QUEUE_SIZE_ARM (1 << 6)
+#define CL_DEVICE_SCHEDULING_KERNEL_BATCHING_ARM                (1 << 0)
+#define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_ARM           (1 << 1)
+#define CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_MODIFIER_ARM  (1 << 2)
+#define CL_DEVICE_SCHEDULING_DEFERRED_FLUSH_ARM                 (1 << 3)
+#define CL_DEVICE_SCHEDULING_REGISTER_ALLOCATION_ARM            (1 << 4)
+#define CL_DEVICE_SCHEDULING_WARP_THROTTLING_ARM                (1 << 5)
+#define CL_DEVICE_SCHEDULING_COMPUTE_UNIT_BATCH_QUEUE_SIZE_ARM  (1 << 6)
 
 #define CL_DEVICE_SUPPORTED_REGISTER_ALLOCATIONS_ARM            0x41EB
 #define CL_DEVICE_MAX_WARP_COUNT_ARM                            0x41EA
@@ -1764,389 +1709,389 @@ typedef cl_bitfield cl_device_scheduling_controls_capabilities_arm;
 #define CL_QUEUE_DEFERRED_FLUSH_ARM                             0x41EC
 
 /**************************************
-* cl_arm_controlled_kernel_termination
-***************************************/
+ * cl_arm_controlled_kernel_termination
+ ***************************************/
 
-#define cl_arm_controlled_kernel_termination 1
+#define cl_arm_controlled_kernel_termination                    1
 
 /* Error code to indicate kernel terminated with failure */
-#define CL_COMMAND_TERMINATED_ITSELF_WITH_FAILURE_ARM -1108
+#define CL_COMMAND_TERMINATED_ITSELF_WITH_FAILURE_ARM           -1108
 
 /* cl_device_info */
-#define CL_DEVICE_CONTROLLED_TERMINATION_CAPABILITIES_ARM 0x41EE
+#define CL_DEVICE_CONTROLLED_TERMINATION_CAPABILITIES_ARM       0x41EE
 
 /* Bit fields for controlled termination feature query */
 typedef cl_bitfield cl_device_controlled_termination_capabilities_arm;
 
 #define CL_DEVICE_CONTROLLED_TERMINATION_SUCCESS_ARM (1 << 0)
 #define CL_DEVICE_CONTROLLED_TERMINATION_FAILURE_ARM (1 << 1)
-#define CL_DEVICE_CONTROLLED_TERMINATION_QUERY_ARM (1 << 2)
+#define CL_DEVICE_CONTROLLED_TERMINATION_QUERY_ARM   (1 << 2)
 
 /* cl_event_info */
-#define CL_EVENT_COMMAND_TERMINATION_REASON_ARM 0x41ED
+#define CL_EVENT_COMMAND_TERMINATION_REASON_ARM      0x41ED
 
 /* Values returned for event termination reason query */
 typedef cl_uint cl_command_termination_reason_arm;
 
-#define CL_COMMAND_TERMINATION_COMPLETION_ARM  0
+#define CL_COMMAND_TERMINATION_COMPLETION_ARM         0
 #define CL_COMMAND_TERMINATION_CONTROLLED_SUCCESS_ARM 1
 #define CL_COMMAND_TERMINATION_CONTROLLED_FAILURE_ARM 2
-#define CL_COMMAND_TERMINATION_ERROR_ARM 3
+#define CL_COMMAND_TERMINATION_ERROR_ARM              3
 
 /*************************************
-* cl_arm_protected_memory_allocation *
-*************************************/
+ * cl_arm_protected_memory_allocation *
+ *************************************/
 
-#define cl_arm_protected_memory_allocation 1
+#define cl_arm_protected_memory_allocation            1
 
-#define CL_MEM_PROTECTED_ALLOC_ARM (1ULL << 36)
+#define CL_MEM_PROTECTED_ALLOC_ARM                    (1ULL << 36)
 
 /******************************************
-* cl_intel_exec_by_local_thread extension *
-******************************************/
+ * cl_intel_exec_by_local_thread extension *
+ ******************************************/
 
-#define cl_intel_exec_by_local_thread 1
+#define cl_intel_exec_by_local_thread                 1
 
-#define CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL      (((cl_bitfield)1) << 31)
+#define CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL       (((cl_bitfield)1) << 31)
 
 /***************************************************************
-* cl_intel_device_attribute_query
-***************************************************************/
+ * cl_intel_device_attribute_query
+ ***************************************************************/
 
-#define cl_intel_device_attribute_query 1
+#define cl_intel_device_attribute_query               1
 
-typedef cl_bitfield         cl_device_feature_capabilities_intel;
+typedef cl_bitfield cl_device_feature_capabilities_intel;
 
 /* cl_device_feature_capabilities_intel */
-#define CL_DEVICE_FEATURE_FLAG_DP4A_INTEL                   (1 << 0)
-#define CL_DEVICE_FEATURE_FLAG_DPAS_INTEL                   (1 << 1)
+#define CL_DEVICE_FEATURE_FLAG_DP4A_INTEL        (1 << 0)
+#define CL_DEVICE_FEATURE_FLAG_DPAS_INTEL        (1 << 1)
 
 /* cl_device_info */
-#define CL_DEVICE_IP_VERSION_INTEL                          0x4250
-#define CL_DEVICE_ID_INTEL                                  0x4251
-#define CL_DEVICE_NUM_SLICES_INTEL                          0x4252
-#define CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL            0x4253
-#define CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL               0x4254
-#define CL_DEVICE_NUM_THREADS_PER_EU_INTEL                  0x4255
-#define CL_DEVICE_FEATURE_CAPABILITIES_INTEL                0x4256
+#define CL_DEVICE_IP_VERSION_INTEL               0x4250
+#define CL_DEVICE_ID_INTEL                       0x4251
+#define CL_DEVICE_NUM_SLICES_INTEL               0x4252
+#define CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL 0x4253
+#define CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL    0x4254
+#define CL_DEVICE_NUM_THREADS_PER_EU_INTEL       0x4255
+#define CL_DEVICE_FEATURE_CAPABILITIES_INTEL     0x4256
 
 /***********************************************
-* cl_intel_device_partition_by_names extension *
-************************************************/
+ * cl_intel_device_partition_by_names extension *
+ ************************************************/
 
-#define cl_intel_device_partition_by_names 1
+#define cl_intel_device_partition_by_names       1
 
-#define CL_DEVICE_PARTITION_BY_NAMES_INTEL          0x4052
-#define CL_PARTITION_BY_NAMES_LIST_END_INTEL        -1
+#define CL_DEVICE_PARTITION_BY_NAMES_INTEL       0x4052
+#define CL_PARTITION_BY_NAMES_LIST_END_INTEL     -1
 
 /************************************************
-* cl_intel_accelerator extension                *
-* cl_intel_motion_estimation extension          *
-* cl_intel_advanced_motion_estimation extension *
-*************************************************/
+ * cl_intel_accelerator extension                *
+ * cl_intel_motion_estimation extension          *
+ * cl_intel_advanced_motion_estimation extension *
+ *************************************************/
 
-#define cl_intel_accelerator 1
-#define cl_intel_motion_estimation 1
-#define cl_intel_advanced_motion_estimation 1
+#define cl_intel_accelerator                     1
+#define cl_intel_motion_estimation               1
+#define cl_intel_advanced_motion_estimation      1
 
 typedef struct _cl_accelerator_intel* cl_accelerator_intel;
-typedef cl_uint cl_accelerator_type_intel;
-typedef cl_uint cl_accelerator_info_intel;
+typedef cl_uint                       cl_accelerator_type_intel;
+typedef cl_uint                       cl_accelerator_info_intel;
 
-typedef struct _cl_motion_estimation_desc_intel {
-    cl_uint mb_block_type;
-    cl_uint subpixel_mode;
-    cl_uint sad_adjust_mode;
-    cl_uint search_path_type;
+typedef struct _cl_motion_estimation_desc_intel
+{
+  cl_uint mb_block_type;
+  cl_uint subpixel_mode;
+  cl_uint sad_adjust_mode;
+  cl_uint search_path_type;
 } cl_motion_estimation_desc_intel;
 
 /* error codes */
-#define CL_INVALID_ACCELERATOR_INTEL                              -1094
-#define CL_INVALID_ACCELERATOR_TYPE_INTEL                         -1095
-#define CL_INVALID_ACCELERATOR_DESCRIPTOR_INTEL                   -1096
-#define CL_ACCELERATOR_TYPE_NOT_SUPPORTED_INTEL                   -1097
+#define CL_INVALID_ACCELERATOR_INTEL                        -1094
+#define CL_INVALID_ACCELERATOR_TYPE_INTEL                   -1095
+#define CL_INVALID_ACCELERATOR_DESCRIPTOR_INTEL             -1096
+#define CL_ACCELERATOR_TYPE_NOT_SUPPORTED_INTEL             -1097
 
 /* cl_accelerator_type_intel */
-#define CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL               0x0
+#define CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL         0x0
 
 /* cl_accelerator_info_intel */
-#define CL_ACCELERATOR_DESCRIPTOR_INTEL                           0x4090
-#define CL_ACCELERATOR_REFERENCE_COUNT_INTEL                      0x4091
-#define CL_ACCELERATOR_CONTEXT_INTEL                              0x4092
-#define CL_ACCELERATOR_TYPE_INTEL                                 0x4093
+#define CL_ACCELERATOR_DESCRIPTOR_INTEL                     0x4090
+#define CL_ACCELERATOR_REFERENCE_COUNT_INTEL                0x4091
+#define CL_ACCELERATOR_CONTEXT_INTEL                        0x4092
+#define CL_ACCELERATOR_TYPE_INTEL                           0x4093
 
 /* cl_motion_detect_desc_intel flags */
-#define CL_ME_MB_TYPE_16x16_INTEL                                 0x0
-#define CL_ME_MB_TYPE_8x8_INTEL                                   0x1
-#define CL_ME_MB_TYPE_4x4_INTEL                                   0x2
+#define CL_ME_MB_TYPE_16x16_INTEL                           0x0
+#define CL_ME_MB_TYPE_8x8_INTEL                             0x1
+#define CL_ME_MB_TYPE_4x4_INTEL                             0x2
 
-#define CL_ME_SUBPIXEL_MODE_INTEGER_INTEL                         0x0
-#define CL_ME_SUBPIXEL_MODE_HPEL_INTEL                            0x1
-#define CL_ME_SUBPIXEL_MODE_QPEL_INTEL                            0x2
+#define CL_ME_SUBPIXEL_MODE_INTEGER_INTEL                   0x0
+#define CL_ME_SUBPIXEL_MODE_HPEL_INTEL                      0x1
+#define CL_ME_SUBPIXEL_MODE_QPEL_INTEL                      0x2
 
-#define CL_ME_SAD_ADJUST_MODE_NONE_INTEL                          0x0
-#define CL_ME_SAD_ADJUST_MODE_HAAR_INTEL                          0x1
+#define CL_ME_SAD_ADJUST_MODE_NONE_INTEL                    0x0
+#define CL_ME_SAD_ADJUST_MODE_HAAR_INTEL                    0x1
 
-#define CL_ME_SEARCH_PATH_RADIUS_2_2_INTEL                        0x0
-#define CL_ME_SEARCH_PATH_RADIUS_4_4_INTEL                        0x1
-#define CL_ME_SEARCH_PATH_RADIUS_16_12_INTEL                      0x5
+#define CL_ME_SEARCH_PATH_RADIUS_2_2_INTEL                  0x0
+#define CL_ME_SEARCH_PATH_RADIUS_4_4_INTEL                  0x1
+#define CL_ME_SEARCH_PATH_RADIUS_16_12_INTEL                0x5
 
-#define CL_ME_SKIP_BLOCK_TYPE_16x16_INTEL                         0x0
-#define CL_ME_CHROMA_INTRA_PREDICT_ENABLED_INTEL                  0x1
-#define CL_ME_LUMA_INTRA_PREDICT_ENABLED_INTEL                    0x2
-#define CL_ME_SKIP_BLOCK_TYPE_8x8_INTEL                           0x4
+#define CL_ME_SKIP_BLOCK_TYPE_16x16_INTEL                   0x0
+#define CL_ME_CHROMA_INTRA_PREDICT_ENABLED_INTEL            0x1
+#define CL_ME_LUMA_INTRA_PREDICT_ENABLED_INTEL              0x2
+#define CL_ME_SKIP_BLOCK_TYPE_8x8_INTEL                     0x4
 
-#define CL_ME_FORWARD_INPUT_MODE_INTEL                            0x1
-#define CL_ME_BACKWARD_INPUT_MODE_INTEL                           0x2
-#define CL_ME_BIDIRECTION_INPUT_MODE_INTEL                        0x3
+#define CL_ME_FORWARD_INPUT_MODE_INTEL                      0x1
+#define CL_ME_BACKWARD_INPUT_MODE_INTEL                     0x2
+#define CL_ME_BIDIRECTION_INPUT_MODE_INTEL                  0x3
 
-#define CL_ME_BIDIR_WEIGHT_QUARTER_INTEL                          16
-#define CL_ME_BIDIR_WEIGHT_THIRD_INTEL                            21
-#define CL_ME_BIDIR_WEIGHT_HALF_INTEL                             32
-#define CL_ME_BIDIR_WEIGHT_TWO_THIRD_INTEL                        43
-#define CL_ME_BIDIR_WEIGHT_THREE_QUARTER_INTEL                    48
+#define CL_ME_BIDIR_WEIGHT_QUARTER_INTEL                    16
+#define CL_ME_BIDIR_WEIGHT_THIRD_INTEL                      21
+#define CL_ME_BIDIR_WEIGHT_HALF_INTEL                       32
+#define CL_ME_BIDIR_WEIGHT_TWO_THIRD_INTEL                  43
+#define CL_ME_BIDIR_WEIGHT_THREE_QUARTER_INTEL              48
 
-#define CL_ME_COST_PENALTY_NONE_INTEL                             0x0
-#define CL_ME_COST_PENALTY_LOW_INTEL                              0x1
-#define CL_ME_COST_PENALTY_NORMAL_INTEL                           0x2
-#define CL_ME_COST_PENALTY_HIGH_INTEL                             0x3
+#define CL_ME_COST_PENALTY_NONE_INTEL                       0x0
+#define CL_ME_COST_PENALTY_LOW_INTEL                        0x1
+#define CL_ME_COST_PENALTY_NORMAL_INTEL                     0x2
+#define CL_ME_COST_PENALTY_HIGH_INTEL                       0x3
 
-#define CL_ME_COST_PRECISION_QPEL_INTEL                           0x0
-#define CL_ME_COST_PRECISION_HPEL_INTEL                           0x1
-#define CL_ME_COST_PRECISION_PEL_INTEL                            0x2
-#define CL_ME_COST_PRECISION_DPEL_INTEL                           0x3
+#define CL_ME_COST_PRECISION_QPEL_INTEL                     0x0
+#define CL_ME_COST_PRECISION_HPEL_INTEL                     0x1
+#define CL_ME_COST_PRECISION_PEL_INTEL                      0x2
+#define CL_ME_COST_PRECISION_DPEL_INTEL                     0x3
 
-#define CL_ME_LUMA_PREDICTOR_MODE_VERTICAL_INTEL                  0x0
-#define CL_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_INTEL                0x1
-#define CL_ME_LUMA_PREDICTOR_MODE_DC_INTEL                        0x2
-#define CL_ME_LUMA_PREDICTOR_MODE_DIAGONAL_DOWN_LEFT_INTEL        0x3
+#define CL_ME_LUMA_PREDICTOR_MODE_VERTICAL_INTEL            0x0
+#define CL_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_INTEL          0x1
+#define CL_ME_LUMA_PREDICTOR_MODE_DC_INTEL                  0x2
+#define CL_ME_LUMA_PREDICTOR_MODE_DIAGONAL_DOWN_LEFT_INTEL  0x3
 
-#define CL_ME_LUMA_PREDICTOR_MODE_DIAGONAL_DOWN_RIGHT_INTEL       0x4
-#define CL_ME_LUMA_PREDICTOR_MODE_PLANE_INTEL                     0x4
-#define CL_ME_LUMA_PREDICTOR_MODE_VERTICAL_RIGHT_INTEL            0x5
-#define CL_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_DOWN_INTEL           0x6
-#define CL_ME_LUMA_PREDICTOR_MODE_VERTICAL_LEFT_INTEL             0x7
-#define CL_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_UP_INTEL             0x8
+#define CL_ME_LUMA_PREDICTOR_MODE_DIAGONAL_DOWN_RIGHT_INTEL 0x4
+#define CL_ME_LUMA_PREDICTOR_MODE_PLANE_INTEL               0x4
+#define CL_ME_LUMA_PREDICTOR_MODE_VERTICAL_RIGHT_INTEL      0x5
+#define CL_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_DOWN_INTEL     0x6
+#define CL_ME_LUMA_PREDICTOR_MODE_VERTICAL_LEFT_INTEL       0x7
+#define CL_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_UP_INTEL       0x8
 
-#define CL_ME_CHROMA_PREDICTOR_MODE_DC_INTEL                      0x0
-#define CL_ME_CHROMA_PREDICTOR_MODE_HORIZONTAL_INTEL              0x1
-#define CL_ME_CHROMA_PREDICTOR_MODE_VERTICAL_INTEL                0x2
-#define CL_ME_CHROMA_PREDICTOR_MODE_PLANE_INTEL                   0x3
+#define CL_ME_CHROMA_PREDICTOR_MODE_DC_INTEL                0x0
+#define CL_ME_CHROMA_PREDICTOR_MODE_HORIZONTAL_INTEL        0x1
+#define CL_ME_CHROMA_PREDICTOR_MODE_VERTICAL_INTEL          0x2
+#define CL_ME_CHROMA_PREDICTOR_MODE_PLANE_INTEL             0x3
 
 /* cl_device_info */
-#define CL_DEVICE_ME_VERSION_INTEL                                0x407E
+#define CL_DEVICE_ME_VERSION_INTEL                          0x407E
 
-#define CL_ME_VERSION_LEGACY_INTEL                                0x0
-#define CL_ME_VERSION_ADVANCED_VER_1_INTEL                        0x1
-#define CL_ME_VERSION_ADVANCED_VER_2_INTEL                        0x2
+#define CL_ME_VERSION_LEGACY_INTEL                          0x0
+#define CL_ME_VERSION_ADVANCED_VER_1_INTEL                  0x1
+#define CL_ME_VERSION_ADVANCED_VER_2_INTEL                  0x2
 
 extern CL_API_ENTRY cl_accelerator_intel CL_API_CALL
-clCreateAcceleratorINTEL(
-    cl_context                   context,
-    cl_accelerator_type_intel    accelerator_type,
-    size_t                       descriptor_size,
-    const void*                  descriptor,
-    cl_int*                      errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+clCreateAcceleratorINTEL(cl_context                context,
+                         cl_accelerator_type_intel accelerator_type,
+                         size_t                    descriptor_size,
+                         const void*               descriptor,
+                         cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_accelerator_intel (CL_API_CALL *clCreateAcceleratorINTEL_fn)(
-    cl_context                   context,
-    cl_accelerator_type_intel    accelerator_type,
-    size_t                       descriptor_size,
-    const void*                  descriptor,
-    cl_int*                      errcode_ret) CL_API_SUFFIX__VERSION_1_2;
-
-extern CL_API_ENTRY cl_int CL_API_CALL
-clGetAcceleratorInfoINTEL(
-    cl_accelerator_intel         accelerator,
-    cl_accelerator_info_intel    param_name,
-    size_t                       param_value_size,
-    void*                        param_value,
-    size_t*                      param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
-
-typedef cl_int (CL_API_CALL *clGetAcceleratorInfoINTEL_fn)(
-    cl_accelerator_intel         accelerator,
-    cl_accelerator_info_intel    param_name,
-    size_t                       param_value_size,
-    void*                        param_value,
-    size_t*                      param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_accelerator_intel(CL_API_CALL* clCreateAcceleratorINTEL_fn)(
+  cl_context                context,
+  cl_accelerator_type_intel accelerator_type,
+  size_t                    descriptor_size,
+  const void*               descriptor,
+  cl_int*                   errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clRetainAcceleratorINTEL(
-    cl_accelerator_intel         accelerator) CL_API_SUFFIX__VERSION_1_2;
+clGetAcceleratorInfoINTEL(cl_accelerator_intel      accelerator,
+                          cl_accelerator_info_intel param_name,
+                          size_t                    param_value_size,
+                          void*                     param_value,
+                          size_t*                   param_value_size_ret)
+  CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *clRetainAcceleratorINTEL_fn)(
-    cl_accelerator_intel         accelerator) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clGetAcceleratorInfoINTEL_fn)(
+  cl_accelerator_intel      accelerator,
+  cl_accelerator_info_intel param_name,
+  size_t                    param_value_size,
+  void*                     param_value,
+  size_t*                   param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clReleaseAcceleratorINTEL(
-    cl_accelerator_intel         accelerator) CL_API_SUFFIX__VERSION_1_2;
+clRetainAcceleratorINTEL(cl_accelerator_intel accelerator)
+  CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *clReleaseAcceleratorINTEL_fn)(
-    cl_accelerator_intel         accelerator) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clRetainAcceleratorINTEL_fn)(
+  cl_accelerator_intel accelerator) CL_API_SUFFIX__VERSION_1_2;
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clReleaseAcceleratorINTEL(cl_accelerator_intel accelerator)
+  CL_API_SUFFIX__VERSION_1_2;
+
+typedef cl_int(CL_API_CALL* clReleaseAcceleratorINTEL_fn)(
+  cl_accelerator_intel accelerator) CL_API_SUFFIX__VERSION_1_2;
 
 /******************************************
-* cl_intel_simultaneous_sharing extension *
-*******************************************/
+ * cl_intel_simultaneous_sharing extension *
+ *******************************************/
 
-#define cl_intel_simultaneous_sharing 1
+#define cl_intel_simultaneous_sharing             1
 
-#define CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL            0x4104
-#define CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL        0x4105
+#define CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL     0x4104
+#define CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL 0x4105
 
 /***********************************
-* cl_intel_egl_image_yuv extension *
-************************************/
+ * cl_intel_egl_image_yuv extension *
+ ************************************/
 
-#define cl_intel_egl_image_yuv 1
+#define cl_intel_egl_image_yuv                    1
 
-#define CL_EGL_YUV_PLANE_INTEL                           0x4107
+#define CL_EGL_YUV_PLANE_INTEL                    0x4107
 
 /********************************
-* cl_intel_packed_yuv extension *
-*********************************/
+ * cl_intel_packed_yuv extension *
+ *********************************/
 
-#define cl_intel_packed_yuv 1
+#define cl_intel_packed_yuv                       1
 
-#define CL_YUYV_INTEL                                    0x4076
-#define CL_UYVY_INTEL                                    0x4077
-#define CL_YVYU_INTEL                                    0x4078
-#define CL_VYUY_INTEL                                    0x4079
+#define CL_YUYV_INTEL                             0x4076
+#define CL_UYVY_INTEL                             0x4077
+#define CL_YVYU_INTEL                             0x4078
+#define CL_VYUY_INTEL                             0x4079
 
 /********************************************
-* cl_intel_required_subgroup_size extension *
-*********************************************/
+ * cl_intel_required_subgroup_size extension *
+ *********************************************/
 
-#define cl_intel_required_subgroup_size 1
+#define cl_intel_required_subgroup_size           1
 
-#define CL_DEVICE_SUB_GROUP_SIZES_INTEL                  0x4108
-#define CL_KERNEL_SPILL_MEM_SIZE_INTEL                   0x4109
-#define CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL           0x410A
+#define CL_DEVICE_SUB_GROUP_SIZES_INTEL           0x4108
+#define CL_KERNEL_SPILL_MEM_SIZE_INTEL            0x4109
+#define CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL    0x410A
 
 /****************************************
-* cl_intel_driver_diagnostics extension *
-*****************************************/
+ * cl_intel_driver_diagnostics extension *
+ *****************************************/
 
-#define cl_intel_driver_diagnostics 1
+#define cl_intel_driver_diagnostics               1
 
 typedef cl_uint cl_diagnostics_verbose_level;
 
-#define CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL                0x4106
+#define CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL                       0x4106
 
-#define CL_CONTEXT_DIAGNOSTICS_LEVEL_ALL_INTEL           ( 0xff )
-#define CL_CONTEXT_DIAGNOSTICS_LEVEL_GOOD_INTEL          ( 1 )
-#define CL_CONTEXT_DIAGNOSTICS_LEVEL_BAD_INTEL           ( 1 << 1 )
-#define CL_CONTEXT_DIAGNOSTICS_LEVEL_NEUTRAL_INTEL       ( 1 << 2 )
+#define CL_CONTEXT_DIAGNOSTICS_LEVEL_ALL_INTEL                  (0xff)
+#define CL_CONTEXT_DIAGNOSTICS_LEVEL_GOOD_INTEL                 (1)
+#define CL_CONTEXT_DIAGNOSTICS_LEVEL_BAD_INTEL                  (1 << 1)
+#define CL_CONTEXT_DIAGNOSTICS_LEVEL_NEUTRAL_INTEL              (1 << 2)
 
 /********************************
-* cl_intel_planar_yuv extension *
-*********************************/
+ * cl_intel_planar_yuv extension *
+ *********************************/
 
-#define CL_NV12_INTEL                                       0x410E
+#define CL_NV12_INTEL                                           0x410E
 
-#define CL_MEM_NO_ACCESS_INTEL                              ( 1 << 24 )
-#define CL_MEM_ACCESS_FLAGS_UNRESTRICTED_INTEL              ( 1 << 25 )
+#define CL_MEM_NO_ACCESS_INTEL                                  (1 << 24)
+#define CL_MEM_ACCESS_FLAGS_UNRESTRICTED_INTEL                  (1 << 25)
 
-#define CL_DEVICE_PLANAR_YUV_MAX_WIDTH_INTEL                0x417E
-#define CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL               0x417F
+#define CL_DEVICE_PLANAR_YUV_MAX_WIDTH_INTEL                    0x417E
+#define CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL                   0x417F
 
 /*******************************************************
-* cl_intel_device_side_avc_motion_estimation extension *
-********************************************************/
+ * cl_intel_device_side_avc_motion_estimation extension *
+ ********************************************************/
 
-#define CL_DEVICE_AVC_ME_VERSION_INTEL                      0x410B
-#define CL_DEVICE_AVC_ME_SUPPORTS_TEXTURE_SAMPLER_USE_INTEL 0x410C
-#define CL_DEVICE_AVC_ME_SUPPORTS_PREEMPTION_INTEL          0x410D
+#define CL_DEVICE_AVC_ME_VERSION_INTEL                          0x410B
+#define CL_DEVICE_AVC_ME_SUPPORTS_TEXTURE_SAMPLER_USE_INTEL     0x410C
+#define CL_DEVICE_AVC_ME_SUPPORTS_PREEMPTION_INTEL              0x410D
 
-#define CL_AVC_ME_VERSION_0_INTEL                           0x0   /* No support. */
-#define CL_AVC_ME_VERSION_1_INTEL                           0x1   /* First supported version. */
+#define CL_AVC_ME_VERSION_0_INTEL                               0x0 /* No support. */
+#define CL_AVC_ME_VERSION_1_INTEL                               0x1 /* First supported version. */
 
-#define CL_AVC_ME_MAJOR_16x16_INTEL                         0x0
-#define CL_AVC_ME_MAJOR_16x8_INTEL                          0x1
-#define CL_AVC_ME_MAJOR_8x16_INTEL                          0x2
-#define CL_AVC_ME_MAJOR_8x8_INTEL                           0x3
+#define CL_AVC_ME_MAJOR_16x16_INTEL                             0x0
+#define CL_AVC_ME_MAJOR_16x8_INTEL                              0x1
+#define CL_AVC_ME_MAJOR_8x16_INTEL                              0x2
+#define CL_AVC_ME_MAJOR_8x8_INTEL                               0x3
 
-#define CL_AVC_ME_MINOR_8x8_INTEL                           0x0
-#define CL_AVC_ME_MINOR_8x4_INTEL                           0x1
-#define CL_AVC_ME_MINOR_4x8_INTEL                           0x2
-#define CL_AVC_ME_MINOR_4x4_INTEL                           0x3
+#define CL_AVC_ME_MINOR_8x8_INTEL                               0x0
+#define CL_AVC_ME_MINOR_8x4_INTEL                               0x1
+#define CL_AVC_ME_MINOR_4x8_INTEL                               0x2
+#define CL_AVC_ME_MINOR_4x4_INTEL                               0x3
 
-#define CL_AVC_ME_MAJOR_FORWARD_INTEL                       0x0
-#define CL_AVC_ME_MAJOR_BACKWARD_INTEL                      0x1
-#define CL_AVC_ME_MAJOR_BIDIRECTIONAL_INTEL                 0x2
+#define CL_AVC_ME_MAJOR_FORWARD_INTEL                           0x0
+#define CL_AVC_ME_MAJOR_BACKWARD_INTEL                          0x1
+#define CL_AVC_ME_MAJOR_BIDIRECTIONAL_INTEL                     0x2
 
-#define CL_AVC_ME_PARTITION_MASK_ALL_INTEL                  0x0
-#define CL_AVC_ME_PARTITION_MASK_16x16_INTEL                0x7E
-#define CL_AVC_ME_PARTITION_MASK_16x8_INTEL                 0x7D
-#define CL_AVC_ME_PARTITION_MASK_8x16_INTEL                 0x7B
-#define CL_AVC_ME_PARTITION_MASK_8x8_INTEL                  0x77
-#define CL_AVC_ME_PARTITION_MASK_8x4_INTEL                  0x6F
-#define CL_AVC_ME_PARTITION_MASK_4x8_INTEL                  0x5F
-#define CL_AVC_ME_PARTITION_MASK_4x4_INTEL                  0x3F
+#define CL_AVC_ME_PARTITION_MASK_ALL_INTEL                      0x0
+#define CL_AVC_ME_PARTITION_MASK_16x16_INTEL                    0x7E
+#define CL_AVC_ME_PARTITION_MASK_16x8_INTEL                     0x7D
+#define CL_AVC_ME_PARTITION_MASK_8x16_INTEL                     0x7B
+#define CL_AVC_ME_PARTITION_MASK_8x8_INTEL                      0x77
+#define CL_AVC_ME_PARTITION_MASK_8x4_INTEL                      0x6F
+#define CL_AVC_ME_PARTITION_MASK_4x8_INTEL                      0x5F
+#define CL_AVC_ME_PARTITION_MASK_4x4_INTEL                      0x3F
 
-#define CL_AVC_ME_SEARCH_WINDOW_EXHAUSTIVE_INTEL            0x0
-#define CL_AVC_ME_SEARCH_WINDOW_SMALL_INTEL                 0x1
-#define CL_AVC_ME_SEARCH_WINDOW_TINY_INTEL                  0x2
-#define CL_AVC_ME_SEARCH_WINDOW_EXTRA_TINY_INTEL            0x3
-#define CL_AVC_ME_SEARCH_WINDOW_DIAMOND_INTEL               0x4
-#define CL_AVC_ME_SEARCH_WINDOW_LARGE_DIAMOND_INTEL         0x5
-#define CL_AVC_ME_SEARCH_WINDOW_RESERVED0_INTEL             0x6
-#define CL_AVC_ME_SEARCH_WINDOW_RESERVED1_INTEL             0x7
-#define CL_AVC_ME_SEARCH_WINDOW_CUSTOM_INTEL                0x8
-#define CL_AVC_ME_SEARCH_WINDOW_16x12_RADIUS_INTEL          0x9
-#define CL_AVC_ME_SEARCH_WINDOW_4x4_RADIUS_INTEL            0x2
-#define CL_AVC_ME_SEARCH_WINDOW_2x2_RADIUS_INTEL            0xa
+#define CL_AVC_ME_SEARCH_WINDOW_EXHAUSTIVE_INTEL                0x0
+#define CL_AVC_ME_SEARCH_WINDOW_SMALL_INTEL                     0x1
+#define CL_AVC_ME_SEARCH_WINDOW_TINY_INTEL                      0x2
+#define CL_AVC_ME_SEARCH_WINDOW_EXTRA_TINY_INTEL                0x3
+#define CL_AVC_ME_SEARCH_WINDOW_DIAMOND_INTEL                   0x4
+#define CL_AVC_ME_SEARCH_WINDOW_LARGE_DIAMOND_INTEL             0x5
+#define CL_AVC_ME_SEARCH_WINDOW_RESERVED0_INTEL                 0x6
+#define CL_AVC_ME_SEARCH_WINDOW_RESERVED1_INTEL                 0x7
+#define CL_AVC_ME_SEARCH_WINDOW_CUSTOM_INTEL                    0x8
+#define CL_AVC_ME_SEARCH_WINDOW_16x12_RADIUS_INTEL              0x9
+#define CL_AVC_ME_SEARCH_WINDOW_4x4_RADIUS_INTEL                0x2
+#define CL_AVC_ME_SEARCH_WINDOW_2x2_RADIUS_INTEL                0xa
 
-#define CL_AVC_ME_SAD_ADJUST_MODE_NONE_INTEL                0x0
-#define CL_AVC_ME_SAD_ADJUST_MODE_HAAR_INTEL                0x2
+#define CL_AVC_ME_SAD_ADJUST_MODE_NONE_INTEL                    0x0
+#define CL_AVC_ME_SAD_ADJUST_MODE_HAAR_INTEL                    0x2
 
-#define CL_AVC_ME_SUBPIXEL_MODE_INTEGER_INTEL               0x0
-#define CL_AVC_ME_SUBPIXEL_MODE_HPEL_INTEL                  0x1
-#define CL_AVC_ME_SUBPIXEL_MODE_QPEL_INTEL                  0x3
+#define CL_AVC_ME_SUBPIXEL_MODE_INTEGER_INTEL                   0x0
+#define CL_AVC_ME_SUBPIXEL_MODE_HPEL_INTEL                      0x1
+#define CL_AVC_ME_SUBPIXEL_MODE_QPEL_INTEL                      0x3
 
-#define CL_AVC_ME_COST_PRECISION_QPEL_INTEL                 0x0
-#define CL_AVC_ME_COST_PRECISION_HPEL_INTEL                 0x1
-#define CL_AVC_ME_COST_PRECISION_PEL_INTEL                  0x2
-#define CL_AVC_ME_COST_PRECISION_DPEL_INTEL                 0x3
+#define CL_AVC_ME_COST_PRECISION_QPEL_INTEL                     0x0
+#define CL_AVC_ME_COST_PRECISION_HPEL_INTEL                     0x1
+#define CL_AVC_ME_COST_PRECISION_PEL_INTEL                      0x2
+#define CL_AVC_ME_COST_PRECISION_DPEL_INTEL                     0x3
 
-#define CL_AVC_ME_BIDIR_WEIGHT_QUARTER_INTEL                0x10
-#define CL_AVC_ME_BIDIR_WEIGHT_THIRD_INTEL                  0x15
-#define CL_AVC_ME_BIDIR_WEIGHT_HALF_INTEL                   0x20
-#define CL_AVC_ME_BIDIR_WEIGHT_TWO_THIRD_INTEL              0x2B
-#define CL_AVC_ME_BIDIR_WEIGHT_THREE_QUARTER_INTEL          0x30
+#define CL_AVC_ME_BIDIR_WEIGHT_QUARTER_INTEL                    0x10
+#define CL_AVC_ME_BIDIR_WEIGHT_THIRD_INTEL                      0x15
+#define CL_AVC_ME_BIDIR_WEIGHT_HALF_INTEL                       0x20
+#define CL_AVC_ME_BIDIR_WEIGHT_TWO_THIRD_INTEL                  0x2B
+#define CL_AVC_ME_BIDIR_WEIGHT_THREE_QUARTER_INTEL              0x30
 
-#define CL_AVC_ME_BORDER_REACHED_LEFT_INTEL                 0x0
-#define CL_AVC_ME_BORDER_REACHED_RIGHT_INTEL                0x2
-#define CL_AVC_ME_BORDER_REACHED_TOP_INTEL                  0x4
-#define CL_AVC_ME_BORDER_REACHED_BOTTOM_INTEL               0x8
+#define CL_AVC_ME_BORDER_REACHED_LEFT_INTEL                     0x0
+#define CL_AVC_ME_BORDER_REACHED_RIGHT_INTEL                    0x2
+#define CL_AVC_ME_BORDER_REACHED_TOP_INTEL                      0x4
+#define CL_AVC_ME_BORDER_REACHED_BOTTOM_INTEL                   0x8
 
-#define CL_AVC_ME_SKIP_BLOCK_PARTITION_16x16_INTEL          0x0
-#define CL_AVC_ME_SKIP_BLOCK_PARTITION_8x8_INTEL            0x4000
+#define CL_AVC_ME_SKIP_BLOCK_PARTITION_16x16_INTEL              0x0
+#define CL_AVC_ME_SKIP_BLOCK_PARTITION_8x8_INTEL                0x4000
 
-#define CL_AVC_ME_SKIP_BLOCK_16x16_FORWARD_ENABLE_INTEL     ( 0x1 << 24 )
-#define CL_AVC_ME_SKIP_BLOCK_16x16_BACKWARD_ENABLE_INTEL    ( 0x2 << 24 )
-#define CL_AVC_ME_SKIP_BLOCK_16x16_DUAL_ENABLE_INTEL        ( 0x3 << 24 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_FORWARD_ENABLE_INTEL       ( 0x55 << 24 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_BACKWARD_ENABLE_INTEL      ( 0xAA << 24 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_DUAL_ENABLE_INTEL          ( 0xFF << 24 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_0_FORWARD_ENABLE_INTEL     ( 0x1 << 24 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_0_BACKWARD_ENABLE_INTEL    ( 0x2 << 24 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_1_FORWARD_ENABLE_INTEL     ( 0x1 << 26 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_1_BACKWARD_ENABLE_INTEL    ( 0x2 << 26 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_2_FORWARD_ENABLE_INTEL     ( 0x1 << 28 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_2_BACKWARD_ENABLE_INTEL    ( 0x2 << 28 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_3_FORWARD_ENABLE_INTEL     ( 0x1 << 30 )
-#define CL_AVC_ME_SKIP_BLOCK_8x8_3_BACKWARD_ENABLE_INTEL    ( 0x2 << 30 )
+#define CL_AVC_ME_SKIP_BLOCK_16x16_FORWARD_ENABLE_INTEL         (0x1 << 24)
+#define CL_AVC_ME_SKIP_BLOCK_16x16_BACKWARD_ENABLE_INTEL        (0x2 << 24)
+#define CL_AVC_ME_SKIP_BLOCK_16x16_DUAL_ENABLE_INTEL            (0x3 << 24)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_FORWARD_ENABLE_INTEL           (0x55 << 24)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_BACKWARD_ENABLE_INTEL          (0xAA << 24)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_DUAL_ENABLE_INTEL              (0xFF << 24)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_0_FORWARD_ENABLE_INTEL         (0x1 << 24)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_0_BACKWARD_ENABLE_INTEL        (0x2 << 24)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_1_FORWARD_ENABLE_INTEL         (0x1 << 26)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_1_BACKWARD_ENABLE_INTEL        (0x2 << 26)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_2_FORWARD_ENABLE_INTEL         (0x1 << 28)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_2_BACKWARD_ENABLE_INTEL        (0x2 << 28)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_3_FORWARD_ENABLE_INTEL         (0x1 << 30)
+#define CL_AVC_ME_SKIP_BLOCK_8x8_3_BACKWARD_ENABLE_INTEL        (0x2 << 30)
 
-#define CL_AVC_ME_BLOCK_BASED_SKIP_4x4_INTEL                0x00
-#define CL_AVC_ME_BLOCK_BASED_SKIP_8x8_INTEL                0x80
+#define CL_AVC_ME_BLOCK_BASED_SKIP_4x4_INTEL                    0x00
+#define CL_AVC_ME_BLOCK_BASED_SKIP_8x8_INTEL                    0x80
 
-#define CL_AVC_ME_INTRA_16x16_INTEL                         0x0
-#define CL_AVC_ME_INTRA_8x8_INTEL                           0x1
-#define CL_AVC_ME_INTRA_4x4_INTEL                           0x2
+#define CL_AVC_ME_INTRA_16x16_INTEL                             0x0
+#define CL_AVC_ME_INTRA_8x8_INTEL                               0x1
+#define CL_AVC_ME_INTRA_4x4_INTEL                               0x2
 
-#define CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_16x16_INTEL     0x6
-#define CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_8x8_INTEL       0x5
-#define CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_4x4_INTEL       0x3
+#define CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_16x16_INTEL         0x6
+#define CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_8x8_INTEL           0x5
+#define CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_4x4_INTEL           0x3
 
 #define CL_AVC_ME_INTRA_NEIGHBOR_LEFT_MASK_ENABLE_INTEL         0x60
 #define CL_AVC_ME_INTRA_NEIGHBOR_UPPER_MASK_ENABLE_INTEL        0x10
@@ -2168,269 +2113,241 @@ typedef cl_uint cl_diagnostics_verbose_level;
 #define CL_AVC_ME_CHROMA_PREDICTOR_MODE_VERTICAL_INTEL          0x2
 #define CL_AVC_ME_CHROMA_PREDICTOR_MODE_PLANE_INTEL             0x3
 
-#define CL_AVC_ME_FRAME_FORWARD_INTEL                       0x1
-#define CL_AVC_ME_FRAME_BACKWARD_INTEL                      0x2
-#define CL_AVC_ME_FRAME_DUAL_INTEL                          0x3
+#define CL_AVC_ME_FRAME_FORWARD_INTEL                           0x1
+#define CL_AVC_ME_FRAME_BACKWARD_INTEL                          0x2
+#define CL_AVC_ME_FRAME_DUAL_INTEL                              0x3
 
-#define CL_AVC_ME_SLICE_TYPE_PRED_INTEL                     0x0
-#define CL_AVC_ME_SLICE_TYPE_BPRED_INTEL                    0x1
-#define CL_AVC_ME_SLICE_TYPE_INTRA_INTEL                    0x2
+#define CL_AVC_ME_SLICE_TYPE_PRED_INTEL                         0x0
+#define CL_AVC_ME_SLICE_TYPE_BPRED_INTEL                        0x1
+#define CL_AVC_ME_SLICE_TYPE_INTRA_INTEL                        0x2
 
-#define CL_AVC_ME_INTERLACED_SCAN_TOP_FIELD_INTEL           0x0
-#define CL_AVC_ME_INTERLACED_SCAN_BOTTOM_FIELD_INTEL        0x1
+#define CL_AVC_ME_INTERLACED_SCAN_TOP_FIELD_INTEL               0x0
+#define CL_AVC_ME_INTERLACED_SCAN_BOTTOM_FIELD_INTEL            0x1
 
 /*******************************************
-* cl_intel_unified_shared_memory extension *
-********************************************/
-#define cl_intel_unified_shared_memory 1
+ * cl_intel_unified_shared_memory extension *
+ ********************************************/
+#define cl_intel_unified_shared_memory                          1
 
-typedef cl_bitfield         cl_device_unified_shared_memory_capabilities_intel;
-typedef cl_properties 		cl_mem_properties_intel;
-typedef cl_bitfield         cl_mem_alloc_flags_intel;
-typedef cl_uint             cl_mem_info_intel;
-typedef cl_uint             cl_unified_shared_memory_type_intel;
-typedef cl_uint             cl_mem_advice_intel;
+typedef cl_bitfield   cl_device_unified_shared_memory_capabilities_intel;
+typedef cl_properties cl_mem_properties_intel;
+typedef cl_bitfield   cl_mem_alloc_flags_intel;
+typedef cl_uint       cl_mem_info_intel;
+typedef cl_uint       cl_unified_shared_memory_type_intel;
+typedef cl_uint       cl_mem_advice_intel;
 
 /* cl_device_info */
-#define CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL               0x4190
-#define CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL             0x4191
-#define CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL 0x4192
-#define CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL 0x4193
-#define CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL      0x4194
+#define CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL                   0x4190
+#define CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL                 0x4191
+#define CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL   0x4192
+#define CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL    0x4193
+#define CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL          0x4194
 
 /* cl_device_unified_shared_memory_capabilities_intel - bitfield */
-#define CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL               (1 << 0)
-#define CL_UNIFIED_SHARED_MEMORY_ATOMIC_ACCESS_INTEL        (1 << 1)
-#define CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ACCESS_INTEL    (1 << 2)
+#define CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL                   (1 << 0)
+#define CL_UNIFIED_SHARED_MEMORY_ATOMIC_ACCESS_INTEL            (1 << 1)
+#define CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ACCESS_INTEL        (1 << 2)
 #define CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ATOMIC_ACCESS_INTEL (1 << 3)
 
 /* cl_mem_properties_intel */
-#define CL_MEM_ALLOC_FLAGS_INTEL                            0x4195
+#define CL_MEM_ALLOC_FLAGS_INTEL                                0x4195
 
 /* cl_mem_alloc_flags_intel - bitfield */
-#define CL_MEM_ALLOC_WRITE_COMBINED_INTEL                   (1 << 0)
-#define CL_MEM_ALLOC_INITIAL_PLACEMENT_DEVICE_INTEL         (1 << 1)
-#define CL_MEM_ALLOC_INITIAL_PLACEMENT_HOST_INTEL           (1 << 2)
+#define CL_MEM_ALLOC_WRITE_COMBINED_INTEL                       (1 << 0)
+#define CL_MEM_ALLOC_INITIAL_PLACEMENT_DEVICE_INTEL             (1 << 1)
+#define CL_MEM_ALLOC_INITIAL_PLACEMENT_HOST_INTEL               (1 << 2)
 
 /* cl_mem_alloc_info_intel */
-#define CL_MEM_ALLOC_TYPE_INTEL                             0x419A
-#define CL_MEM_ALLOC_BASE_PTR_INTEL                         0x419B
-#define CL_MEM_ALLOC_SIZE_INTEL                             0x419C
-#define CL_MEM_ALLOC_DEVICE_INTEL                           0x419D
+#define CL_MEM_ALLOC_TYPE_INTEL                                 0x419A
+#define CL_MEM_ALLOC_BASE_PTR_INTEL                             0x419B
+#define CL_MEM_ALLOC_SIZE_INTEL                                 0x419C
+#define CL_MEM_ALLOC_DEVICE_INTEL                               0x419D
 
 /* cl_unified_shared_memory_type_intel */
-#define CL_MEM_TYPE_UNKNOWN_INTEL                           0x4196
-#define CL_MEM_TYPE_HOST_INTEL                              0x4197
-#define CL_MEM_TYPE_DEVICE_INTEL                            0x4198
-#define CL_MEM_TYPE_SHARED_INTEL                            0x4199
+#define CL_MEM_TYPE_UNKNOWN_INTEL                               0x4196
+#define CL_MEM_TYPE_HOST_INTEL                                  0x4197
+#define CL_MEM_TYPE_DEVICE_INTEL                                0x4198
+#define CL_MEM_TYPE_SHARED_INTEL                                0x4199
 
 /* cl_kernel_exec_info */
-#define CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL      0x4200
-#define CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL    0x4201
-#define CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL    0x4202
-#define CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL                  0x4203
+#define CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL          0x4200
+#define CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL        0x4201
+#define CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL        0x4202
+#define CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL                      0x4203
 
 /* cl_command_type */
-#define CL_COMMAND_MEMFILL_INTEL                            0x4204
-#define CL_COMMAND_MEMCPY_INTEL                             0x4205
-#define CL_COMMAND_MIGRATEMEM_INTEL                         0x4206
-#define CL_COMMAND_MEMADVISE_INTEL                          0x4207
+#define CL_COMMAND_MEMFILL_INTEL                                0x4204
+#define CL_COMMAND_MEMCPY_INTEL                                 0x4205
+#define CL_COMMAND_MIGRATEMEM_INTEL                             0x4206
+#define CL_COMMAND_MEMADVISE_INTEL                              0x4207
 
+typedef void*(CL_API_CALL* clHostMemAllocINTEL_fn)(
+  cl_context                     context,
+  const cl_mem_properties_intel* properties,
+  size_t                         size,
+  cl_uint                        alignment,
+  cl_int*                        errcode_ret);
 
-typedef void* (CL_API_CALL *
-clHostMemAllocINTEL_fn)(
-    cl_context context,
-    const cl_mem_properties_intel* properties,
-    size_t size,
-    cl_uint alignment,
-    cl_int* errcode_ret) ;
+typedef void*(CL_API_CALL* clDeviceMemAllocINTEL_fn)(
+  cl_context                     context,
+  cl_device_id                   device,
+  const cl_mem_properties_intel* properties,
+  size_t                         size,
+  cl_uint                        alignment,
+  cl_int*                        errcode_ret);
 
-typedef void* (CL_API_CALL *
-clDeviceMemAllocINTEL_fn)(
-    cl_context context,
-    cl_device_id device,
-    const cl_mem_properties_intel* properties,
-    size_t size,
-    cl_uint alignment,
-    cl_int* errcode_ret) ;
+typedef void*(CL_API_CALL* clSharedMemAllocINTEL_fn)(
+  cl_context                     context,
+  cl_device_id                   device,
+  const cl_mem_properties_intel* properties,
+  size_t                         size,
+  cl_uint                        alignment,
+  cl_int*                        errcode_ret);
 
-typedef void* (CL_API_CALL *
-clSharedMemAllocINTEL_fn)(
-    cl_context context,
-    cl_device_id device,
-    const cl_mem_properties_intel* properties,
-    size_t size,
-    cl_uint alignment,
-    cl_int* errcode_ret) ;
+typedef cl_int(CL_API_CALL* clMemFreeINTEL_fn)(cl_context context, void* ptr);
 
-typedef cl_int (CL_API_CALL *
-clMemFreeINTEL_fn)(
-    cl_context context,
-    void* ptr) ;
+typedef cl_int(CL_API_CALL* clMemBlockingFreeINTEL_fn)(cl_context context,
+                                                       void*      ptr);
 
-typedef cl_int (CL_API_CALL *
-clMemBlockingFreeINTEL_fn)(
-    cl_context context,
-    void* ptr) ;
+typedef cl_int(CL_API_CALL* clGetMemAllocInfoINTEL_fn)(
+  cl_context        context,
+  const void*       ptr,
+  cl_mem_info_intel param_name,
+  size_t            param_value_size,
+  void*             param_value,
+  size_t*           param_value_size_ret);
 
-typedef cl_int (CL_API_CALL *
-clGetMemAllocInfoINTEL_fn)(
-    cl_context context,
-    const void* ptr,
-    cl_mem_info_intel param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret) ;
+typedef cl_int(CL_API_CALL* clSetKernelArgMemPointerINTEL_fn)(
+  cl_kernel   kernel,
+  cl_uint     arg_index,
+  const void* arg_value);
 
-typedef cl_int (CL_API_CALL *
-clSetKernelArgMemPointerINTEL_fn)(
-    cl_kernel kernel,
-    cl_uint arg_index,
-    const void* arg_value) ;
+typedef cl_int(CL_API_CALL* clEnqueueMemFillINTEL_fn)(
+  cl_command_queue command_queue,
+  void*            dst_ptr,
+  const void*      pattern,
+  size_t           pattern_size,
+  size_t           size,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event);
 
-typedef cl_int (CL_API_CALL *
-clEnqueueMemFillINTEL_fn)(
-    cl_command_queue command_queue,
-    void* dst_ptr,
-    const void* pattern,
-    size_t pattern_size,
-    size_t size,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+typedef cl_int(CL_API_CALL* clEnqueueMemcpyINTEL_fn)(
+  cl_command_queue command_queue,
+  cl_bool          blocking,
+  void*            dst_ptr,
+  const void*      src_ptr,
+  size_t           size,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event);
 
-typedef cl_int (CL_API_CALL *
-clEnqueueMemcpyINTEL_fn)(
-    cl_command_queue command_queue,
-    cl_bool blocking,
-    void* dst_ptr,
-    const void* src_ptr,
-    size_t size,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
-
-typedef cl_int (CL_API_CALL *
-clEnqueueMemAdviseINTEL_fn)(
-    cl_command_queue command_queue,
-    const void* ptr,
-    size_t size,
-    cl_mem_advice_intel advice,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+typedef cl_int(CL_API_CALL* clEnqueueMemAdviseINTEL_fn)(
+  cl_command_queue    command_queue,
+  const void*         ptr,
+  size_t              size,
+  cl_mem_advice_intel advice,
+  cl_uint             num_events_in_wait_list,
+  const cl_event*     event_wait_list,
+  cl_event*           event);
 
 #ifndef CL_NO_PROTOTYPES
 
 extern CL_API_ENTRY void* CL_API_CALL
-clHostMemAllocINTEL(
-    cl_context context,
-    const cl_mem_properties_intel* properties,
-    size_t size,
-    cl_uint alignment,
-    cl_int* errcode_ret) ;
+clHostMemAllocINTEL(cl_context                     context,
+                    const cl_mem_properties_intel* properties,
+                    size_t                         size,
+                    cl_uint                        alignment,
+                    cl_int*                        errcode_ret);
 
 extern CL_API_ENTRY void* CL_API_CALL
-clDeviceMemAllocINTEL(
-    cl_context context,
-    cl_device_id device,
-    const cl_mem_properties_intel* properties,
-    size_t size,
-    cl_uint alignment,
-    cl_int* errcode_ret) ;
+clDeviceMemAllocINTEL(cl_context                     context,
+                      cl_device_id                   device,
+                      const cl_mem_properties_intel* properties,
+                      size_t                         size,
+                      cl_uint                        alignment,
+                      cl_int*                        errcode_ret);
 
 extern CL_API_ENTRY void* CL_API_CALL
-clSharedMemAllocINTEL(
-    cl_context context,
-    cl_device_id device,
-    const cl_mem_properties_intel* properties,
-    size_t size,
-    cl_uint alignment,
-    cl_int* errcode_ret) ;
+clSharedMemAllocINTEL(cl_context                     context,
+                      cl_device_id                   device,
+                      const cl_mem_properties_intel* properties,
+                      size_t                         size,
+                      cl_uint                        alignment,
+                      cl_int*                        errcode_ret);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clMemFreeINTEL(
-    cl_context context,
-    void* ptr) ;
+clMemFreeINTEL(cl_context context, void* ptr);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clMemBlockingFreeINTEL(
-    cl_context context,
-    void* ptr) ;
+clMemBlockingFreeINTEL(cl_context context, void* ptr);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetMemAllocInfoINTEL(
-    cl_context context,
-    const void* ptr,
-    cl_mem_info_intel param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret) ;
+clGetMemAllocInfoINTEL(cl_context        context,
+                       const void*       ptr,
+                       cl_mem_info_intel param_name,
+                       size_t            param_value_size,
+                       void*             param_value,
+                       size_t*           param_value_size_ret);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clSetKernelArgMemPointerINTEL(
-    cl_kernel kernel,
-    cl_uint arg_index,
-    const void* arg_value) ;
+clSetKernelArgMemPointerINTEL(cl_kernel   kernel,
+                              cl_uint     arg_index,
+                              const void* arg_value);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueMemFillINTEL(
-    cl_command_queue command_queue,
-    void* dst_ptr,
-    const void* pattern,
-    size_t pattern_size,
-    size_t size,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+clEnqueueMemFillINTEL(cl_command_queue command_queue,
+                      void*            dst_ptr,
+                      const void*      pattern,
+                      size_t           pattern_size,
+                      size_t           size,
+                      cl_uint          num_events_in_wait_list,
+                      const cl_event*  event_wait_list,
+                      cl_event*        event);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueMemcpyINTEL(
-    cl_command_queue command_queue,
-    cl_bool blocking,
-    void* dst_ptr,
-    const void* src_ptr,
-    size_t size,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+clEnqueueMemcpyINTEL(cl_command_queue command_queue,
+                     cl_bool          blocking,
+                     void*            dst_ptr,
+                     const void*      src_ptr,
+                     size_t           size,
+                     cl_uint          num_events_in_wait_list,
+                     const cl_event*  event_wait_list,
+                     cl_event*        event);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueMemAdviseINTEL(
-    cl_command_queue command_queue,
-    const void* ptr,
-    size_t size,
-    cl_mem_advice_intel advice,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+clEnqueueMemAdviseINTEL(cl_command_queue    command_queue,
+                        const void*         ptr,
+                        size_t              size,
+                        cl_mem_advice_intel advice,
+                        cl_uint             num_events_in_wait_list,
+                        const cl_event*     event_wait_list,
+                        cl_event*           event);
 
 #endif /* CL_NO_PROTOTYPES */
 
 #if defined(CL_VERSION_1_2)
 /* Requires OpenCL 1.2 for cl_mem_migration_flags: */
 
-typedef cl_int (CL_API_CALL *
-clEnqueueMigrateMemINTEL_fn)(
-    cl_command_queue command_queue,
-    const void* ptr,
-    size_t size,
-    cl_mem_migration_flags flags,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+typedef cl_int(CL_API_CALL* clEnqueueMigrateMemINTEL_fn)(
+  cl_command_queue       command_queue,
+  const void*            ptr,
+  size_t                 size,
+  cl_mem_migration_flags flags,
+  cl_uint                num_events_in_wait_list,
+  const cl_event*        event_wait_list,
+  cl_event*              event);
 
 #ifndef CL_NO_PROTOTYPES
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueMigrateMemINTEL(
-    cl_command_queue command_queue,
-    const void* ptr,
-    size_t size,
-    cl_mem_migration_flags flags,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+clEnqueueMigrateMemINTEL(cl_command_queue       command_queue,
+                         const void*            ptr,
+                         size_t                 size,
+                         cl_mem_migration_flags flags,
+                         cl_uint                num_events_in_wait_list,
+                         const cl_event*        event_wait_list,
+                         cl_event*              event);
 
 #endif /* CL_NO_PROTOTYPES */
 
@@ -2438,141 +2355,139 @@ clEnqueueMigrateMemINTEL(
 
 /* deprecated, use clEnqueueMemFillINTEL instead */
 
-typedef cl_int (CL_API_CALL *
-clEnqueueMemsetINTEL_fn)(
-    cl_command_queue command_queue,
-    void* dst_ptr,
-    cl_int value,
-    size_t size,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+typedef cl_int(CL_API_CALL* clEnqueueMemsetINTEL_fn)(
+  cl_command_queue command_queue,
+  void*            dst_ptr,
+  cl_int           value,
+  size_t           size,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event);
 
 #ifndef CL_NO_PROTOTYPES
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueMemsetINTEL(
-    cl_command_queue command_queue,
-    void* dst_ptr,
-    cl_int value,
-    size_t size,
-    cl_uint num_events_in_wait_list,
-    const cl_event* event_wait_list,
-    cl_event* event) ;
+clEnqueueMemsetINTEL(cl_command_queue command_queue,
+                     void*            dst_ptr,
+                     cl_int           value,
+                     size_t           size,
+                     cl_uint          num_events_in_wait_list,
+                     const cl_event*  event_wait_list,
+                     cl_event*        event);
 
 #endif /* CL_NO_PROTOTYPES */
 
 /***************************************************************
-* cl_intel_mem_alloc_buffer_location
-***************************************************************/
+ * cl_intel_mem_alloc_buffer_location
+ ***************************************************************/
 #define cl_intel_mem_alloc_buffer_location 1
-#define CL_INTEL_MEM_ALLOC_BUFFER_LOCATION_EXTENSION_NAME \
-    "cl_intel_mem_alloc_buffer_location"
+#define CL_INTEL_MEM_ALLOC_BUFFER_LOCATION_EXTENSION_NAME                      \
+  "cl_intel_mem_alloc_buffer_location"
 
 /* cl_mem_properties_intel */
-#define CL_MEM_ALLOC_BUFFER_LOCATION_INTEL                  0x419E
+#define CL_MEM_ALLOC_BUFFER_LOCATION_INTEL     0x419E
 
 /* cl_mem_alloc_info_intel */
 /* enum CL_MEM_ALLOC_BUFFER_LOCATION_INTEL */
 
 /***************************************************
-* cl_intel_create_buffer_with_properties extension *
-****************************************************/
+ * cl_intel_create_buffer_with_properties extension *
+ ****************************************************/
 
 #define cl_intel_create_buffer_with_properties 1
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateBufferWithPropertiesINTEL(
-    cl_context   context,
-    const cl_mem_properties_intel* properties,
-    cl_mem_flags flags,
-    size_t       size,
-    void *       host_ptr,
-    cl_int *     errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+clCreateBufferWithPropertiesINTEL(cl_context                     context,
+                                  const cl_mem_properties_intel* properties,
+                                  cl_mem_flags                   flags,
+                                  size_t                         size,
+                                  void*                          host_ptr,
+                                  cl_int*                        errcode_ret)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem (CL_API_CALL *
-clCreateBufferWithPropertiesINTEL_fn)(
-    cl_context   context,
-    const cl_mem_properties_intel* properties,
-    cl_mem_flags flags,
-    size_t       size,
-    void *       host_ptr,
-    cl_int *     errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* clCreateBufferWithPropertiesINTEL_fn)(
+  cl_context                     context,
+  const cl_mem_properties_intel* properties,
+  cl_mem_flags                   flags,
+  size_t                         size,
+  void*                          host_ptr,
+  cl_int*                        errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 /******************************************
-* cl_intel_mem_channel_property extension *
-*******************************************/
+ * cl_intel_mem_channel_property extension *
+ *******************************************/
 
 #define CL_MEM_CHANNEL_INTEL            0x4213
 
 /*********************************
-* cl_intel_mem_force_host_memory *
-**********************************/
+ * cl_intel_mem_force_host_memory *
+ **********************************/
 
-#define cl_intel_mem_force_host_memory 1
+#define cl_intel_mem_force_host_memory  1
 
 /* cl_mem_flags */
-#define CL_MEM_FORCE_HOST_MEMORY_INTEL                      (1 << 20)
+#define CL_MEM_FORCE_HOST_MEMORY_INTEL  (1 << 20)
 
 /***************************************************************
-* cl_intel_command_queue_families
-***************************************************************/
+ * cl_intel_command_queue_families
+ ***************************************************************/
 #define cl_intel_command_queue_families 1
 
-typedef cl_bitfield         cl_command_queue_capabilities_intel;
+typedef cl_bitfield cl_command_queue_capabilities_intel;
 
-#define CL_QUEUE_FAMILY_MAX_NAME_SIZE_INTEL                 64
+#define CL_QUEUE_FAMILY_MAX_NAME_SIZE_INTEL 64
 
-typedef struct _cl_queue_family_properties_intel {
-    cl_command_queue_properties properties;
-    cl_command_queue_capabilities_intel capabilities;
-    cl_uint count;
-    char name[CL_QUEUE_FAMILY_MAX_NAME_SIZE_INTEL];
+typedef struct _cl_queue_family_properties_intel
+{
+  cl_command_queue_properties         properties;
+  cl_command_queue_capabilities_intel capabilities;
+  cl_uint                             count;
+  char                                name[CL_QUEUE_FAMILY_MAX_NAME_SIZE_INTEL];
 } cl_queue_family_properties_intel;
 
 /* cl_device_info */
-#define CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL             0x418B
+#define CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL                0x418B
 
 /* cl_queue_properties */
-#define CL_QUEUE_FAMILY_INTEL                               0x418C
-#define CL_QUEUE_INDEX_INTEL                                0x418D
+#define CL_QUEUE_FAMILY_INTEL                                  0x418C
+#define CL_QUEUE_INDEX_INTEL                                   0x418D
 
 /* cl_command_queue_capabilities_intel */
-#define CL_QUEUE_DEFAULT_CAPABILITIES_INTEL                 0
-#define CL_QUEUE_CAPABILITY_CREATE_SINGLE_QUEUE_EVENTS_INTEL (1 << 0)
-#define CL_QUEUE_CAPABILITY_CREATE_CROSS_QUEUE_EVENTS_INTEL (1 << 1)
+#define CL_QUEUE_DEFAULT_CAPABILITIES_INTEL                    0
+#define CL_QUEUE_CAPABILITY_CREATE_SINGLE_QUEUE_EVENTS_INTEL   (1 << 0)
+#define CL_QUEUE_CAPABILITY_CREATE_CROSS_QUEUE_EVENTS_INTEL    (1 << 1)
 #define CL_QUEUE_CAPABILITY_SINGLE_QUEUE_EVENT_WAIT_LIST_INTEL (1 << 2)
-#define CL_QUEUE_CAPABILITY_CROSS_QUEUE_EVENT_WAIT_LIST_INTEL (1 << 3)
-#define CL_QUEUE_CAPABILITY_TRANSFER_BUFFER_INTEL           (1 << 8)
-#define CL_QUEUE_CAPABILITY_TRANSFER_BUFFER_RECT_INTEL      (1 << 9)
-#define CL_QUEUE_CAPABILITY_MAP_BUFFER_INTEL                (1 << 10)
-#define CL_QUEUE_CAPABILITY_FILL_BUFFER_INTEL               (1 << 11)
-#define CL_QUEUE_CAPABILITY_TRANSFER_IMAGE_INTEL            (1 << 12)
-#define CL_QUEUE_CAPABILITY_MAP_IMAGE_INTEL                 (1 << 13)
-#define CL_QUEUE_CAPABILITY_FILL_IMAGE_INTEL                (1 << 14)
-#define CL_QUEUE_CAPABILITY_TRANSFER_BUFFER_IMAGE_INTEL     (1 << 15)
-#define CL_QUEUE_CAPABILITY_TRANSFER_IMAGE_BUFFER_INTEL     (1 << 16)
-#define CL_QUEUE_CAPABILITY_MARKER_INTEL                    (1 << 24)
-#define CL_QUEUE_CAPABILITY_BARRIER_INTEL                   (1 << 25)
-#define CL_QUEUE_CAPABILITY_KERNEL_INTEL                    (1 << 26)
+#define CL_QUEUE_CAPABILITY_CROSS_QUEUE_EVENT_WAIT_LIST_INTEL  (1 << 3)
+#define CL_QUEUE_CAPABILITY_TRANSFER_BUFFER_INTEL              (1 << 8)
+#define CL_QUEUE_CAPABILITY_TRANSFER_BUFFER_RECT_INTEL         (1 << 9)
+#define CL_QUEUE_CAPABILITY_MAP_BUFFER_INTEL                   (1 << 10)
+#define CL_QUEUE_CAPABILITY_FILL_BUFFER_INTEL                  (1 << 11)
+#define CL_QUEUE_CAPABILITY_TRANSFER_IMAGE_INTEL               (1 << 12)
+#define CL_QUEUE_CAPABILITY_MAP_IMAGE_INTEL                    (1 << 13)
+#define CL_QUEUE_CAPABILITY_FILL_IMAGE_INTEL                   (1 << 14)
+#define CL_QUEUE_CAPABILITY_TRANSFER_BUFFER_IMAGE_INTEL        (1 << 15)
+#define CL_QUEUE_CAPABILITY_TRANSFER_IMAGE_BUFFER_INTEL        (1 << 16)
+#define CL_QUEUE_CAPABILITY_MARKER_INTEL                       (1 << 24)
+#define CL_QUEUE_CAPABILITY_BARRIER_INTEL                      (1 << 25)
+#define CL_QUEUE_CAPABILITY_KERNEL_INTEL                       (1 << 26)
 
 /***************************************************************
-* cl_intel_queue_no_sync_operations
-***************************************************************/
+ * cl_intel_queue_no_sync_operations
+ ***************************************************************/
 
-#define cl_intel_queue_no_sync_operations 1
+#define cl_intel_queue_no_sync_operations                      1
 
 /* addition to cl_command_queue_properties */
-#define CL_QUEUE_NO_SYNC_OPERATIONS_INTEL                   (1 << 29)    
-    
-/***************************************************************
-* cl_intel_sharing_format_query
-***************************************************************/
-#define cl_intel_sharing_format_query 1
+#define CL_QUEUE_NO_SYNC_OPERATIONS_INTEL                      (1 << 29)
 
 /***************************************************************
-* cl_ext_image_requirements_info
-***************************************************************/
+ * cl_intel_sharing_format_query
+ ***************************************************************/
+#define cl_intel_sharing_format_query                          1
+
+/***************************************************************
+ * cl_ext_image_requirements_info
+ ***************************************************************/
 
 #ifdef CL_VERSION_3_0
 
@@ -2589,46 +2504,44 @@ typedef cl_uint cl_image_requirements_info_ext;
 #define CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT         0x12B6
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetImageRequirementsInfoEXT(
-    cl_context                     context,
-    const cl_mem_properties*       properties,
-    cl_mem_flags                   flags,
-    const cl_image_format*         image_format,
-    const cl_image_desc*           image_desc,
-    cl_image_requirements_info_ext param_name,
-    size_t  param_value_size,
-    void*   param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_3_0;
+clGetImageRequirementsInfoEXT(cl_context                     context,
+                              const cl_mem_properties*       properties,
+                              cl_mem_flags                   flags,
+                              const cl_image_format*         image_format,
+                              const cl_image_desc*           image_desc,
+                              cl_image_requirements_info_ext param_name,
+                              size_t                         param_value_size,
+                              void*                          param_value,
+                              size_t* param_value_size_ret)
+  CL_API_SUFFIX__VERSION_3_0;
 
-typedef cl_int (CL_API_CALL *
-clGetImageRequirementsInfoEXT_fn)(
-    cl_context                     context,
-    const cl_mem_properties*       properties,
-    cl_mem_flags                   flags,
-    const cl_image_format*         image_format,
-    const cl_image_desc*           image_desc,
-    cl_image_requirements_info_ext param_name,
-    size_t  param_value_size,
-    void*   param_value,
-    size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_3_0;
+typedef cl_int(CL_API_CALL* clGetImageRequirementsInfoEXT_fn)(
+  cl_context                     context,
+  const cl_mem_properties*       properties,
+  cl_mem_flags                   flags,
+  const cl_image_format*         image_format,
+  const cl_image_desc*           image_desc,
+  cl_image_requirements_info_ext param_name,
+  size_t                         param_value_size,
+  void*                          param_value,
+  size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_3_0;
 
 #endif
 
 /***************************************************************
-* cl_ext_image_from_buffer
-***************************************************************/
+ * cl_ext_image_from_buffer
+ ***************************************************************/
 
 #ifdef CL_VERSION_3_0
 
-#define cl_ext_image_from_buffer 1
+#define cl_ext_image_from_buffer                        1
 
-#define CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT  0x1291
+#define CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT 0x1291
 
 #endif
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif /* __CL_EXT_H */

--- a/CL/cl_ext_intel.h
+++ b/CL/cl_ext_intel.h
@@ -16,4 +16,5 @@
  ******************************************************************************/
 
 #include <CL/cl_ext.h>
-#pragma message("The Intel extensions have been moved into cl_ext.h.  Please include cl_ext.h directly.")
+#pragma message(                                                               \
+  "The Intel extensions have been moved into cl_ext.h.  Please include cl_ext.h directly.")

--- a/CL/cl_gl.h
+++ b/CL/cl_gl.h
@@ -23,46 +23,45 @@
 extern "C" {
 #endif
 
-typedef cl_uint     cl_gl_object_type;
-typedef cl_uint     cl_gl_texture_info;
-typedef cl_uint     cl_gl_platform_info;
-typedef struct __GLsync *cl_GLsync;
+typedef cl_uint          cl_gl_object_type;
+typedef cl_uint          cl_gl_texture_info;
+typedef cl_uint          cl_gl_platform_info;
+typedef struct __GLsync* cl_GLsync;
 
-/* cl_gl_object_type = 0x2000 - 0x200F enum values are currently taken           */
-#define CL_GL_OBJECT_BUFFER                     0x2000
-#define CL_GL_OBJECT_TEXTURE2D                  0x2001
-#define CL_GL_OBJECT_TEXTURE3D                  0x2002
-#define CL_GL_OBJECT_RENDERBUFFER               0x2003
+/* cl_gl_object_type = 0x2000 - 0x200F enum values are currently taken */
+#define CL_GL_OBJECT_BUFFER       0x2000
+#define CL_GL_OBJECT_TEXTURE2D    0x2001
+#define CL_GL_OBJECT_TEXTURE3D    0x2002
+#define CL_GL_OBJECT_RENDERBUFFER 0x2003
 #ifdef CL_VERSION_1_2
-#define CL_GL_OBJECT_TEXTURE2D_ARRAY            0x200E
-#define CL_GL_OBJECT_TEXTURE1D                  0x200F
-#define CL_GL_OBJECT_TEXTURE1D_ARRAY            0x2010
-#define CL_GL_OBJECT_TEXTURE_BUFFER             0x2011
+#define CL_GL_OBJECT_TEXTURE2D_ARRAY 0x200E
+#define CL_GL_OBJECT_TEXTURE1D       0x200F
+#define CL_GL_OBJECT_TEXTURE1D_ARRAY 0x2010
+#define CL_GL_OBJECT_TEXTURE_BUFFER  0x2011
 #endif
 
 /* cl_gl_texture_info           */
-#define CL_GL_TEXTURE_TARGET                    0x2004
-#define CL_GL_MIPMAP_LEVEL                      0x2005
+#define CL_GL_TEXTURE_TARGET 0x2004
+#define CL_GL_MIPMAP_LEVEL   0x2005
 #ifdef CL_VERSION_1_2
-#define CL_GL_NUM_SAMPLES                       0x2012
+#define CL_GL_NUM_SAMPLES 0x2012
 #endif
 
-
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateFromGLBuffer(cl_context     context,
-                     cl_mem_flags   flags,
-                     cl_GLuint      bufobj,
-                     cl_int *       errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+clCreateFromGLBuffer(cl_context   context,
+                     cl_mem_flags flags,
+                     cl_GLuint    bufobj,
+                     cl_int*      errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateFromGLTexture(cl_context      context,
-                      cl_mem_flags    flags,
-                      cl_GLenum       target,
-                      cl_GLint        miplevel,
-                      cl_GLuint       texture,
-                      cl_int *        errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+clCreateFromGLTexture(cl_context   context,
+                      cl_mem_flags flags,
+                      cl_GLenum    target,
+                      cl_GLint     miplevel,
+                      cl_GLuint    texture,
+                      cl_int*      errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 #endif
 
@@ -70,125 +69,124 @@ extern CL_API_ENTRY cl_mem CL_API_CALL
 clCreateFromGLRenderbuffer(cl_context   context,
                            cl_mem_flags flags,
                            cl_GLuint    renderbuffer,
-                           cl_int *     errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+                           cl_int*      errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetGLObjectInfo(cl_mem                memobj,
-                  cl_gl_object_type *   gl_object_type,
-                  cl_GLuint *           gl_object_name) CL_API_SUFFIX__VERSION_1_0;
+clGetGLObjectInfo(cl_mem             memobj,
+                  cl_gl_object_type* gl_object_type,
+                  cl_GLuint*         gl_object_name) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetGLTextureInfo(cl_mem               memobj,
-                   cl_gl_texture_info   param_name,
-                   size_t               param_value_size,
-                   void *               param_value,
-                   size_t *             param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetGLTextureInfo(cl_mem             memobj,
+                   cl_gl_texture_info param_name,
+                   size_t             param_value_size,
+                   void*              param_value,
+                   size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueAcquireGLObjects(cl_command_queue      command_queue,
-                          cl_uint               num_objects,
-                          const cl_mem *        mem_objects,
-                          cl_uint               num_events_in_wait_list,
-                          const cl_event *      event_wait_list,
-                          cl_event *            event) CL_API_SUFFIX__VERSION_1_0;
+clEnqueueAcquireGLObjects(cl_command_queue command_queue,
+                          cl_uint          num_objects,
+                          const cl_mem*    mem_objects,
+                          cl_uint          num_events_in_wait_list,
+                          const cl_event*  event_wait_list,
+                          cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueReleaseGLObjects(cl_command_queue      command_queue,
-                          cl_uint               num_objects,
-                          const cl_mem *        mem_objects,
-                          cl_uint               num_events_in_wait_list,
-                          const cl_event *      event_wait_list,
-                          cl_event *            event) CL_API_SUFFIX__VERSION_1_0;
-
+clEnqueueReleaseGLObjects(cl_command_queue command_queue,
+                          cl_uint          num_objects,
+                          const cl_mem*    mem_objects,
+                          cl_uint          num_events_in_wait_list,
+                          const cl_event*  event_wait_list,
+                          cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 /* Deprecated OpenCL 1.1 APIs */
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED cl_mem CL_API_CALL
-clCreateFromGLTexture2D(cl_context      context,
-                        cl_mem_flags    flags,
-                        cl_GLenum       target,
-                        cl_GLint        miplevel,
-                        cl_GLuint       texture,
-                        cl_int *        errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+clCreateFromGLTexture2D(cl_context   context,
+                        cl_mem_flags flags,
+                        cl_GLenum    target,
+                        cl_GLint     miplevel,
+                        cl_GLuint    texture,
+                        cl_int*      errcode_ret)
+  CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED cl_mem CL_API_CALL
-clCreateFromGLTexture3D(cl_context      context,
-                        cl_mem_flags    flags,
-                        cl_GLenum       target,
-                        cl_GLint        miplevel,
-                        cl_GLuint       texture,
-                        cl_int *        errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+clCreateFromGLTexture3D(cl_context   context,
+                        cl_mem_flags flags,
+                        cl_GLenum    target,
+                        cl_GLint     miplevel,
+                        cl_GLuint    texture,
+                        cl_int*      errcode_ret)
+  CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
 /* cl_khr_gl_sharing extension  */
 
 #define cl_khr_gl_sharing 1
 
-typedef cl_uint     cl_gl_context_info;
+typedef cl_uint cl_gl_context_info;
 
 /* Additional Error Codes  */
-#define CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR  -1000
+#define CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR -1000
 
 /* cl_gl_context_info  */
-#define CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR    0x2006
-#define CL_DEVICES_FOR_GL_CONTEXT_KHR           0x2007
+#define CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR   0x2006
+#define CL_DEVICES_FOR_GL_CONTEXT_KHR          0x2007
 
 /* Additional cl_context_properties  */
-#define CL_GL_CONTEXT_KHR                       0x2008
-#define CL_EGL_DISPLAY_KHR                      0x2009
-#define CL_GLX_DISPLAY_KHR                      0x200A
-#define CL_WGL_HDC_KHR                          0x200B
-#define CL_CGL_SHAREGROUP_KHR                   0x200C
+#define CL_GL_CONTEXT_KHR                      0x2008
+#define CL_EGL_DISPLAY_KHR                     0x2009
+#define CL_GLX_DISPLAY_KHR                     0x200A
+#define CL_WGL_HDC_KHR                         0x200B
+#define CL_CGL_SHAREGROUP_KHR                  0x200C
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetGLContextInfoKHR(const cl_context_properties * properties,
-                      cl_gl_context_info            param_name,
-                      size_t                        param_value_size,
-                      void *                        param_value,
-                      size_t *                      param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+clGetGLContextInfoKHR(const cl_context_properties* properties,
+                      cl_gl_context_info           param_name,
+                      size_t                       param_value_size,
+                      void*                        param_value,
+                      size_t* param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int (CL_API_CALL *clGetGLContextInfoKHR_fn)(
-    const cl_context_properties * properties,
-    cl_gl_context_info            param_name,
-    size_t                        param_value_size,
-    void *                        param_value,
-    size_t *                      param_value_size_ret);
+typedef cl_int(CL_API_CALL* clGetGLContextInfoKHR_fn)(
+  const cl_context_properties* properties,
+  cl_gl_context_info           param_name,
+  size_t                       param_value_size,
+  void*                        param_value,
+  size_t*                      param_value_size_ret);
 
-/* 
+/*
  *  cl_khr_gl_event extension
  */
-#define CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR     0x200D
+#define CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR 0x200D
 
 extern CL_API_ENTRY cl_event CL_API_CALL
 clCreateEventFromGLsyncKHR(cl_context context,
                            cl_GLsync  sync,
-                           cl_int *   errcode_ret) CL_API_SUFFIX__VERSION_1_1;
+                           cl_int*    errcode_ret) CL_API_SUFFIX__VERSION_1_1;
 
 /***************************************************************
-* cl_intel_sharing_format_query_gl
-***************************************************************/
+ * cl_intel_sharing_format_query_gl
+ ***************************************************************/
 #define cl_intel_sharing_format_query_gl 1
 
 /* when cl_khr_gl_sharing is supported */
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetSupportedGLTextureFormatsINTEL(
-    cl_context context,
-    cl_mem_flags flags,
-    cl_mem_object_type image_type,
-    cl_uint num_entries,
-    cl_GLenum* gl_formats,
-    cl_uint* num_texture_formats) ;
+clGetSupportedGLTextureFormatsINTEL(cl_context         context,
+                                    cl_mem_flags       flags,
+                                    cl_mem_object_type image_type,
+                                    cl_uint            num_entries,
+                                    cl_GLenum*         gl_formats,
+                                    cl_uint*           num_texture_formats);
 
-typedef cl_int (CL_API_CALL *
-clGetSupportedGLTextureFormatsINTEL_fn)(
-    cl_context context,
-    cl_mem_flags flags,
-    cl_mem_object_type image_type,
-    cl_uint num_entries,
-    cl_GLenum* gl_formats,
-    cl_uint* num_texture_formats) ;
+typedef cl_int(CL_API_CALL* clGetSupportedGLTextureFormatsINTEL_fn)(
+  cl_context         context,
+  cl_mem_flags       flags,
+  cl_mem_object_type image_type,
+  cl_uint            num_entries,
+  cl_GLenum*         gl_formats,
+  cl_uint*           num_texture_formats);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  /* __OPENCL_CL_GL_H */
+#endif /* __OPENCL_CL_GL_H */

--- a/CL/cl_gl_ext.h
+++ b/CL/cl_gl_ext.h
@@ -15,4 +15,5 @@
  ******************************************************************************/
 
 #include <CL/cl_gl.h>
-#pragma message("All OpenGL-related extensions have been moved into cl_gl.h.  Please include cl_gl.h directly.")
+#pragma message(                                                               \
+  "All OpenGL-related extensions have been moved into cl_gl.h.  Please include cl_gl.h directly.")

--- a/CL/cl_half.h
+++ b/CL/cl_half.h
@@ -37,7 +37,6 @@
 extern "C" {
 #endif
 
-
 /**
  * Rounding mode used when converting to cl_half.
  */
@@ -49,31 +48,26 @@ typedef enum
   CL_HALF_RTN, // round towards negative infinity
 } cl_half_rounding_mode;
 
-
 /* Private utility macros. */
-#define CL_HALF_EXP_MASK 0x7C00
+#define CL_HALF_EXP_MASK       0x7C00
 #define CL_HALF_MAX_FINITE_MAG 0x7BFF
-
 
 /*
  * Utility to deal with values that overflow when converting to half precision.
  */
-static inline cl_half cl_half_handle_overflow(cl_half_rounding_mode rounding_mode,
-                                              uint16_t sign)
+static inline cl_half
+cl_half_handle_overflow(cl_half_rounding_mode rounding_mode, uint16_t sign)
 {
-  if (rounding_mode == CL_HALF_RTZ)
-  {
+  if (rounding_mode == CL_HALF_RTZ) {
     // Round overflow towards zero -> largest finite number (preserving sign)
     return (sign << 15) | CL_HALF_MAX_FINITE_MAG;
-  }
-  else if (rounding_mode == CL_HALF_RTP && sign)
-  {
-    // Round negative overflow towards positive infinity -> most negative finite number
+  } else if (rounding_mode == CL_HALF_RTP && sign) {
+    // Round negative overflow towards positive infinity -> most negative finite
+    // number
     return (1 << 15) | CL_HALF_MAX_FINITE_MAG;
-  }
-  else if (rounding_mode == CL_HALF_RTN && !sign)
-  {
-    // Round positive overflow towards negative infinity -> largest finite number
+  } else if (rounding_mode == CL_HALF_RTN && !sign) {
+    // Round positive overflow towards negative infinity -> largest finite
+    // number
     return CL_HALF_MAX_FINITE_MAG;
   }
 
@@ -84,16 +78,13 @@ static inline cl_half cl_half_handle_overflow(cl_half_rounding_mode rounding_mod
 /*
  * Utility to deal with values that underflow when converting to half precision.
  */
-static inline cl_half cl_half_handle_underflow(cl_half_rounding_mode rounding_mode,
-                                               uint16_t sign)
+static inline cl_half
+cl_half_handle_underflow(cl_half_rounding_mode rounding_mode, uint16_t sign)
 {
-  if (rounding_mode == CL_HALF_RTP && !sign)
-  {
+  if (rounding_mode == CL_HALF_RTP && !sign) {
     // Round underflow towards positive infinity -> smallest positive value
     return (sign << 15) | 1;
-  }
-  else if (rounding_mode == CL_HALF_RTN && sign)
-  {
+  } else if (rounding_mode == CL_HALF_RTN && sign) {
     // Round underflow towards negative infinity -> largest negative value
     return (sign << 15) | 1;
   }
@@ -102,11 +93,11 @@ static inline cl_half cl_half_handle_underflow(cl_half_rounding_mode rounding_mo
   return (sign << 15);
 }
 
-
 /**
  * Convert a cl_float to a cl_half.
  */
-static inline cl_half cl_half_from_float(cl_float f, cl_half_rounding_mode rounding_mode)
+static inline cl_half
+cl_half_from_float(cl_float f, cl_half_rounding_mode rounding_mode)
 {
   // Type-punning to get direct access to underlying bits
   union
@@ -124,7 +115,7 @@ static inline cl_half cl_half_from_float(cl_float f, cl_half_rounding_mode round
   uint32_t f_mant = f32.i & ((1 << (CL_FLT_MANT_DIG - 1)) - 1);
 
   // Remove FP32 exponent bias
-  int32_t exp = f_exp - CL_FLT_MAX_EXP + 1;
+  int32_t  exp = f_exp - CL_FLT_MAX_EXP + 1;
 
   // Add FP16 exponent bias
   uint16_t h_exp = (uint16_t)(exp + CL_HALF_MAX_EXP - 1);
@@ -133,43 +124,35 @@ static inline cl_half cl_half_from_float(cl_float f, cl_half_rounding_mode round
   uint32_t lsb_pos = CL_FLT_MANT_DIG - CL_HALF_MANT_DIG;
 
   // Check for NaN / infinity
-  if (f_exp == 0xFF)
-  {
-    if (f_mant)
-    {
+  if (f_exp == 0xFF) {
+    if (f_mant) {
       // NaN -> propagate mantissa and silence it
       uint16_t h_mant = (uint16_t)(f_mant >> lsb_pos);
       h_mant |= 0x200;
       return (sign << 15) | CL_HALF_EXP_MASK | h_mant;
-    }
-    else
-    {
+    } else {
       // Infinity -> zero mantissa
       return (sign << 15) | CL_HALF_EXP_MASK;
     }
   }
 
   // Check for zero
-  if (!f_exp && !f_mant)
-  {
+  if (!f_exp && !f_mant) {
     return (sign << 15);
   }
 
   // Check for overflow
-  if (exp >= CL_HALF_MAX_EXP)
-  {
+  if (exp >= CL_HALF_MAX_EXP) {
     return cl_half_handle_overflow(rounding_mode, sign);
   }
 
   // Check for underflow
-  if (exp < (CL_HALF_MIN_EXP - CL_HALF_MANT_DIG - 1))
-  {
+  if (exp < (CL_HALF_MIN_EXP - CL_HALF_MANT_DIG - 1)) {
     return cl_half_handle_underflow(rounding_mode, sign);
   }
 
   // Check for value that will become denormal
-  if (exp < -14)
-  {
+  if (exp < -14) {
     // Denormal -> include the implicit 1 from the FP32 mantissa
     h_exp = 0;
     f_mant |= 1 << (CL_FLT_MANT_DIG - 1);
@@ -184,16 +167,12 @@ static inline cl_half cl_half_from_float(cl_float f, cl_half_rounding_mode round
   // Check whether we need to round
   uint32_t halfway = 1 << (lsb_pos - 1);
   uint32_t mask = (halfway << 1) - 1;
-  switch (rounding_mode)
-  {
+  switch (rounding_mode) {
     case CL_HALF_RTE:
-      if ((f_mant & mask) > halfway)
-      {
+      if ((f_mant & mask) > halfway) {
         // More than halfway -> round up
         h_mant += 1;
-      }
-      else if ((f_mant & mask) == halfway)
-      {
+      } else if ((f_mant & mask) == halfway) {
         // Exactly halfway -> round to nearest even
         if (h_mant & 0x1)
           h_mant += 1;
@@ -203,15 +182,13 @@ static inline cl_half cl_half_from_float(cl_float f, cl_half_rounding_mode round
       // Mantissa has already been truncated -> do nothing
       break;
     case CL_HALF_RTP:
-      if ((f_mant & mask) && !sign)
-      {
+      if ((f_mant & mask) && !sign) {
         // Round positive numbers up
         h_mant += 1;
       }
       break;
     case CL_HALF_RTN:
-      if ((f_mant & mask) && sign)
-      {
+      if ((f_mant & mask) && sign) {
         // Round negative numbers down
         h_mant += 1;
       }
@@ -219,8 +196,7 @@ static inline cl_half cl_half_from_float(cl_float f, cl_half_rounding_mode round
   }
 
   // Check for mantissa overflow
-  if (h_mant & 0x400)
-  {
+  if (h_mant & 0x400) {
     h_exp += 1;
     h_mant = 0;
   }
@@ -228,17 +204,17 @@ static inline cl_half cl_half_from_float(cl_float f, cl_half_rounding_mode round
   return (sign << 15) | (h_exp << 10) | h_mant;
 }
 
-
 /**
  * Convert a cl_double to a cl_half.
  */
-static inline cl_half cl_half_from_double(cl_double d, cl_half_rounding_mode rounding_mode)
+static inline cl_half
+cl_half_from_double(cl_double d, cl_half_rounding_mode rounding_mode)
 {
   // Type-punning to get direct access to underlying bits
   union
   {
     cl_double d;
-    uint64_t i;
+    uint64_t  i;
   } f64;
   f64.d = d;
 
@@ -250,7 +226,7 @@ static inline cl_half cl_half_from_double(cl_double d, cl_half_rounding_mode rou
   uint64_t d_mant = f64.i & (((uint64_t)1 << (CL_DBL_MANT_DIG - 1)) - 1);
 
   // Remove FP64 exponent bias
-  int64_t exp = d_exp - CL_DBL_MAX_EXP + 1;
+  int64_t  exp = d_exp - CL_DBL_MAX_EXP + 1;
 
   // Add FP16 exponent bias
   uint16_t h_exp = (uint16_t)(exp + CL_HALF_MAX_EXP - 1);
@@ -259,43 +235,35 @@ static inline cl_half cl_half_from_double(cl_double d, cl_half_rounding_mode rou
   uint32_t lsb_pos = CL_DBL_MANT_DIG - CL_HALF_MANT_DIG;
 
   // Check for NaN / infinity
-  if (d_exp == 0x7FF)
-  {
-    if (d_mant)
-    {
+  if (d_exp == 0x7FF) {
+    if (d_mant) {
       // NaN -> propagate mantissa and silence it
       uint16_t h_mant = (uint16_t)(d_mant >> lsb_pos);
       h_mant |= 0x200;
       return (sign << 15) | CL_HALF_EXP_MASK | h_mant;
-    }
-    else
-    {
+    } else {
       // Infinity -> zero mantissa
       return (sign << 15) | CL_HALF_EXP_MASK;
     }
   }
 
   // Check for zero
-  if (!d_exp && !d_mant)
-  {
+  if (!d_exp && !d_mant) {
     return (sign << 15);
   }
 
   // Check for overflow
-  if (exp >= CL_HALF_MAX_EXP)
-  {
+  if (exp >= CL_HALF_MAX_EXP) {
     return cl_half_handle_overflow(rounding_mode, sign);
   }
 
   // Check for underflow
-  if (exp < (CL_HALF_MIN_EXP - CL_HALF_MANT_DIG - 1))
-  {
+  if (exp < (CL_HALF_MIN_EXP - CL_HALF_MANT_DIG - 1)) {
     return cl_half_handle_underflow(rounding_mode, sign);
   }
 
   // Check for value that will become denormal
-  if (exp < -14)
-  {
+  if (exp < -14) {
     // Include the implicit 1 from the FP64 mantissa
     h_exp = 0;
     d_mant |= (uint64_t)1 << (CL_DBL_MANT_DIG - 1);
@@ -310,16 +278,12 @@ static inline cl_half cl_half_from_double(cl_double d, cl_half_rounding_mode rou
   // Check whether we need to round
   uint64_t halfway = (uint64_t)1 << (lsb_pos - 1);
   uint64_t mask = (halfway << 1) - 1;
-  switch (rounding_mode)
-  {
+  switch (rounding_mode) {
     case CL_HALF_RTE:
-      if ((d_mant & mask) > halfway)
-      {
+      if ((d_mant & mask) > halfway) {
         // More than halfway -> round up
         h_mant += 1;
-      }
-      else if ((d_mant & mask) == halfway)
-      {
+      } else if ((d_mant & mask) == halfway) {
         // Exactly halfway -> round to nearest even
         if (h_mant & 0x1)
           h_mant += 1;
@@ -329,15 +293,13 @@ static inline cl_half cl_half_from_double(cl_double d, cl_half_rounding_mode rou
       // Mantissa has already been truncated -> do nothing
       break;
     case CL_HALF_RTP:
-      if ((d_mant & mask) && !sign)
-      {
+      if ((d_mant & mask) && !sign) {
         // Round positive numbers up
         h_mant += 1;
       }
       break;
     case CL_HALF_RTN:
-      if ((d_mant & mask) && sign)
-      {
+      if ((d_mant & mask) && sign) {
         // Round negative numbers down
         h_mant += 1;
       }
@@ -345,8 +307,7 @@ static inline cl_half cl_half_from_double(cl_double d, cl_half_rounding_mode rou
   }
 
   // Check for mantissa overflow
-  if (h_mant & 0x400)
-  {
+  if (h_mant & 0x400) {
     h_exp += 1;
     h_mant = 0;
   }
@@ -354,11 +315,11 @@ static inline cl_half cl_half_from_double(cl_double d, cl_half_rounding_mode rou
   return (sign << 15) | (h_exp << 10) | h_mant;
 }
 
-
 /**
  * Convert a cl_half to a cl_float.
  */
-static inline cl_float cl_half_to_float(cl_half h)
+static inline cl_float
+cl_half_to_float(cl_half h)
 {
   // Type-punning to get direct access to underlying bits
   union
@@ -375,24 +336,20 @@ static inline cl_float cl_half_to_float(cl_half h)
   uint16_t h_mant = h & 0x3FF;
 
   // Remove FP16 exponent bias
-  int32_t exp = h_exp - CL_HALF_MAX_EXP + 1;
+  int32_t  exp = h_exp - CL_HALF_MAX_EXP + 1;
 
   // Add FP32 exponent bias
   uint32_t f_exp = exp + CL_FLT_MAX_EXP - 1;
 
   // Check for NaN / infinity
-  if (h_exp == 0x1F)
-  {
-    if (h_mant)
-    {
+  if (h_exp == 0x1F) {
+    if (h_mant) {
       // NaN -> propagate mantissa and silence it
       uint32_t f_mant = h_mant << (CL_FLT_MANT_DIG - CL_HALF_MANT_DIG);
       f_mant |= 0x400000;
       f32.i = (sign << 31) | 0x7F800000 | f_mant;
       return f32.f;
-    }
-    else
-    {
+    } else {
       // Infinity -> zero mantissa
       f32.i = (sign << 31) | 0x7F800000;
       return f32.f;
@@ -400,21 +357,16 @@ static inline cl_float cl_half_to_float(cl_half h)
   }
 
   // Check for zero / denormal
-  if (h_exp == 0)
-  {
-    if (h_mant == 0)
-    {
+  if (h_exp == 0) {
+    if (h_mant == 0) {
       // Zero -> zero exponent
       f_exp = 0;
-    }
-    else
-    {
+    } else {
       // Denormal -> normalize it
       // - Shift mantissa to make most-significant 1 implicit
       // - Adjust exponent accordingly
       uint32_t shift = 0;
-      while ((h_mant & 0x400) == 0)
-      {
+      while ((h_mant & 0x400) == 0) {
         h_mant <<= 1;
         shift++;
       }
@@ -427,14 +379,11 @@ static inline cl_float cl_half_to_float(cl_half h)
   return f32.f;
 }
 
-
 #undef CL_HALF_EXP_MASK
 #undef CL_HALF_MAX_FINITE_MAG
-
 
 #ifdef __cplusplus
 }
 #endif
 
-
-#endif  /* OPENCL_CL_HALF_H */
+#endif /* OPENCL_CL_HALF_H */

--- a/CL/cl_icd.h
+++ b/CL/cl_icd.h
@@ -23,8 +23,8 @@
 #include <CL/cl_gl.h>
 
 #if defined(_WIN32)
-#include <CL/cl_d3d11.h>
 #include <CL/cl_d3d10.h>
+#include <CL/cl_d3d11.h>
 #include <CL/cl_dx9_media_sharing.h>
 #endif
 
@@ -41,610 +41,821 @@ extern "C" {
 /* API function pointer definitions */
 
 // Platform APIs
-typedef cl_int(CL_API_CALL *cl_api_clGetPlatformIDs)(
-    cl_uint num_entries, cl_platform_id *platforms,
-    cl_uint *num_platforms) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetPlatformIDs)(cl_uint num_entries,
+                                                     cl_platform_id* platforms,
+                                                     cl_uint* num_platforms)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetPlatformInfo)(
-    cl_platform_id platform, cl_platform_info param_name,
-    size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetPlatformInfo)(
+  cl_platform_id   platform,
+  cl_platform_info param_name,
+  size_t           param_value_size,
+  void*            param_value,
+  size_t*          param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 // Device APIs
-typedef cl_int(CL_API_CALL *cl_api_clGetDeviceIDs)(
-    cl_platform_id platform, cl_device_type device_type, cl_uint num_entries,
-    cl_device_id *devices, cl_uint *num_devices) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetDeviceIDs)(cl_platform_id platform,
+                                                   cl_device_type device_type,
+                                                   cl_uint        num_entries,
+                                                   cl_device_id*  devices,
+                                                   cl_uint*       num_devices)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetDeviceInfo)(
-    cl_device_id device, cl_device_info param_name, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetDeviceInfo)(
+  cl_device_id   device,
+  cl_device_info param_name,
+  size_t         param_value_size,
+  void*          param_value,
+  size_t*        param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
-typedef cl_int(CL_API_CALL *cl_api_clCreateSubDevices)(
-    cl_device_id in_device,
-    const cl_device_partition_property *partition_properties,
-    cl_uint num_entries, cl_device_id *out_devices, cl_uint *num_devices);
+typedef cl_int(CL_API_CALL* cl_api_clCreateSubDevices)(
+  cl_device_id                        in_device,
+  const cl_device_partition_property* partition_properties,
+  cl_uint                             num_entries,
+  cl_device_id*                       out_devices,
+  cl_uint*                            num_devices);
 
-typedef cl_int(CL_API_CALL *cl_api_clRetainDevice)(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* cl_api_clRetainDevice)(cl_device_id device)
+  CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int(CL_API_CALL *cl_api_clReleaseDevice)(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* cl_api_clReleaseDevice)(cl_device_id device)
+  CL_API_SUFFIX__VERSION_1_2;
 
 #else
 
-typedef void *cl_api_clCreateSubDevices;
-typedef void *cl_api_clRetainDevice;
-typedef void *cl_api_clReleaseDevice;
+typedef void* cl_api_clCreateSubDevices;
+typedef void* cl_api_clRetainDevice;
+typedef void* cl_api_clReleaseDevice;
 
 #endif
 
 // Context APIs
-typedef cl_context(CL_API_CALL *cl_api_clCreateContext)(
-    const cl_context_properties *properties, cl_uint num_devices,
-    const cl_device_id *devices,
-    void(CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *),
-    void *user_data, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_context(CL_API_CALL* cl_api_clCreateContext)(
+  const cl_context_properties* properties,
+  cl_uint                      num_devices,
+  const cl_device_id*          devices,
+  void(CL_CALLBACK* pfn_notify)(const char*, const void*, size_t, void*),
+  void*   user_data,
+  cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_context(CL_API_CALL *cl_api_clCreateContextFromType)(
-    const cl_context_properties *properties, cl_device_type device_type,
-    void(CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *),
-    void *user_data, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_context(CL_API_CALL* cl_api_clCreateContextFromType)(
+  const cl_context_properties* properties,
+  cl_device_type               device_type,
+  void(CL_CALLBACK* pfn_notify)(const char*, const void*, size_t, void*),
+  void*   user_data,
+  cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clRetainContext)(
-    cl_context context) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clRetainContext)(cl_context context)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clReleaseContext)(
-    cl_context context) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clReleaseContext)(cl_context context)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetContextInfo)(
-    cl_context context, cl_context_info param_name, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetContextInfo)(
+  cl_context      context,
+  cl_context_info param_name,
+  size_t          param_value_size,
+  void*           param_value,
+  size_t*         param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 // Command Queue APIs
-typedef cl_command_queue(CL_API_CALL *cl_api_clCreateCommandQueue)(
-    cl_context context, cl_device_id device,
-    cl_command_queue_properties properties,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_command_queue(CL_API_CALL* cl_api_clCreateCommandQueue)(
+  cl_context                  context,
+  cl_device_id                device,
+  cl_command_queue_properties properties,
+  cl_int*                     errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_2_0
 
-typedef
-cl_command_queue(CL_API_CALL *cl_api_clCreateCommandQueueWithProperties)(
-    cl_context /* context */, cl_device_id /* device */,
-    const cl_queue_properties * /* properties */,
-    cl_int * /* errcode_ret */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_command_queue(
+  CL_API_CALL* cl_api_clCreateCommandQueueWithProperties)(
+  cl_context /* context */,
+  cl_device_id /* device */,
+  const cl_queue_properties* /* properties */,
+  cl_int* /* errcode_ret */) CL_API_SUFFIX__VERSION_2_0;
 
 #else
 
-typedef void *cl_api_clCreateCommandQueueWithProperties;
+typedef void* cl_api_clCreateCommandQueueWithProperties;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clRetainCommandQueue)(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clRetainCommandQueue)(
+  cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clReleaseCommandQueue)(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clReleaseCommandQueue)(
+  cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetCommandQueueInfo)(
-    cl_command_queue command_queue, cl_command_queue_info param_name,
-    size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetCommandQueueInfo)(
+  cl_command_queue      command_queue,
+  cl_command_queue_info param_name,
+  size_t                param_value_size,
+  void*                 param_value,
+  size_t*               param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 // Memory Object APIs
-typedef cl_mem(CL_API_CALL *cl_api_clCreateBuffer)(
-    cl_context context, cl_mem_flags flags, size_t size, void *host_ptr,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateBuffer)(cl_context   context,
+                                                   cl_mem_flags flags,
+                                                   size_t       size,
+                                                   void*        host_ptr,
+                                                   cl_int*      errcode_ret)
+  CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateImage)(
-    cl_context context, cl_mem_flags flags, const cl_image_format *image_format,
-    const cl_image_desc *image_desc, void *host_ptr,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateImage)(
+  cl_context             context,
+  cl_mem_flags           flags,
+  const cl_image_format* image_format,
+  const cl_image_desc*   image_desc,
+  void*                  host_ptr,
+  cl_int*                errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 #else
 
-typedef void *cl_api_clCreateImage;
+typedef void* cl_api_clCreateImage;
 
 #endif
 
 #ifdef CL_VERSION_3_0
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateBufferWithProperties)(
-    cl_context context, const cl_mem_properties *properties, cl_mem_flags flags,
-    size_t size, void *host_ptr,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_3_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateBufferWithProperties)(
+  cl_context               context,
+  const cl_mem_properties* properties,
+  cl_mem_flags             flags,
+  size_t                   size,
+  void*                    host_ptr,
+  cl_int*                  errcode_ret) CL_API_SUFFIX__VERSION_3_0;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateImageWithProperties)(
-    cl_context context, const cl_mem_properties *properties, cl_mem_flags flags,
-    const cl_image_format *image_format, const cl_image_desc *image_desc,
-    void *host_ptr, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_3_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateImageWithProperties)(
+  cl_context               context,
+  const cl_mem_properties* properties,
+  cl_mem_flags             flags,
+  const cl_image_format*   image_format,
+  const cl_image_desc*     image_desc,
+  void*                    host_ptr,
+  cl_int*                  errcode_ret) CL_API_SUFFIX__VERSION_3_0;
 
 typedef cl_int(CL_API_CALL* cl_api_clSetContextDestructorCallback)(
-    cl_context context,
-    void(CL_CALLBACK* pfn_notify)(cl_context context, void* user_data),
-    void* user_data) CL_API_SUFFIX__VERSION_3_0;
+  cl_context context,
+  void(CL_CALLBACK* pfn_notify)(cl_context context, void* user_data),
+  void* user_data) CL_API_SUFFIX__VERSION_3_0;
 
 #else
 
-typedef void *cl_api_clCreateBufferWithProperties;
-typedef void *cl_api_clCreateImageWithProperties;
-typedef void *cl_api_clSetContextDestructorCallback;
+typedef void* cl_api_clCreateBufferWithProperties;
+typedef void* cl_api_clCreateImageWithProperties;
+typedef void* cl_api_clSetContextDestructorCallback;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clRetainMemObject)(
-    cl_mem memobj) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clRetainMemObject)(cl_mem memobj)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clReleaseMemObject)(
-    cl_mem memobj) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clReleaseMemObject)(cl_mem memobj)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetSupportedImageFormats)(
-    cl_context context, cl_mem_flags flags, cl_mem_object_type image_type,
-    cl_uint num_entries, cl_image_format *image_formats,
-    cl_uint *num_image_formats) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetSupportedImageFormats)(
+  cl_context         context,
+  cl_mem_flags       flags,
+  cl_mem_object_type image_type,
+  cl_uint            num_entries,
+  cl_image_format*   image_formats,
+  cl_uint*           num_image_formats) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetMemObjectInfo)(
-    cl_mem memobj, cl_mem_info param_name, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetMemObjectInfo)(
+  cl_mem      memobj,
+  cl_mem_info param_name,
+  size_t      param_value_size,
+  void*       param_value,
+  size_t*     param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetImageInfo)(
-    cl_mem image, cl_image_info param_name, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetImageInfo)(cl_mem        image,
+                                                   cl_image_info param_name,
+                                                   size_t  param_value_size,
+                                                   void*   param_value,
+                                                   size_t* param_value_size_ret)
+  CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_2_0
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreatePipe)(
-    cl_context /* context */, cl_mem_flags /* flags */,
-    cl_uint /* pipe_packet_size */, cl_uint /* pipe_max_packets */,
-    const cl_pipe_properties * /* properties */,
-    cl_int * /* errcode_ret */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreatePipe)(
+  cl_context /* context */,
+  cl_mem_flags /* flags */,
+  cl_uint /* pipe_packet_size */,
+  cl_uint /* pipe_max_packets */,
+  const cl_pipe_properties* /* properties */,
+  cl_int* /* errcode_ret */) CL_API_SUFFIX__VERSION_2_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetPipeInfo)(
-    cl_mem /* pipe */, cl_pipe_info /* param_name */,
-    size_t /* param_value_size */, void * /* param_value */,
-    size_t * /* param_value_size_ret */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetPipeInfo)(
+  cl_mem /* pipe */,
+  cl_pipe_info /* param_name */,
+  size_t /* param_value_size */,
+  void* /* param_value */,
+  size_t* /* param_value_size_ret */) CL_API_SUFFIX__VERSION_2_0;
 
-typedef void *(CL_API_CALL *cl_api_clSVMAlloc)(
-    cl_context /* context */, cl_svm_mem_flags /* flags */, size_t /* size */,
-    unsigned int /* alignment */)CL_API_SUFFIX__VERSION_2_0;
+typedef void*(CL_API_CALL* cl_api_clSVMAlloc)(cl_context /* context */,
+                                              cl_svm_mem_flags /* flags */,
+                                              size_t /* size */,
+                                              unsigned int /* alignment */)
+  CL_API_SUFFIX__VERSION_2_0;
 
-typedef void(CL_API_CALL *cl_api_clSVMFree)(
-    cl_context /* context */,
-    void * /* svm_pointer */) CL_API_SUFFIX__VERSION_2_0;
+typedef void(CL_API_CALL* cl_api_clSVMFree)(cl_context /* context */,
+                                            void* /* svm_pointer */)
+  CL_API_SUFFIX__VERSION_2_0;
 
 #else
 
-typedef void *cl_api_clCreatePipe;
-typedef void *cl_api_clGetPipeInfo;
-typedef void *cl_api_clSVMAlloc;
-typedef void *cl_api_clSVMFree;
+typedef void* cl_api_clCreatePipe;
+typedef void* cl_api_clGetPipeInfo;
+typedef void* cl_api_clSVMAlloc;
+typedef void* cl_api_clSVMFree;
 
 #endif
 
 // Sampler APIs
-typedef cl_sampler(CL_API_CALL *cl_api_clCreateSampler)(
-    cl_context context, cl_bool normalized_coords,
-    cl_addressing_mode addressing_mode, cl_filter_mode filter_mode,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_sampler(CL_API_CALL* cl_api_clCreateSampler)(
+  cl_context         context,
+  cl_bool            normalized_coords,
+  cl_addressing_mode addressing_mode,
+  cl_filter_mode     filter_mode,
+  cl_int*            errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clRetainSampler)(
-    cl_sampler sampler) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clRetainSampler)(cl_sampler sampler)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clReleaseSampler)(
-    cl_sampler sampler) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clReleaseSampler)(cl_sampler sampler)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetSamplerInfo)(
-    cl_sampler sampler, cl_sampler_info param_name, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetSamplerInfo)(
+  cl_sampler      sampler,
+  cl_sampler_info param_name,
+  size_t          param_value_size,
+  void*           param_value,
+  size_t*         param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_2_0
 
-typedef
-cl_sampler(CL_API_CALL *cl_api_clCreateSamplerWithProperties)(
-    cl_context /* context */,
-    const cl_sampler_properties * /* sampler_properties */,
-    cl_int * /* errcode_ret */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_sampler(CL_API_CALL* cl_api_clCreateSamplerWithProperties)(
+  cl_context /* context */,
+  const cl_sampler_properties* /* sampler_properties */,
+  cl_int* /* errcode_ret */) CL_API_SUFFIX__VERSION_2_0;
 
 #else
 
-typedef void *cl_api_clCreateSamplerWithProperties;
+typedef void* cl_api_clCreateSamplerWithProperties;
 
 #endif
 
 // Program Object APIs
-typedef cl_program(CL_API_CALL *cl_api_clCreateProgramWithSource)(
-    cl_context context, cl_uint count, const char **strings,
-    const size_t *lengths, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_program(CL_API_CALL* cl_api_clCreateProgramWithSource)(
+  cl_context    context,
+  cl_uint       count,
+  const char**  strings,
+  const size_t* lengths,
+  cl_int*       errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_program(CL_API_CALL *cl_api_clCreateProgramWithBinary)(
-    cl_context context, cl_uint num_devices, const cl_device_id *device_list,
-    const size_t *lengths, const unsigned char **binaries,
-    cl_int *binary_status, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_program(CL_API_CALL* cl_api_clCreateProgramWithBinary)(
+  cl_context            context,
+  cl_uint               num_devices,
+  const cl_device_id*   device_list,
+  const size_t*         lengths,
+  const unsigned char** binaries,
+  cl_int*               binary_status,
+  cl_int*               errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
-typedef
-cl_program(CL_API_CALL *cl_api_clCreateProgramWithBuiltInKernels)(
-    cl_context context, cl_uint num_devices, const cl_device_id *device_list,
-    const char *kernel_names, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_program(CL_API_CALL* cl_api_clCreateProgramWithBuiltInKernels)(
+  cl_context          context,
+  cl_uint             num_devices,
+  const cl_device_id* device_list,
+  const char*         kernel_names,
+  cl_int*             errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 #else
 
-typedef void *cl_api_clCreateProgramWithBuiltInKernels;
+typedef void* cl_api_clCreateProgramWithBuiltInKernels;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clRetainProgram)(
-    cl_program program) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clRetainProgram)(cl_program program)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clReleaseProgram)(
-    cl_program program) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clReleaseProgram)(cl_program program)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clBuildProgram)(
-    cl_program program, cl_uint num_devices, const cl_device_id *device_list,
-    const char *options,
-    void(CL_CALLBACK *pfn_notify)(cl_program program, void *user_data),
-    void *user_data) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clBuildProgram)(
+  cl_program          program,
+  cl_uint             num_devices,
+  const cl_device_id* device_list,
+  const char*         options,
+  void(CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+  void* user_data) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
-typedef cl_int(CL_API_CALL *cl_api_clCompileProgram)(
-    cl_program program, cl_uint num_devices, const cl_device_id *device_list,
-    const char *options, cl_uint num_input_headers,
-    const cl_program *input_headers, const char **header_include_names,
-    void(CL_CALLBACK *pfn_notify)(cl_program program, void *user_data),
-    void *user_data) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* cl_api_clCompileProgram)(
+  cl_program          program,
+  cl_uint             num_devices,
+  const cl_device_id* device_list,
+  const char*         options,
+  cl_uint             num_input_headers,
+  const cl_program*   input_headers,
+  const char**        header_include_names,
+  void(CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+  void* user_data) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_program(CL_API_CALL *cl_api_clLinkProgram)(
-    cl_context context, cl_uint num_devices, const cl_device_id *device_list,
-    const char *options, cl_uint num_input_programs,
-    const cl_program *input_programs,
-    void(CL_CALLBACK *pfn_notify)(cl_program program, void *user_data),
-    void *user_data, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_program(CL_API_CALL* cl_api_clLinkProgram)(
+  cl_context          context,
+  cl_uint             num_devices,
+  const cl_device_id* device_list,
+  const char*         options,
+  cl_uint             num_input_programs,
+  const cl_program*   input_programs,
+  void(CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+  void*   user_data,
+  cl_int* errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 #else
 
-typedef void *cl_api_clCompileProgram;
-typedef void *cl_api_clLinkProgram;
+typedef void* cl_api_clCompileProgram;
+typedef void* cl_api_clLinkProgram;
 
 #endif
 
 #ifdef CL_VERSION_2_2
 
-typedef
-cl_int(CL_API_CALL *cl_api_clSetProgramSpecializationConstant)(
-    cl_program program, cl_uint spec_id, size_t spec_size,
-    const void *spec_value) CL_API_SUFFIX__VERSION_2_2;
+typedef cl_int(CL_API_CALL* cl_api_clSetProgramSpecializationConstant)(
+  cl_program  program,
+  cl_uint     spec_id,
+  size_t      spec_size,
+  const void* spec_value) CL_API_SUFFIX__VERSION_2_2;
 
-typedef cl_int(CL_API_CALL *cl_api_clSetProgramReleaseCallback)(
-    cl_program program,
-    void(CL_CALLBACK *pfn_notify)(cl_program program, void *user_data),
-    void *user_data) CL_API_SUFFIX__VERSION_2_2;
+typedef cl_int(CL_API_CALL* cl_api_clSetProgramReleaseCallback)(
+  cl_program program,
+  void(CL_CALLBACK* pfn_notify)(cl_program program, void* user_data),
+  void* user_data) CL_API_SUFFIX__VERSION_2_2;
 
 #else
 
-typedef void *cl_api_clSetProgramSpecializationConstant;
-typedef void *cl_api_clSetProgramReleaseCallback;
+typedef void* cl_api_clSetProgramSpecializationConstant;
+typedef void* cl_api_clSetProgramReleaseCallback;
 
 #endif
 
 #ifdef CL_VERSION_1_2
 
-typedef cl_int(CL_API_CALL *cl_api_clUnloadPlatformCompiler)(
-    cl_platform_id platform) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* cl_api_clUnloadPlatformCompiler)(
+  cl_platform_id platform) CL_API_SUFFIX__VERSION_1_2;
 
 #else
 
-typedef void *cl_api_clUnloadPlatformCompiler;
+typedef void* cl_api_clUnloadPlatformCompiler;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clGetProgramInfo)(
-    cl_program program, cl_program_info param_name, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetProgramInfo)(
+  cl_program      program,
+  cl_program_info param_name,
+  size_t          param_value_size,
+  void*           param_value,
+  size_t*         param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetProgramBuildInfo)(
-    cl_program program, cl_device_id device, cl_program_build_info param_name,
-    size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetProgramBuildInfo)(
+  cl_program            program,
+  cl_device_id          device,
+  cl_program_build_info param_name,
+  size_t                param_value_size,
+  void*                 param_value,
+  size_t*               param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 // Kernel Object APIs
-typedef cl_kernel(CL_API_CALL *cl_api_clCreateKernel)(
-    cl_program program, const char *kernel_name,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_kernel(CL_API_CALL* cl_api_clCreateKernel)(cl_program  program,
+                                                      const char* kernel_name,
+                                                      cl_int*     errcode_ret)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clCreateKernelsInProgram)(
-    cl_program program, cl_uint num_kernels, cl_kernel *kernels,
-    cl_uint *num_kernels_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clCreateKernelsInProgram)(
+  cl_program program,
+  cl_uint    num_kernels,
+  cl_kernel* kernels,
+  cl_uint*   num_kernels_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clRetainKernel)(
-    cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clRetainKernel)(cl_kernel kernel)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clReleaseKernel)(
-    cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clReleaseKernel)(cl_kernel kernel)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clSetKernelArg)(
-    cl_kernel kernel, cl_uint arg_index, size_t arg_size,
-    const void *arg_value) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clSetKernelArg)(cl_kernel   kernel,
+                                                   cl_uint     arg_index,
+                                                   size_t      arg_size,
+                                                   const void* arg_value)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetKernelInfo)(
-    cl_kernel kernel, cl_kernel_info param_name, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetKernelInfo)(
+  cl_kernel      kernel,
+  cl_kernel_info param_name,
+  size_t         param_value_size,
+  void*          param_value,
+  size_t*        param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
-typedef cl_int(CL_API_CALL *cl_api_clGetKernelArgInfo)(
-    cl_kernel kernel, cl_uint arg_indx, cl_kernel_arg_info param_name,
-    size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* cl_api_clGetKernelArgInfo)(
+  cl_kernel          kernel,
+  cl_uint            arg_indx,
+  cl_kernel_arg_info param_name,
+  size_t             param_value_size,
+  void*              param_value,
+  size_t*            param_value_size_ret) CL_API_SUFFIX__VERSION_1_2;
 
 #else
 
-typedef void *cl_api_clGetKernelArgInfo;
+typedef void* cl_api_clGetKernelArgInfo;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clGetKernelWorkGroupInfo)(
-    cl_kernel kernel, cl_device_id device, cl_kernel_work_group_info param_name,
-    size_t param_value_size, void *param_value,
-    size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetKernelWorkGroupInfo)(
+  cl_kernel                 kernel,
+  cl_device_id              device,
+  cl_kernel_work_group_info param_name,
+  size_t                    param_value_size,
+  void*                     param_value,
+  size_t*                   param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_2_0
 
-typedef cl_int(CL_API_CALL *cl_api_clSetKernelArgSVMPointer)(
-    cl_kernel /* kernel */, cl_uint /* arg_index */,
-    const void * /* arg_value */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_int(CL_API_CALL* cl_api_clSetKernelArgSVMPointer)(
+  cl_kernel /* kernel */,
+  cl_uint /* arg_index */,
+  const void* /* arg_value */) CL_API_SUFFIX__VERSION_2_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clSetKernelExecInfo)(
-    cl_kernel /* kernel */, cl_kernel_exec_info /* param_name */,
-    size_t /* param_value_size */,
-    const void * /* param_value */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_int(CL_API_CALL* cl_api_clSetKernelExecInfo)(
+  cl_kernel /* kernel */,
+  cl_kernel_exec_info /* param_name */,
+  size_t /* param_value_size */,
+  const void* /* param_value */) CL_API_SUFFIX__VERSION_2_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetKernelSubGroupInfoKHR)(
-    cl_kernel /* in_kernel */, cl_device_id /*in_device*/,
-    cl_kernel_sub_group_info /* param_name */, size_t /*input_value_size*/,
-    const void * /*input_value*/, size_t /*param_value_size*/,
-    void * /*param_value*/,
-    size_t * /*param_value_size_ret*/) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetKernelSubGroupInfoKHR)(
+  cl_kernel /* in_kernel */,
+  cl_device_id /*in_device*/,
+  cl_kernel_sub_group_info /* param_name */,
+  size_t /*input_value_size*/,
+  const void* /*input_value*/,
+  size_t /*param_value_size*/,
+  void* /*param_value*/,
+  size_t* /*param_value_size_ret*/) CL_API_SUFFIX__VERSION_2_0;
 
 #else
 
-typedef void *cl_api_clSetKernelArgSVMPointer;
-typedef void *cl_api_clSetKernelExecInfo;
-typedef void *cl_api_clGetKernelSubGroupInfoKHR;
+typedef void* cl_api_clSetKernelArgSVMPointer;
+typedef void* cl_api_clSetKernelExecInfo;
+typedef void* cl_api_clGetKernelSubGroupInfoKHR;
 
 #endif
 
 // Event Object APIs
-typedef cl_int(CL_API_CALL *cl_api_clWaitForEvents)(
-    cl_uint num_events, const cl_event *event_list) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clWaitForEvents)(cl_uint         num_events,
+                                                    const cl_event* event_list)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetEventInfo)(
-    cl_event event, cl_event_info param_name, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetEventInfo)(cl_event      event,
+                                                   cl_event_info param_name,
+                                                   size_t  param_value_size,
+                                                   void*   param_value,
+                                                   size_t* param_value_size_ret)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clRetainEvent)(cl_event event)
-    CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clRetainEvent)(cl_event event)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clReleaseEvent)(cl_event event)
-    CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clReleaseEvent)(cl_event event)
+  CL_API_SUFFIX__VERSION_1_0;
 
 // Profiling APIs
-typedef cl_int(CL_API_CALL *cl_api_clGetEventProfilingInfo)(
-    cl_event event, cl_profiling_info param_name, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetEventProfilingInfo)(
+  cl_event          event,
+  cl_profiling_info param_name,
+  size_t            param_value_size,
+  void*             param_value,
+  size_t*           param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
 // Flush and Finish APIs
-typedef cl_int(CL_API_CALL *cl_api_clFlush)(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clFlush)(cl_command_queue command_queue)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clFinish)(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clFinish)(cl_command_queue command_queue)
+  CL_API_SUFFIX__VERSION_1_0;
 
 // Enqueued Commands APIs
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueReadBuffer)(
-    cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_read,
-    size_t offset, size_t cb, void *ptr, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueReadBuffer)(
+  cl_command_queue command_queue,
+  cl_mem           buffer,
+  cl_bool          blocking_read,
+  size_t           offset,
+  size_t           cb,
+  void*            ptr,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_1
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueReadBufferRect)(
-    cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_read,
-    const size_t *buffer_origin, const size_t *host_origin,
-    const size_t *region, size_t buffer_row_pitch, size_t buffer_slice_pitch,
-    size_t host_row_pitch, size_t host_slice_pitch, void *ptr,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueReadBufferRect)(
+  cl_command_queue command_queue,
+  cl_mem           buffer,
+  cl_bool          blocking_read,
+  const size_t*    buffer_origin,
+  const size_t*    host_origin,
+  const size_t*    region,
+  size_t           buffer_row_pitch,
+  size_t           buffer_slice_pitch,
+  size_t           host_row_pitch,
+  size_t           host_slice_pitch,
+  void*            ptr,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_1;
 
 #else
 
-typedef void *cl_api_clEnqueueReadBufferRect;
+typedef void* cl_api_clEnqueueReadBufferRect;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueWriteBuffer)(
-    cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_write,
-    size_t offset, size_t cb, const void *ptr, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueWriteBuffer)(
+  cl_command_queue command_queue,
+  cl_mem           buffer,
+  cl_bool          blocking_write,
+  size_t           offset,
+  size_t           cb,
+  const void*      ptr,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_1
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueWriteBufferRect)(
-    cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_read,
-    const size_t *buffer_origin, const size_t *host_origin,
-    const size_t *region, size_t buffer_row_pitch, size_t buffer_slice_pitch,
-    size_t host_row_pitch, size_t host_slice_pitch, const void *ptr,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueWriteBufferRect)(
+  cl_command_queue command_queue,
+  cl_mem           buffer,
+  cl_bool          blocking_read,
+  const size_t*    buffer_origin,
+  const size_t*    host_origin,
+  const size_t*    region,
+  size_t           buffer_row_pitch,
+  size_t           buffer_slice_pitch,
+  size_t           host_row_pitch,
+  size_t           host_slice_pitch,
+  const void*      ptr,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_1;
 
 #else
 
-typedef void *cl_api_clEnqueueWriteBufferRect;
+typedef void* cl_api_clEnqueueWriteBufferRect;
 
 #endif
 
 #ifdef CL_VERSION_1_2
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueFillBuffer)(
-    cl_command_queue command_queue, cl_mem buffer, const void *pattern,
-    size_t pattern_size, size_t offset, size_t cb,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueFillBuffer)(
+  cl_command_queue command_queue,
+  cl_mem           buffer,
+  const void*      pattern,
+  size_t           pattern_size,
+  size_t           offset,
+  size_t           cb,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 #else
 
-typedef void *cl_api_clEnqueueFillBuffer;
+typedef void* cl_api_clEnqueueFillBuffer;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueCopyBuffer)(
-    cl_command_queue command_queue, cl_mem src_buffer, cl_mem dst_buffer,
-    size_t src_offset, size_t dst_offset, size_t cb,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueCopyBuffer)(
+  cl_command_queue command_queue,
+  cl_mem           src_buffer,
+  cl_mem           dst_buffer,
+  size_t           src_offset,
+  size_t           dst_offset,
+  size_t           cb,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_1
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueCopyBufferRect)(
-    cl_command_queue command_queue, cl_mem src_buffer, cl_mem dst_buffer,
-    const size_t *src_origin, const size_t *dst_origin, const size_t *region,
-    size_t src_row_pitch, size_t src_slice_pitch, size_t dst_row_pitch,
-    size_t dst_slice_pitch, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueCopyBufferRect)(
+  cl_command_queue command_queue,
+  cl_mem           src_buffer,
+  cl_mem           dst_buffer,
+  const size_t*    src_origin,
+  const size_t*    dst_origin,
+  const size_t*    region,
+  size_t           src_row_pitch,
+  size_t           src_slice_pitch,
+  size_t           dst_row_pitch,
+  size_t           dst_slice_pitch,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_1;
 
 #else
 
-typedef void *cl_api_clEnqueueCopyBufferRect;
+typedef void* cl_api_clEnqueueCopyBufferRect;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueReadImage)(
-    cl_command_queue command_queue, cl_mem image, cl_bool blocking_read,
-    const size_t *origin, const size_t *region, size_t row_pitch,
-    size_t slice_pitch, void *ptr, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueReadImage)(
+  cl_command_queue command_queue,
+  cl_mem           image,
+  cl_bool          blocking_read,
+  const size_t*    origin,
+  const size_t*    region,
+  size_t           row_pitch,
+  size_t           slice_pitch,
+  void*            ptr,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueWriteImage)(
-    cl_command_queue command_queue, cl_mem image, cl_bool blocking_write,
-    const size_t *origin, const size_t *region, size_t input_row_pitch,
-    size_t input_slice_pitch, const void *ptr, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueWriteImage)(
+  cl_command_queue command_queue,
+  cl_mem           image,
+  cl_bool          blocking_write,
+  const size_t*    origin,
+  const size_t*    region,
+  size_t           input_row_pitch,
+  size_t           input_slice_pitch,
+  const void*      ptr,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueFillImage)(
-    cl_command_queue command_queue, cl_mem image, const void *fill_color,
-    const size_t origin[3], const size_t region[3],
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueFillImage)(
+  cl_command_queue command_queue,
+  cl_mem           image,
+  const void*      fill_color,
+  const size_t     origin[3],
+  const size_t     region[3],
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 #else
 
-typedef void *cl_api_clEnqueueFillImage;
+typedef void* cl_api_clEnqueueFillImage;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueCopyImage)(
-    cl_command_queue command_queue, cl_mem src_image, cl_mem dst_image,
-    const size_t *src_origin, const size_t *dst_origin, const size_t *region,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueCopyImage)(
+  cl_command_queue command_queue,
+  cl_mem           src_image,
+  cl_mem           dst_image,
+  const size_t*    src_origin,
+  const size_t*    dst_origin,
+  const size_t*    region,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueCopyImageToBuffer)(
-    cl_command_queue command_queue, cl_mem src_image, cl_mem dst_buffer,
-    const size_t *src_origin, const size_t *region, size_t dst_offset,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueCopyImageToBuffer)(
+  cl_command_queue command_queue,
+  cl_mem           src_image,
+  cl_mem           dst_buffer,
+  const size_t*    src_origin,
+  const size_t*    region,
+  size_t           dst_offset,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueCopyBufferToImage)(
-    cl_command_queue command_queue, cl_mem src_buffer, cl_mem dst_image,
-    size_t src_offset, const size_t *dst_origin, const size_t *region,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueCopyBufferToImage)(
+  cl_command_queue command_queue,
+  cl_mem           src_buffer,
+  cl_mem           dst_image,
+  size_t           src_offset,
+  const size_t*    dst_origin,
+  const size_t*    region,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef void *(CL_API_CALL *cl_api_clEnqueueMapBuffer)(
-    cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_map,
-    cl_map_flags map_flags, size_t offset, size_t cb,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event, cl_int *errcode_ret)CL_API_SUFFIX__VERSION_1_0;
+typedef void*(CL_API_CALL* cl_api_clEnqueueMapBuffer)(
+  cl_command_queue command_queue,
+  cl_mem           buffer,
+  cl_bool          blocking_map,
+  cl_map_flags     map_flags,
+  size_t           offset,
+  size_t           cb,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event,
+  cl_int*          errcode_ret)CL_API_SUFFIX__VERSION_1_0;
 
-typedef void *(CL_API_CALL *cl_api_clEnqueueMapImage)(
-    cl_command_queue command_queue, cl_mem image, cl_bool blocking_map,
-    cl_map_flags map_flags, const size_t *origin, const size_t *region,
-    size_t *image_row_pitch, size_t *image_slice_pitch,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event, cl_int *errcode_ret)CL_API_SUFFIX__VERSION_1_0;
+typedef void*(CL_API_CALL* cl_api_clEnqueueMapImage)(
+  cl_command_queue command_queue,
+  cl_mem           image,
+  cl_bool          blocking_map,
+  cl_map_flags     map_flags,
+  const size_t*    origin,
+  const size_t*    region,
+  size_t*          image_row_pitch,
+  size_t*          image_slice_pitch,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event,
+  cl_int*          errcode_ret)CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueUnmapMemObject)(
-    cl_command_queue command_queue, cl_mem memobj, void *mapped_ptr,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueUnmapMemObject)(
+  cl_command_queue command_queue,
+  cl_mem           memobj,
+  void*            mapped_ptr,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueMigrateMemObjects)(
-    cl_command_queue command_queue, cl_uint num_mem_objects,
-    const cl_mem *mem_objects, cl_mem_migration_flags flags,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueMigrateMemObjects)(
+  cl_command_queue       command_queue,
+  cl_uint                num_mem_objects,
+  const cl_mem*          mem_objects,
+  cl_mem_migration_flags flags,
+  cl_uint                num_events_in_wait_list,
+  const cl_event*        event_wait_list,
+  cl_event*              event) CL_API_SUFFIX__VERSION_1_2;
 
 #else
 
-typedef void *cl_api_clEnqueueMigrateMemObjects;
+typedef void* cl_api_clEnqueueMigrateMemObjects;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueNDRangeKernel)(
-    cl_command_queue command_queue, cl_kernel kernel, cl_uint work_dim,
-    const size_t *global_work_offset, const size_t *global_work_size,
-    const size_t *local_work_size, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueNDRangeKernel)(
+  cl_command_queue command_queue,
+  cl_kernel        kernel,
+  cl_uint          work_dim,
+  const size_t*    global_work_offset,
+  const size_t*    global_work_size,
+  const size_t*    local_work_size,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueTask)(
-    cl_command_queue command_queue, cl_kernel kernel,
-    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueTask)(
+  cl_command_queue command_queue,
+  cl_kernel        kernel,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueNativeKernel)(
-    cl_command_queue command_queue, void(CL_CALLBACK *user_func)(void *),
-    void *args, size_t cb_args, cl_uint num_mem_objects, const cl_mem *mem_list,
-    const void **args_mem_loc, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueNativeKernel)(
+  cl_command_queue command_queue,
+  void(CL_CALLBACK* user_func)(void*),
+  void*           args,
+  size_t          cb_args,
+  cl_uint         num_mem_objects,
+  const cl_mem*   mem_list,
+  const void**    args_mem_loc,
+  cl_uint         num_events_in_wait_list,
+  const cl_event* event_wait_list,
+  cl_event*       event) CL_API_SUFFIX__VERSION_1_0;
 
 #ifdef CL_VERSION_1_2
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueMarkerWithWaitList)(
-    cl_command_queue command_queue, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueMarkerWithWaitList)(
+  cl_command_queue command_queue,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueBarrierWithWaitList)(
-    cl_command_queue command_queue, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueBarrierWithWaitList)(
+  cl_command_queue command_queue,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
-typedef void *(
-    CL_API_CALL *cl_api_clGetExtensionFunctionAddressForPlatform)(
-    cl_platform_id platform,
-    const char *function_name)CL_API_SUFFIX__VERSION_1_2;
+typedef void*(CL_API_CALL* cl_api_clGetExtensionFunctionAddressForPlatform)(
+  cl_platform_id platform,
+  const char*    function_name)CL_API_SUFFIX__VERSION_1_2;
 
 #else
 
-typedef void *cl_api_clEnqueueMarkerWithWaitList;
-typedef void *cl_api_clEnqueueBarrierWithWaitList;
-typedef void *cl_api_clGetExtensionFunctionAddressForPlatform;
+typedef void* cl_api_clEnqueueMarkerWithWaitList;
+typedef void* cl_api_clEnqueueBarrierWithWaitList;
+typedef void* cl_api_clGetExtensionFunctionAddressForPlatform;
 
 #endif
 
@@ -652,334 +863,473 @@ typedef void *cl_api_clGetExtensionFunctionAddressForPlatform;
 
 #ifdef CL_VERSION_2_0
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueSVMFree)(
-    cl_command_queue /* command_queue */, cl_uint /* num_svm_pointers */,
-    void ** /* svm_pointers */,
-    void(CL_CALLBACK *pfn_free_func)(cl_command_queue /* queue */,
-                                     cl_uint /* num_svm_pointers */,
-                                     void ** /* svm_pointers[] */,
-                                     void * /* user_data */),
-    void * /* user_data */, cl_uint /* num_events_in_wait_list */,
-    const cl_event * /* event_wait_list */,
-    cl_event * /* event */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueSVMFree)(
+  cl_command_queue /* command_queue */,
+  cl_uint /* num_svm_pointers */,
+  void** /* svm_pointers */,
+  void(CL_CALLBACK* pfn_free_func)(cl_command_queue /* queue */,
+                                   cl_uint /* num_svm_pointers */,
+                                   void** /* svm_pointers[] */,
+                                   void* /* user_data */),
+  void* /* user_data */,
+  cl_uint /* num_events_in_wait_list */,
+  const cl_event* /* event_wait_list */,
+  cl_event* /* event */) CL_API_SUFFIX__VERSION_2_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueSVMMemcpy)(
-    cl_command_queue /* command_queue */, cl_bool /* blocking_copy */,
-    void * /* dst_ptr */, const void * /* src_ptr */, size_t /* size */,
-    cl_uint /* num_events_in_wait_list */,
-    const cl_event * /* event_wait_list */,
-    cl_event * /* event */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueSVMMemcpy)(
+  cl_command_queue /* command_queue */,
+  cl_bool /* blocking_copy */,
+  void* /* dst_ptr */,
+  const void* /* src_ptr */,
+  size_t /* size */,
+  cl_uint /* num_events_in_wait_list */,
+  const cl_event* /* event_wait_list */,
+  cl_event* /* event */) CL_API_SUFFIX__VERSION_2_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueSVMMemFill)(
-    cl_command_queue /* command_queue */, void * /* svm_ptr */,
-    const void * /* pattern */, size_t /* pattern_size */, size_t /* size */,
-    cl_uint /* num_events_in_wait_list */,
-    const cl_event * /* event_wait_list */,
-    cl_event * /* event */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueSVMMemFill)(
+  cl_command_queue /* command_queue */,
+  void* /* svm_ptr */,
+  const void* /* pattern */,
+  size_t /* pattern_size */,
+  size_t /* size */,
+  cl_uint /* num_events_in_wait_list */,
+  const cl_event* /* event_wait_list */,
+  cl_event* /* event */) CL_API_SUFFIX__VERSION_2_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueSVMMap)(
-    cl_command_queue /* command_queue */, cl_bool /* blocking_map */,
-    cl_map_flags /* map_flags */, void * /* svm_ptr */, size_t /* size */,
-    cl_uint /* num_events_in_wait_list */,
-    const cl_event * /* event_wait_list */,
-    cl_event * /* event */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueSVMMap)(
+  cl_command_queue /* command_queue */,
+  cl_bool /* blocking_map */,
+  cl_map_flags /* map_flags */,
+  void* /* svm_ptr */,
+  size_t /* size */,
+  cl_uint /* num_events_in_wait_list */,
+  const cl_event* /* event_wait_list */,
+  cl_event* /* event */) CL_API_SUFFIX__VERSION_2_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueSVMUnmap)(
-    cl_command_queue /* command_queue */, void * /* svm_ptr */,
-    cl_uint /* num_events_in_wait_list */,
-    const cl_event * /* event_wait_list */,
-    cl_event * /* event */) CL_API_SUFFIX__VERSION_2_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueSVMUnmap)(
+  cl_command_queue /* command_queue */,
+  void* /* svm_ptr */,
+  cl_uint /* num_events_in_wait_list */,
+  const cl_event* /* event_wait_list */,
+  cl_event* /* event */) CL_API_SUFFIX__VERSION_2_0;
 
 #else
 
-typedef void *cl_api_clEnqueueSVMFree;
-typedef void *cl_api_clEnqueueSVMMemcpy;
-typedef void *cl_api_clEnqueueSVMMemFill;
-typedef void *cl_api_clEnqueueSVMMap;
-typedef void *cl_api_clEnqueueSVMUnmap;
+typedef void* cl_api_clEnqueueSVMFree;
+typedef void* cl_api_clEnqueueSVMMemcpy;
+typedef void* cl_api_clEnqueueSVMMemFill;
+typedef void* cl_api_clEnqueueSVMMap;
+typedef void* cl_api_clEnqueueSVMUnmap;
 
 #endif
 
 // Deprecated APIs
-typedef cl_int(CL_API_CALL *cl_api_clSetCommandQueueProperty)(
-    cl_command_queue command_queue, cl_command_queue_properties properties,
-    cl_bool enable, cl_command_queue_properties *old_properties)
-    CL_API_SUFFIX__VERSION_1_0_DEPRECATED;
+typedef cl_int(CL_API_CALL* cl_api_clSetCommandQueueProperty)(
+  cl_command_queue             command_queue,
+  cl_command_queue_properties  properties,
+  cl_bool                      enable,
+  cl_command_queue_properties* old_properties)
+  CL_API_SUFFIX__VERSION_1_0_DEPRECATED;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateImage2D)(
-    cl_context context, cl_mem_flags flags, const cl_image_format *image_format,
-    size_t image_width, size_t image_height, size_t image_row_pitch,
-    void *host_ptr, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateImage2D)(
+  cl_context             context,
+  cl_mem_flags           flags,
+  const cl_image_format* image_format,
+  size_t                 image_width,
+  size_t                 image_height,
+  size_t                 image_row_pitch,
+  void*                  host_ptr,
+  cl_int*                errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateImage3D)(
-    cl_context context, cl_mem_flags flags, const cl_image_format *image_format,
-    size_t image_width, size_t image_height, size_t image_depth,
-    size_t image_row_pitch, size_t image_slice_pitch, void *host_ptr,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateImage3D)(
+  cl_context             context,
+  cl_mem_flags           flags,
+  const cl_image_format* image_format,
+  size_t                 image_width,
+  size_t                 image_height,
+  size_t                 image_depth,
+  size_t                 image_row_pitch,
+  size_t                 image_slice_pitch,
+  void*                  host_ptr,
+  cl_int*                errcode_ret) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
-typedef cl_int(CL_API_CALL *cl_api_clUnloadCompiler)(void)
-    CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+typedef cl_int(CL_API_CALL* cl_api_clUnloadCompiler)(void)
+  CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueMarker)(
-    cl_command_queue command_queue,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueMarker)(
+  cl_command_queue command_queue,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueWaitForEvents)(
-    cl_command_queue command_queue, cl_uint num_events,
-    const cl_event *event_list) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueWaitForEvents)(
+  cl_command_queue command_queue,
+  cl_uint          num_events,
+  const cl_event*  event_list) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueBarrier)(
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueBarrier)(
+  cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
-typedef void *(CL_API_CALL *cl_api_clGetExtensionFunctionAddress)(
-    const char *function_name)CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
+typedef void*(CL_API_CALL* cl_api_clGetExtensionFunctionAddress)(
+  const char* function_name)CL_API_SUFFIX__VERSION_1_1_DEPRECATED;
 
 // GL and other APIs
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromGLBuffer)(
-    cl_context context, cl_mem_flags flags, cl_GLuint bufobj,
-    int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromGLBuffer)(cl_context   context,
+                                                         cl_mem_flags flags,
+                                                         cl_GLuint    bufobj,
+                                                         int* errcode_ret)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromGLTexture)(
-    cl_context context, cl_mem_flags flags, cl_GLenum target, cl_GLint miplevel,
-    cl_GLuint texture, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromGLTexture)(cl_context   context,
+                                                          cl_mem_flags flags,
+                                                          cl_GLenum    target,
+                                                          cl_GLint     miplevel,
+                                                          cl_GLuint    texture,
+                                                          cl_int* errcode_ret)
+  CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromGLTexture2D)(
-    cl_context context, cl_mem_flags flags, cl_GLenum target, cl_GLint miplevel,
-    cl_GLuint texture, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromGLTexture2D)(cl_context context,
+                                                            cl_mem_flags flags,
+                                                            cl_GLenum    target,
+                                                            cl_GLint  miplevel,
+                                                            cl_GLuint texture,
+                                                            cl_int* errcode_ret)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromGLTexture3D)(
-    cl_context context, cl_mem_flags flags, cl_GLenum target, cl_GLint miplevel,
-    cl_GLuint texture, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromGLTexture3D)(cl_context context,
+                                                            cl_mem_flags flags,
+                                                            cl_GLenum    target,
+                                                            cl_GLint  miplevel,
+                                                            cl_GLuint texture,
+                                                            cl_int* errcode_ret)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromGLRenderbuffer)(
-    cl_context context, cl_mem_flags flags, cl_GLuint renderbuffer,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromGLRenderbuffer)(
+  cl_context   context,
+  cl_mem_flags flags,
+  cl_GLuint    renderbuffer,
+  cl_int*      errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetGLObjectInfo)(
-    cl_mem memobj, cl_gl_object_type *gl_object_type,
-    cl_GLuint *gl_object_name) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetGLObjectInfo)(
+  cl_mem             memobj,
+  cl_gl_object_type* gl_object_type,
+  cl_GLuint*         gl_object_name) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetGLTextureInfo)(
-    cl_mem memobj, cl_gl_texture_info param_name, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetGLTextureInfo)(
+  cl_mem             memobj,
+  cl_gl_texture_info param_name,
+  size_t             param_value_size,
+  void*              param_value,
+  size_t*            param_value_size_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueAcquireGLObjects)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueAcquireGLObjects)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueReleaseGLObjects)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueReleaseGLObjects)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
 /* cl_khr_gl_sharing */
-typedef cl_int(CL_API_CALL *cl_api_clGetGLContextInfoKHR)(
-    const cl_context_properties *properties, cl_gl_context_info param_name,
-    size_t param_value_size, void *param_value, size_t *param_value_size_ret);
+typedef cl_int(CL_API_CALL* cl_api_clGetGLContextInfoKHR)(
+  const cl_context_properties* properties,
+  cl_gl_context_info           param_name,
+  size_t                       param_value_size,
+  void*                        param_value,
+  size_t*                      param_value_size_ret);
 
 /* cl_khr_gl_event */
-typedef cl_event(CL_API_CALL *cl_api_clCreateEventFromGLsyncKHR)(
-    cl_context context, cl_GLsync sync, cl_int *errcode_ret);
+typedef cl_event(CL_API_CALL* cl_api_clCreateEventFromGLsyncKHR)(
+  cl_context context,
+  cl_GLsync  sync,
+  cl_int*    errcode_ret);
 
 #if defined(_WIN32)
 
 /* cl_khr_d3d10_sharing */
 
-typedef cl_int(CL_API_CALL *cl_api_clGetDeviceIDsFromD3D10KHR)(
-    cl_platform_id platform, cl_d3d10_device_source_khr d3d_device_source,
-    void *d3d_object, cl_d3d10_device_set_khr d3d_device_set,
-    cl_uint num_entries, cl_device_id *devices,
-    cl_uint *num_devices) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clGetDeviceIDsFromD3D10KHR)(
+  cl_platform_id             platform,
+  cl_d3d10_device_source_khr d3d_device_source,
+  void*                      d3d_object,
+  cl_d3d10_device_set_khr    d3d_device_set,
+  cl_uint                    num_entries,
+  cl_device_id*              devices,
+  cl_uint*                   num_devices) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromD3D10BufferKHR)(
-    cl_context context, cl_mem_flags flags, ID3D10Buffer *resource,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromD3D10BufferKHR)(
+  cl_context    context,
+  cl_mem_flags  flags,
+  ID3D10Buffer* resource,
+  cl_int*       errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromD3D10Texture2DKHR)(
-    cl_context context, cl_mem_flags flags, ID3D10Texture2D *resource,
-    UINT subresource, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromD3D10Texture2DKHR)(
+  cl_context       context,
+  cl_mem_flags     flags,
+  ID3D10Texture2D* resource,
+  UINT             subresource,
+  cl_int*          errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromD3D10Texture3DKHR)(
-    cl_context context, cl_mem_flags flags, ID3D10Texture3D *resource,
-    UINT subresource, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromD3D10Texture3DKHR)(
+  cl_context       context,
+  cl_mem_flags     flags,
+  ID3D10Texture3D* resource,
+  UINT             subresource,
+  cl_int*          errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
-typedef
-cl_int(CL_API_CALL *cl_api_clEnqueueAcquireD3D10ObjectsKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueAcquireD3D10ObjectsKHR)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-typedef
-cl_int(CL_API_CALL *cl_api_clEnqueueReleaseD3D10ObjectsKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueReleaseD3D10ObjectsKHR)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_0;
 
-extern CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D10KHR(
-    cl_platform_id platform, cl_d3d10_device_source_khr d3d_device_source,
-    void *d3d_object, cl_d3d10_device_set_khr d3d_device_set,
-    cl_uint num_entries, cl_device_id *devices, cl_uint *num_devices);
-
-extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateFromD3D10BufferKHR(cl_context context, cl_mem_flags flags,
-                           ID3D10Buffer *resource, cl_int *errcode_ret);
-
-extern CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture2DKHR(
-    cl_context context, cl_mem_flags flags, ID3D10Texture2D *resource,
-    UINT subresource, cl_int *errcode_ret);
-
-extern CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D10Texture3DKHR(
-    cl_context context, cl_mem_flags flags, ID3D10Texture3D *resource,
-    UINT subresource, cl_int *errcode_ret);
-
-extern CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D10ObjectsKHR(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list, cl_event *event);
-
-extern CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D10ObjectsKHR(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list, cl_event *event);
-
-/* cl_khr_d3d11_sharing */
-typedef cl_int(CL_API_CALL *cl_api_clGetDeviceIDsFromD3D11KHR)(
-    cl_platform_id platform, cl_d3d11_device_source_khr d3d_device_source,
-    void *d3d_object, cl_d3d11_device_set_khr d3d_device_set,
-    cl_uint num_entries, cl_device_id *devices,
-    cl_uint *num_devices) CL_API_SUFFIX__VERSION_1_2;
-
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromD3D11BufferKHR)(
-    cl_context context, cl_mem_flags flags, ID3D11Buffer *resource,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_2;
-
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromD3D11Texture2DKHR)(
-    cl_context context, cl_mem_flags flags, ID3D11Texture2D *resource,
-    UINT subresource, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_2;
-
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromD3D11Texture3DKHR)(
-    cl_context context, cl_mem_flags flags, ID3D11Texture3D *resource,
-    UINT subresource, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_2;
-
-typedef
-cl_int(CL_API_CALL *cl_api_clEnqueueAcquireD3D11ObjectsKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_2;
-
-typedef
-cl_int(CL_API_CALL *cl_api_clEnqueueReleaseD3D11ObjectsKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_2;
-
-/* cl_khr_dx9_media_sharing */
-typedef
-cl_int(CL_API_CALL *cl_api_clGetDeviceIDsFromDX9MediaAdapterKHR)(
-    cl_platform_id platform, cl_uint num_media_adapters,
-    cl_dx9_media_adapter_type_khr *media_adapters_type, void *media_adapters,
-    cl_dx9_media_adapter_set_khr media_adapter_set, cl_uint num_entries,
-    cl_device_id *devices, cl_uint *num_devices) CL_API_SUFFIX__VERSION_1_2;
-
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromDX9MediaSurfaceKHR)(
-    cl_context context, cl_mem_flags flags,
-    cl_dx9_media_adapter_type_khr adapter_type, void *surface_info,
-    cl_uint plane, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_2;
-
-typedef
-cl_int(CL_API_CALL *cl_api_clEnqueueAcquireDX9MediaSurfacesKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_2;
-
-typedef
-cl_int(CL_API_CALL *cl_api_clEnqueueReleaseDX9MediaSurfacesKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_1_2;
-
-/* cl_khr_d3d11_sharing */
-extern CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromD3D11KHR(
-    cl_platform_id platform, cl_d3d11_device_source_khr d3d_device_source,
-    void *d3d_object, cl_d3d11_device_set_khr d3d_device_set,
-    cl_uint num_entries, cl_device_id *devices, cl_uint *num_devices);
+extern CL_API_ENTRY cl_int CL_API_CALL
+clGetDeviceIDsFromD3D10KHR(cl_platform_id             platform,
+                           cl_d3d10_device_source_khr d3d_device_source,
+                           void*                      d3d_object,
+                           cl_d3d10_device_set_khr    d3d_device_set,
+                           cl_uint                    num_entries,
+                           cl_device_id*              devices,
+                           cl_uint*                   num_devices);
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateFromD3D11BufferKHR(cl_context context, cl_mem_flags flags,
-                           ID3D11Buffer *resource, cl_int *errcode_ret);
+clCreateFromD3D10BufferKHR(cl_context    context,
+                           cl_mem_flags  flags,
+                           ID3D10Buffer* resource,
+                           cl_int*       errcode_ret);
 
-extern CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture2DKHR(
-    cl_context context, cl_mem_flags flags, ID3D11Texture2D *resource,
-    UINT subresource, cl_int *errcode_ret);
+extern CL_API_ENTRY cl_mem CL_API_CALL
+clCreateFromD3D10Texture2DKHR(cl_context       context,
+                              cl_mem_flags     flags,
+                              ID3D10Texture2D* resource,
+                              UINT             subresource,
+                              cl_int*          errcode_ret);
 
-extern CL_API_ENTRY cl_mem CL_API_CALL clCreateFromD3D11Texture3DKHR(
-    cl_context context, cl_mem_flags flags, ID3D11Texture3D *resource,
-    UINT subresource, cl_int *errcode_ret);
+extern CL_API_ENTRY cl_mem CL_API_CALL
+clCreateFromD3D10Texture3DKHR(cl_context       context,
+                              cl_mem_flags     flags,
+                              ID3D10Texture3D* resource,
+                              UINT             subresource,
+                              cl_int*          errcode_ret);
 
-extern CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireD3D11ObjectsKHR(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list, cl_event *event);
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueAcquireD3D10ObjectsKHR(cl_command_queue command_queue,
+                                cl_uint          num_objects,
+                                const cl_mem*    mem_objects,
+                                cl_uint          num_events_in_wait_list,
+                                const cl_event*  event_wait_list,
+                                cl_event*        event);
 
-extern CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseD3D11ObjectsKHR(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list, cl_event *event);
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueReleaseD3D10ObjectsKHR(cl_command_queue command_queue,
+                                cl_uint          num_objects,
+                                const cl_mem*    mem_objects,
+                                cl_uint          num_events_in_wait_list,
+                                const cl_event*  event_wait_list,
+                                cl_event*        event);
+
+/* cl_khr_d3d11_sharing */
+typedef cl_int(CL_API_CALL* cl_api_clGetDeviceIDsFromD3D11KHR)(
+  cl_platform_id             platform,
+  cl_d3d11_device_source_khr d3d_device_source,
+  void*                      d3d_object,
+  cl_d3d11_device_set_khr    d3d_device_set,
+  cl_uint                    num_entries,
+  cl_device_id*              devices,
+  cl_uint*                   num_devices) CL_API_SUFFIX__VERSION_1_2;
+
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromD3D11BufferKHR)(
+  cl_context    context,
+  cl_mem_flags  flags,
+  ID3D11Buffer* resource,
+  cl_int*       errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromD3D11Texture2DKHR)(
+  cl_context       context,
+  cl_mem_flags     flags,
+  ID3D11Texture2D* resource,
+  UINT             subresource,
+  cl_int*          errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromD3D11Texture3DKHR)(
+  cl_context       context,
+  cl_mem_flags     flags,
+  ID3D11Texture3D* resource,
+  UINT             subresource,
+  cl_int*          errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueAcquireD3D11ObjectsKHR)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
+
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueReleaseD3D11ObjectsKHR)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 /* cl_khr_dx9_media_sharing */
-extern CL_API_ENTRY cl_int CL_API_CALL clGetDeviceIDsFromDX9MediaAdapterKHR(
-    cl_platform_id platform, cl_uint num_media_adapters,
-    cl_dx9_media_adapter_type_khr *media_adapter_type, void *media_adapters,
-    cl_dx9_media_adapter_set_khr media_adapter_set, cl_uint num_entries,
-    cl_device_id *devices, cl_uint *num_devices);
+typedef cl_int(CL_API_CALL* cl_api_clGetDeviceIDsFromDX9MediaAdapterKHR)(
+  cl_platform_id                 platform,
+  cl_uint                        num_media_adapters,
+  cl_dx9_media_adapter_type_khr* media_adapters_type,
+  void*                          media_adapters,
+  cl_dx9_media_adapter_set_khr   media_adapter_set,
+  cl_uint                        num_entries,
+  cl_device_id*                  devices,
+  cl_uint*                       num_devices) CL_API_SUFFIX__VERSION_1_2;
 
-extern CL_API_ENTRY cl_mem CL_API_CALL clCreateFromDX9MediaSurfaceKHR(
-    cl_context context, cl_mem_flags flags,
-    cl_dx9_media_adapter_type_khr adapter_type, void *surface_info,
-    cl_uint plane, cl_int *errcode_ret);
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromDX9MediaSurfaceKHR)(
+  cl_context                    context,
+  cl_mem_flags                  flags,
+  cl_dx9_media_adapter_type_khr adapter_type,
+  void*                         surface_info,
+  cl_uint                       plane,
+  cl_int*                       errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
-extern CL_API_ENTRY cl_int CL_API_CALL clEnqueueAcquireDX9MediaSurfacesKHR(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list, cl_event *event);
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueAcquireDX9MediaSurfacesKHR)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
-extern CL_API_ENTRY cl_int CL_API_CALL clEnqueueReleaseDX9MediaSurfacesKHR(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list, cl_event *event);
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueReleaseDX9MediaSurfacesKHR)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
+
+/* cl_khr_d3d11_sharing */
+extern CL_API_ENTRY cl_int CL_API_CALL
+clGetDeviceIDsFromD3D11KHR(cl_platform_id             platform,
+                           cl_d3d11_device_source_khr d3d_device_source,
+                           void*                      d3d_object,
+                           cl_d3d11_device_set_khr    d3d_device_set,
+                           cl_uint                    num_entries,
+                           cl_device_id*              devices,
+                           cl_uint*                   num_devices);
+
+extern CL_API_ENTRY cl_mem CL_API_CALL
+clCreateFromD3D11BufferKHR(cl_context    context,
+                           cl_mem_flags  flags,
+                           ID3D11Buffer* resource,
+                           cl_int*       errcode_ret);
+
+extern CL_API_ENTRY cl_mem CL_API_CALL
+clCreateFromD3D11Texture2DKHR(cl_context       context,
+                              cl_mem_flags     flags,
+                              ID3D11Texture2D* resource,
+                              UINT             subresource,
+                              cl_int*          errcode_ret);
+
+extern CL_API_ENTRY cl_mem CL_API_CALL
+clCreateFromD3D11Texture3DKHR(cl_context       context,
+                              cl_mem_flags     flags,
+                              ID3D11Texture3D* resource,
+                              UINT             subresource,
+                              cl_int*          errcode_ret);
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueAcquireD3D11ObjectsKHR(cl_command_queue command_queue,
+                                cl_uint          num_objects,
+                                const cl_mem*    mem_objects,
+                                cl_uint          num_events_in_wait_list,
+                                const cl_event*  event_wait_list,
+                                cl_event*        event);
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueReleaseD3D11ObjectsKHR(cl_command_queue command_queue,
+                                cl_uint          num_objects,
+                                const cl_mem*    mem_objects,
+                                cl_uint          num_events_in_wait_list,
+                                const cl_event*  event_wait_list,
+                                cl_event*        event);
+
+/* cl_khr_dx9_media_sharing */
+extern CL_API_ENTRY cl_int CL_API_CALL
+clGetDeviceIDsFromDX9MediaAdapterKHR(
+  cl_platform_id                 platform,
+  cl_uint                        num_media_adapters,
+  cl_dx9_media_adapter_type_khr* media_adapter_type,
+  void*                          media_adapters,
+  cl_dx9_media_adapter_set_khr   media_adapter_set,
+  cl_uint                        num_entries,
+  cl_device_id*                  devices,
+  cl_uint*                       num_devices);
+
+extern CL_API_ENTRY cl_mem CL_API_CALL
+clCreateFromDX9MediaSurfaceKHR(cl_context                    context,
+                               cl_mem_flags                  flags,
+                               cl_dx9_media_adapter_type_khr adapter_type,
+                               void*                         surface_info,
+                               cl_uint                       plane,
+                               cl_int*                       errcode_ret);
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueAcquireDX9MediaSurfacesKHR(cl_command_queue command_queue,
+                                    cl_uint          num_objects,
+                                    const cl_mem*    mem_objects,
+                                    cl_uint          num_events_in_wait_list,
+                                    const cl_event*  event_wait_list,
+                                    cl_event*        event);
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueReleaseDX9MediaSurfacesKHR(cl_command_queue command_queue,
+                                    cl_uint          num_objects,
+                                    const cl_mem*    mem_objects,
+                                    cl_uint          num_events_in_wait_list,
+                                    const cl_event*  event_wait_list,
+                                    cl_event*        event);
 
 #else
 
 /* cl_khr_d3d10_sharing */
-typedef void *cl_api_clGetDeviceIDsFromD3D10KHR;
-typedef void *cl_api_clCreateFromD3D10BufferKHR;
-typedef void *cl_api_clCreateFromD3D10Texture2DKHR;
-typedef void *cl_api_clCreateFromD3D10Texture3DKHR;
-typedef void *cl_api_clEnqueueAcquireD3D10ObjectsKHR;
-typedef void *cl_api_clEnqueueReleaseD3D10ObjectsKHR;
+typedef void* cl_api_clGetDeviceIDsFromD3D10KHR;
+typedef void* cl_api_clCreateFromD3D10BufferKHR;
+typedef void* cl_api_clCreateFromD3D10Texture2DKHR;
+typedef void* cl_api_clCreateFromD3D10Texture3DKHR;
+typedef void* cl_api_clEnqueueAcquireD3D10ObjectsKHR;
+typedef void* cl_api_clEnqueueReleaseD3D10ObjectsKHR;
 
 /* cl_khr_d3d11_sharing */
-typedef void *cl_api_clGetDeviceIDsFromD3D11KHR;
-typedef void *cl_api_clCreateFromD3D11BufferKHR;
-typedef void *cl_api_clCreateFromD3D11Texture2DKHR;
-typedef void *cl_api_clCreateFromD3D11Texture3DKHR;
-typedef void *cl_api_clEnqueueAcquireD3D11ObjectsKHR;
-typedef void *cl_api_clEnqueueReleaseD3D11ObjectsKHR;
+typedef void* cl_api_clGetDeviceIDsFromD3D11KHR;
+typedef void* cl_api_clCreateFromD3D11BufferKHR;
+typedef void* cl_api_clCreateFromD3D11Texture2DKHR;
+typedef void* cl_api_clCreateFromD3D11Texture3DKHR;
+typedef void* cl_api_clEnqueueAcquireD3D11ObjectsKHR;
+typedef void* cl_api_clEnqueueReleaseD3D11ObjectsKHR;
 
 /* cl_khr_dx9_media_sharing */
-typedef void *cl_api_clCreateFromDX9MediaSurfaceKHR;
-typedef void *cl_api_clEnqueueAcquireDX9MediaSurfacesKHR;
-typedef void *cl_api_clEnqueueReleaseDX9MediaSurfacesKHR;
-typedef void *cl_api_clGetDeviceIDsFromDX9MediaAdapterKHR;
+typedef void* cl_api_clCreateFromDX9MediaSurfaceKHR;
+typedef void* cl_api_clEnqueueAcquireDX9MediaSurfacesKHR;
+typedef void* cl_api_clEnqueueReleaseDX9MediaSurfacesKHR;
+typedef void* cl_api_clGetDeviceIDsFromDX9MediaAdapterKHR;
 
 #endif
 
@@ -987,303 +1337,331 @@ typedef void *cl_api_clGetDeviceIDsFromDX9MediaAdapterKHR;
 
 #ifdef CL_VERSION_1_1
 
-typedef cl_int(CL_API_CALL *cl_api_clSetEventCallback)(
-    cl_event /* event */, cl_int /* command_exec_callback_type */,
-    void(CL_CALLBACK * /* pfn_notify */)(cl_event, cl_int, void *),
-    void * /* user_data */) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* cl_api_clSetEventCallback)(
+  cl_event /* event */,
+  cl_int /* command_exec_callback_type */,
+  void(CL_CALLBACK* /* pfn_notify */)(cl_event, cl_int, void*),
+  void* /* user_data */) CL_API_SUFFIX__VERSION_1_1;
 
-typedef cl_mem(CL_API_CALL *cl_api_clCreateSubBuffer)(
-    cl_mem /* buffer */, cl_mem_flags /* flags */,
-    cl_buffer_create_type /* buffer_create_type */,
-    const void * /* buffer_create_info */,
-    cl_int * /* errcode_ret */) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_mem(CL_API_CALL* cl_api_clCreateSubBuffer)(
+  cl_mem /* buffer */,
+  cl_mem_flags /* flags */,
+  cl_buffer_create_type /* buffer_create_type */,
+  const void* /* buffer_create_info */,
+  cl_int* /* errcode_ret */) CL_API_SUFFIX__VERSION_1_1;
 
-typedef
-cl_int(CL_API_CALL *cl_api_clSetMemObjectDestructorCallback)(
-    cl_mem /* memobj */,
-    void(CL_CALLBACK * /*pfn_notify*/)(cl_mem /* memobj */,
-                                       void * /*user_data*/),
-    void * /*user_data */) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* cl_api_clSetMemObjectDestructorCallback)(
+  cl_mem /* memobj */,
+  void(CL_CALLBACK* /*pfn_notify*/)(cl_mem /* memobj */, void* /*user_data*/),
+  void* /*user_data */) CL_API_SUFFIX__VERSION_1_1;
 
-typedef cl_event(CL_API_CALL *cl_api_clCreateUserEvent)(
-    cl_context /* context */,
-    cl_int * /* errcode_ret */) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_event(CL_API_CALL* cl_api_clCreateUserEvent)(
+  cl_context /* context */,
+  cl_int* /* errcode_ret */) CL_API_SUFFIX__VERSION_1_1;
 
-typedef cl_int(CL_API_CALL *cl_api_clSetUserEventStatus)(
-    cl_event /* event */,
-    cl_int /* execution_status */) CL_API_SUFFIX__VERSION_1_1;
+typedef cl_int(CL_API_CALL* cl_api_clSetUserEventStatus)(
+  cl_event /* event */,
+  cl_int /* execution_status */) CL_API_SUFFIX__VERSION_1_1;
 
 #else
 
-typedef void *cl_api_clSetEventCallback;
-typedef void *cl_api_clCreateSubBuffer;
-typedef void *cl_api_clSetMemObjectDestructorCallback;
-typedef void *cl_api_clCreateUserEvent;
-typedef void *cl_api_clSetUserEventStatus;
+typedef void* cl_api_clSetEventCallback;
+typedef void* cl_api_clCreateSubBuffer;
+typedef void* cl_api_clSetMemObjectDestructorCallback;
+typedef void* cl_api_clCreateUserEvent;
+typedef void* cl_api_clSetUserEventStatus;
 
 #endif
 
-typedef cl_int(CL_API_CALL *cl_api_clCreateSubDevicesEXT)(
-    cl_device_id in_device,
-    const cl_device_partition_property_ext *partition_properties,
-    cl_uint num_entries, cl_device_id *out_devices, cl_uint *num_devices);
+typedef cl_int(CL_API_CALL* cl_api_clCreateSubDevicesEXT)(
+  cl_device_id                            in_device,
+  const cl_device_partition_property_ext* partition_properties,
+  cl_uint                                 num_entries,
+  cl_device_id*                           out_devices,
+  cl_uint*                                num_devices);
 
-typedef cl_int(CL_API_CALL *cl_api_clRetainDeviceEXT)(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clRetainDeviceEXT)(cl_device_id device)
+  CL_API_SUFFIX__VERSION_1_0;
 
-typedef cl_int(CL_API_CALL *cl_api_clReleaseDeviceEXT)(
-    cl_device_id device) CL_API_SUFFIX__VERSION_1_0;
+typedef cl_int(CL_API_CALL* cl_api_clReleaseDeviceEXT)(cl_device_id device)
+  CL_API_SUFFIX__VERSION_1_0;
 
 /* cl_khr_egl_image */
-typedef cl_mem(CL_API_CALL *cl_api_clCreateFromEGLImageKHR)(
-    cl_context context, CLeglDisplayKHR display, CLeglImageKHR image,
-    cl_mem_flags flags, const cl_egl_image_properties_khr *properties,
-    cl_int *errcode_ret);
+typedef cl_mem(CL_API_CALL* cl_api_clCreateFromEGLImageKHR)(
+  cl_context                         context,
+  CLeglDisplayKHR                    display,
+  CLeglImageKHR                      image,
+  cl_mem_flags                       flags,
+  const cl_egl_image_properties_khr* properties,
+  cl_int*                            errcode_ret);
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueAcquireEGLObjectsKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list, cl_event *event);
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueAcquireEGLObjectsKHR)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event);
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueReleaseEGLObjectsKHR)(
-    cl_command_queue command_queue, cl_uint num_objects,
-    const cl_mem *mem_objects, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list, cl_event *event);
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueReleaseEGLObjectsKHR)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event);
 
 /* cl_khr_egl_event */
-typedef cl_event(CL_API_CALL *cl_api_clCreateEventFromEGLSyncKHR)(
-    cl_context context, CLeglSyncKHR sync, CLeglDisplayKHR display,
-    cl_int *errcode_ret);
+typedef cl_event(CL_API_CALL* cl_api_clCreateEventFromEGLSyncKHR)(
+  cl_context      context,
+  CLeglSyncKHR    sync,
+  CLeglDisplayKHR display,
+  cl_int*         errcode_ret);
 
 #ifdef CL_VERSION_2_1
 
-typedef cl_int(CL_API_CALL *cl_api_clSetDefaultDeviceCommandQueue)(
-    cl_context context, cl_device_id device,
-    cl_command_queue command_queue) CL_API_SUFFIX__VERSION_2_1;
+typedef cl_int(CL_API_CALL* cl_api_clSetDefaultDeviceCommandQueue)(
+  cl_context       context,
+  cl_device_id     device,
+  cl_command_queue command_queue) CL_API_SUFFIX__VERSION_2_1;
 
-typedef cl_program(CL_API_CALL *cl_api_clCreateProgramWithIL)(
-    cl_context context, const void *il, size_t length,
-    cl_int *errcode_ret) CL_API_SUFFIX__VERSION_2_1;
+typedef cl_program(CL_API_CALL* cl_api_clCreateProgramWithIL)(
+  cl_context  context,
+  const void* il,
+  size_t      length,
+  cl_int*     errcode_ret) CL_API_SUFFIX__VERSION_2_1;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetKernelSubGroupInfo)(
-    cl_kernel kernel, cl_device_id device, cl_kernel_sub_group_info param_name,
-    size_t input_value_size, const void *input_value, size_t param_value_size,
-    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_2_1;
+typedef cl_int(CL_API_CALL* cl_api_clGetKernelSubGroupInfo)(
+  cl_kernel                kernel,
+  cl_device_id             device,
+  cl_kernel_sub_group_info param_name,
+  size_t                   input_value_size,
+  const void*              input_value,
+  size_t                   param_value_size,
+  void*                    param_value,
+  size_t*                  param_value_size_ret) CL_API_SUFFIX__VERSION_2_1;
 
-typedef cl_kernel(CL_API_CALL *cl_api_clCloneKernel)(
-    cl_kernel source_kernel, cl_int *errcode_ret) CL_API_SUFFIX__VERSION_2_1;
+typedef cl_kernel(CL_API_CALL* cl_api_clCloneKernel)(cl_kernel source_kernel,
+                                                     cl_int*   errcode_ret)
+  CL_API_SUFFIX__VERSION_2_1;
 
-typedef cl_int(CL_API_CALL *cl_api_clEnqueueSVMMigrateMem)(
-    cl_command_queue command_queue, cl_uint num_svm_pointers,
-    const void **svm_pointers, const size_t *sizes,
-    cl_mem_migration_flags flags, cl_uint num_events_in_wait_list,
-    const cl_event *event_wait_list,
-    cl_event *event) CL_API_SUFFIX__VERSION_2_1;
+typedef cl_int(CL_API_CALL* cl_api_clEnqueueSVMMigrateMem)(
+  cl_command_queue       command_queue,
+  cl_uint                num_svm_pointers,
+  const void**           svm_pointers,
+  const size_t*          sizes,
+  cl_mem_migration_flags flags,
+  cl_uint                num_events_in_wait_list,
+  const cl_event*        event_wait_list,
+  cl_event*              event) CL_API_SUFFIX__VERSION_2_1;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetDeviceAndHostTimer)(
-    cl_device_id device, cl_ulong *device_timestamp,
-    cl_ulong *host_timestamp) CL_API_SUFFIX__VERSION_2_1;
+typedef cl_int(CL_API_CALL* cl_api_clGetDeviceAndHostTimer)(
+  cl_device_id device,
+  cl_ulong*    device_timestamp,
+  cl_ulong*    host_timestamp) CL_API_SUFFIX__VERSION_2_1;
 
-typedef cl_int(CL_API_CALL *cl_api_clGetHostTimer)(
-    cl_device_id device, cl_ulong *host_timestamp) CL_API_SUFFIX__VERSION_2_1;
+typedef cl_int(CL_API_CALL* cl_api_clGetHostTimer)(cl_device_id device,
+                                                   cl_ulong*    host_timestamp)
+  CL_API_SUFFIX__VERSION_2_1;
 
 #else
 
-typedef void *cl_api_clSetDefaultDeviceCommandQueue;
-typedef void *cl_api_clCreateProgramWithIL;
-typedef void *cl_api_clGetKernelSubGroupInfo;
-typedef void *cl_api_clCloneKernel;
-typedef void *cl_api_clEnqueueSVMMigrateMem;
-typedef void *cl_api_clGetDeviceAndHostTimer;
-typedef void *cl_api_clGetHostTimer;
+typedef void* cl_api_clSetDefaultDeviceCommandQueue;
+typedef void* cl_api_clCreateProgramWithIL;
+typedef void* cl_api_clGetKernelSubGroupInfo;
+typedef void* cl_api_clCloneKernel;
+typedef void* cl_api_clEnqueueSVMMigrateMem;
+typedef void* cl_api_clGetDeviceAndHostTimer;
+typedef void* cl_api_clGetHostTimer;
 
 #endif
 
 /* Vendor dispatch table structure */
 
-typedef struct _cl_icd_dispatch {
+typedef struct _cl_icd_dispatch
+{
   /* OpenCL 1.0 */
-  cl_api_clGetPlatformIDs clGetPlatformIDs;
-  cl_api_clGetPlatformInfo clGetPlatformInfo;
-  cl_api_clGetDeviceIDs clGetDeviceIDs;
-  cl_api_clGetDeviceInfo clGetDeviceInfo;
-  cl_api_clCreateContext clCreateContext;
-  cl_api_clCreateContextFromType clCreateContextFromType;
-  cl_api_clRetainContext clRetainContext;
-  cl_api_clReleaseContext clReleaseContext;
-  cl_api_clGetContextInfo clGetContextInfo;
-  cl_api_clCreateCommandQueue clCreateCommandQueue;
-  cl_api_clRetainCommandQueue clRetainCommandQueue;
-  cl_api_clReleaseCommandQueue clReleaseCommandQueue;
-  cl_api_clGetCommandQueueInfo clGetCommandQueueInfo;
-  cl_api_clSetCommandQueueProperty clSetCommandQueueProperty;
-  cl_api_clCreateBuffer clCreateBuffer;
-  cl_api_clCreateImage2D clCreateImage2D;
-  cl_api_clCreateImage3D clCreateImage3D;
-  cl_api_clRetainMemObject clRetainMemObject;
-  cl_api_clReleaseMemObject clReleaseMemObject;
-  cl_api_clGetSupportedImageFormats clGetSupportedImageFormats;
-  cl_api_clGetMemObjectInfo clGetMemObjectInfo;
-  cl_api_clGetImageInfo clGetImageInfo;
-  cl_api_clCreateSampler clCreateSampler;
-  cl_api_clRetainSampler clRetainSampler;
-  cl_api_clReleaseSampler clReleaseSampler;
-  cl_api_clGetSamplerInfo clGetSamplerInfo;
-  cl_api_clCreateProgramWithSource clCreateProgramWithSource;
-  cl_api_clCreateProgramWithBinary clCreateProgramWithBinary;
-  cl_api_clRetainProgram clRetainProgram;
-  cl_api_clReleaseProgram clReleaseProgram;
-  cl_api_clBuildProgram clBuildProgram;
-  cl_api_clUnloadCompiler clUnloadCompiler;
-  cl_api_clGetProgramInfo clGetProgramInfo;
-  cl_api_clGetProgramBuildInfo clGetProgramBuildInfo;
-  cl_api_clCreateKernel clCreateKernel;
-  cl_api_clCreateKernelsInProgram clCreateKernelsInProgram;
-  cl_api_clRetainKernel clRetainKernel;
-  cl_api_clReleaseKernel clReleaseKernel;
-  cl_api_clSetKernelArg clSetKernelArg;
-  cl_api_clGetKernelInfo clGetKernelInfo;
-  cl_api_clGetKernelWorkGroupInfo clGetKernelWorkGroupInfo;
-  cl_api_clWaitForEvents clWaitForEvents;
-  cl_api_clGetEventInfo clGetEventInfo;
-  cl_api_clRetainEvent clRetainEvent;
-  cl_api_clReleaseEvent clReleaseEvent;
-  cl_api_clGetEventProfilingInfo clGetEventProfilingInfo;
-  cl_api_clFlush clFlush;
-  cl_api_clFinish clFinish;
-  cl_api_clEnqueueReadBuffer clEnqueueReadBuffer;
-  cl_api_clEnqueueWriteBuffer clEnqueueWriteBuffer;
-  cl_api_clEnqueueCopyBuffer clEnqueueCopyBuffer;
-  cl_api_clEnqueueReadImage clEnqueueReadImage;
-  cl_api_clEnqueueWriteImage clEnqueueWriteImage;
-  cl_api_clEnqueueCopyImage clEnqueueCopyImage;
-  cl_api_clEnqueueCopyImageToBuffer clEnqueueCopyImageToBuffer;
-  cl_api_clEnqueueCopyBufferToImage clEnqueueCopyBufferToImage;
-  cl_api_clEnqueueMapBuffer clEnqueueMapBuffer;
-  cl_api_clEnqueueMapImage clEnqueueMapImage;
-  cl_api_clEnqueueUnmapMemObject clEnqueueUnmapMemObject;
-  cl_api_clEnqueueNDRangeKernel clEnqueueNDRangeKernel;
-  cl_api_clEnqueueTask clEnqueueTask;
-  cl_api_clEnqueueNativeKernel clEnqueueNativeKernel;
-  cl_api_clEnqueueMarker clEnqueueMarker;
-  cl_api_clEnqueueWaitForEvents clEnqueueWaitForEvents;
-  cl_api_clEnqueueBarrier clEnqueueBarrier;
-  cl_api_clGetExtensionFunctionAddress clGetExtensionFunctionAddress;
-  cl_api_clCreateFromGLBuffer clCreateFromGLBuffer;
-  cl_api_clCreateFromGLTexture2D clCreateFromGLTexture2D;
-  cl_api_clCreateFromGLTexture3D clCreateFromGLTexture3D;
-  cl_api_clCreateFromGLRenderbuffer clCreateFromGLRenderbuffer;
-  cl_api_clGetGLObjectInfo clGetGLObjectInfo;
-  cl_api_clGetGLTextureInfo clGetGLTextureInfo;
-  cl_api_clEnqueueAcquireGLObjects clEnqueueAcquireGLObjects;
-  cl_api_clEnqueueReleaseGLObjects clEnqueueReleaseGLObjects;
-  cl_api_clGetGLContextInfoKHR clGetGLContextInfoKHR;
+  cl_api_clGetPlatformIDs                  clGetPlatformIDs;
+  cl_api_clGetPlatformInfo                 clGetPlatformInfo;
+  cl_api_clGetDeviceIDs                    clGetDeviceIDs;
+  cl_api_clGetDeviceInfo                   clGetDeviceInfo;
+  cl_api_clCreateContext                   clCreateContext;
+  cl_api_clCreateContextFromType           clCreateContextFromType;
+  cl_api_clRetainContext                   clRetainContext;
+  cl_api_clReleaseContext                  clReleaseContext;
+  cl_api_clGetContextInfo                  clGetContextInfo;
+  cl_api_clCreateCommandQueue              clCreateCommandQueue;
+  cl_api_clRetainCommandQueue              clRetainCommandQueue;
+  cl_api_clReleaseCommandQueue             clReleaseCommandQueue;
+  cl_api_clGetCommandQueueInfo             clGetCommandQueueInfo;
+  cl_api_clSetCommandQueueProperty         clSetCommandQueueProperty;
+  cl_api_clCreateBuffer                    clCreateBuffer;
+  cl_api_clCreateImage2D                   clCreateImage2D;
+  cl_api_clCreateImage3D                   clCreateImage3D;
+  cl_api_clRetainMemObject                 clRetainMemObject;
+  cl_api_clReleaseMemObject                clReleaseMemObject;
+  cl_api_clGetSupportedImageFormats        clGetSupportedImageFormats;
+  cl_api_clGetMemObjectInfo                clGetMemObjectInfo;
+  cl_api_clGetImageInfo                    clGetImageInfo;
+  cl_api_clCreateSampler                   clCreateSampler;
+  cl_api_clRetainSampler                   clRetainSampler;
+  cl_api_clReleaseSampler                  clReleaseSampler;
+  cl_api_clGetSamplerInfo                  clGetSamplerInfo;
+  cl_api_clCreateProgramWithSource         clCreateProgramWithSource;
+  cl_api_clCreateProgramWithBinary         clCreateProgramWithBinary;
+  cl_api_clRetainProgram                   clRetainProgram;
+  cl_api_clReleaseProgram                  clReleaseProgram;
+  cl_api_clBuildProgram                    clBuildProgram;
+  cl_api_clUnloadCompiler                  clUnloadCompiler;
+  cl_api_clGetProgramInfo                  clGetProgramInfo;
+  cl_api_clGetProgramBuildInfo             clGetProgramBuildInfo;
+  cl_api_clCreateKernel                    clCreateKernel;
+  cl_api_clCreateKernelsInProgram          clCreateKernelsInProgram;
+  cl_api_clRetainKernel                    clRetainKernel;
+  cl_api_clReleaseKernel                   clReleaseKernel;
+  cl_api_clSetKernelArg                    clSetKernelArg;
+  cl_api_clGetKernelInfo                   clGetKernelInfo;
+  cl_api_clGetKernelWorkGroupInfo          clGetKernelWorkGroupInfo;
+  cl_api_clWaitForEvents                   clWaitForEvents;
+  cl_api_clGetEventInfo                    clGetEventInfo;
+  cl_api_clRetainEvent                     clRetainEvent;
+  cl_api_clReleaseEvent                    clReleaseEvent;
+  cl_api_clGetEventProfilingInfo           clGetEventProfilingInfo;
+  cl_api_clFlush                           clFlush;
+  cl_api_clFinish                          clFinish;
+  cl_api_clEnqueueReadBuffer               clEnqueueReadBuffer;
+  cl_api_clEnqueueWriteBuffer              clEnqueueWriteBuffer;
+  cl_api_clEnqueueCopyBuffer               clEnqueueCopyBuffer;
+  cl_api_clEnqueueReadImage                clEnqueueReadImage;
+  cl_api_clEnqueueWriteImage               clEnqueueWriteImage;
+  cl_api_clEnqueueCopyImage                clEnqueueCopyImage;
+  cl_api_clEnqueueCopyImageToBuffer        clEnqueueCopyImageToBuffer;
+  cl_api_clEnqueueCopyBufferToImage        clEnqueueCopyBufferToImage;
+  cl_api_clEnqueueMapBuffer                clEnqueueMapBuffer;
+  cl_api_clEnqueueMapImage                 clEnqueueMapImage;
+  cl_api_clEnqueueUnmapMemObject           clEnqueueUnmapMemObject;
+  cl_api_clEnqueueNDRangeKernel            clEnqueueNDRangeKernel;
+  cl_api_clEnqueueTask                     clEnqueueTask;
+  cl_api_clEnqueueNativeKernel             clEnqueueNativeKernel;
+  cl_api_clEnqueueMarker                   clEnqueueMarker;
+  cl_api_clEnqueueWaitForEvents            clEnqueueWaitForEvents;
+  cl_api_clEnqueueBarrier                  clEnqueueBarrier;
+  cl_api_clGetExtensionFunctionAddress     clGetExtensionFunctionAddress;
+  cl_api_clCreateFromGLBuffer              clCreateFromGLBuffer;
+  cl_api_clCreateFromGLTexture2D           clCreateFromGLTexture2D;
+  cl_api_clCreateFromGLTexture3D           clCreateFromGLTexture3D;
+  cl_api_clCreateFromGLRenderbuffer        clCreateFromGLRenderbuffer;
+  cl_api_clGetGLObjectInfo                 clGetGLObjectInfo;
+  cl_api_clGetGLTextureInfo                clGetGLTextureInfo;
+  cl_api_clEnqueueAcquireGLObjects         clEnqueueAcquireGLObjects;
+  cl_api_clEnqueueReleaseGLObjects         clEnqueueReleaseGLObjects;
+  cl_api_clGetGLContextInfoKHR             clGetGLContextInfoKHR;
 
   /* cl_khr_d3d10_sharing */
-  cl_api_clGetDeviceIDsFromD3D10KHR clGetDeviceIDsFromD3D10KHR;
-  cl_api_clCreateFromD3D10BufferKHR clCreateFromD3D10BufferKHR;
-  cl_api_clCreateFromD3D10Texture2DKHR clCreateFromD3D10Texture2DKHR;
-  cl_api_clCreateFromD3D10Texture3DKHR clCreateFromD3D10Texture3DKHR;
-  cl_api_clEnqueueAcquireD3D10ObjectsKHR clEnqueueAcquireD3D10ObjectsKHR;
-  cl_api_clEnqueueReleaseD3D10ObjectsKHR clEnqueueReleaseD3D10ObjectsKHR;
+  cl_api_clGetDeviceIDsFromD3D10KHR        clGetDeviceIDsFromD3D10KHR;
+  cl_api_clCreateFromD3D10BufferKHR        clCreateFromD3D10BufferKHR;
+  cl_api_clCreateFromD3D10Texture2DKHR     clCreateFromD3D10Texture2DKHR;
+  cl_api_clCreateFromD3D10Texture3DKHR     clCreateFromD3D10Texture3DKHR;
+  cl_api_clEnqueueAcquireD3D10ObjectsKHR   clEnqueueAcquireD3D10ObjectsKHR;
+  cl_api_clEnqueueReleaseD3D10ObjectsKHR   clEnqueueReleaseD3D10ObjectsKHR;
 
   /* OpenCL 1.1 */
-  cl_api_clSetEventCallback clSetEventCallback;
-  cl_api_clCreateSubBuffer clCreateSubBuffer;
-  cl_api_clSetMemObjectDestructorCallback clSetMemObjectDestructorCallback;
-  cl_api_clCreateUserEvent clCreateUserEvent;
-  cl_api_clSetUserEventStatus clSetUserEventStatus;
-  cl_api_clEnqueueReadBufferRect clEnqueueReadBufferRect;
-  cl_api_clEnqueueWriteBufferRect clEnqueueWriteBufferRect;
-  cl_api_clEnqueueCopyBufferRect clEnqueueCopyBufferRect;
+  cl_api_clSetEventCallback                clSetEventCallback;
+  cl_api_clCreateSubBuffer                 clCreateSubBuffer;
+  cl_api_clSetMemObjectDestructorCallback  clSetMemObjectDestructorCallback;
+  cl_api_clCreateUserEvent                 clCreateUserEvent;
+  cl_api_clSetUserEventStatus              clSetUserEventStatus;
+  cl_api_clEnqueueReadBufferRect           clEnqueueReadBufferRect;
+  cl_api_clEnqueueWriteBufferRect          clEnqueueWriteBufferRect;
+  cl_api_clEnqueueCopyBufferRect           clEnqueueCopyBufferRect;
 
   /* cl_ext_device_fission */
-  cl_api_clCreateSubDevicesEXT clCreateSubDevicesEXT;
-  cl_api_clRetainDeviceEXT clRetainDeviceEXT;
-  cl_api_clReleaseDeviceEXT clReleaseDeviceEXT;
+  cl_api_clCreateSubDevicesEXT             clCreateSubDevicesEXT;
+  cl_api_clRetainDeviceEXT                 clRetainDeviceEXT;
+  cl_api_clReleaseDeviceEXT                clReleaseDeviceEXT;
 
   /* cl_khr_gl_event */
-  cl_api_clCreateEventFromGLsyncKHR clCreateEventFromGLsyncKHR;
+  cl_api_clCreateEventFromGLsyncKHR        clCreateEventFromGLsyncKHR;
 
   /* OpenCL 1.2 */
-  cl_api_clCreateSubDevices clCreateSubDevices;
-  cl_api_clRetainDevice clRetainDevice;
-  cl_api_clReleaseDevice clReleaseDevice;
-  cl_api_clCreateImage clCreateImage;
+  cl_api_clCreateSubDevices                clCreateSubDevices;
+  cl_api_clRetainDevice                    clRetainDevice;
+  cl_api_clReleaseDevice                   clReleaseDevice;
+  cl_api_clCreateImage                     clCreateImage;
   cl_api_clCreateProgramWithBuiltInKernels clCreateProgramWithBuiltInKernels;
-  cl_api_clCompileProgram clCompileProgram;
-  cl_api_clLinkProgram clLinkProgram;
-  cl_api_clUnloadPlatformCompiler clUnloadPlatformCompiler;
-  cl_api_clGetKernelArgInfo clGetKernelArgInfo;
-  cl_api_clEnqueueFillBuffer clEnqueueFillBuffer;
-  cl_api_clEnqueueFillImage clEnqueueFillImage;
-  cl_api_clEnqueueMigrateMemObjects clEnqueueMigrateMemObjects;
-  cl_api_clEnqueueMarkerWithWaitList clEnqueueMarkerWithWaitList;
-  cl_api_clEnqueueBarrierWithWaitList clEnqueueBarrierWithWaitList;
+  cl_api_clCompileProgram                  clCompileProgram;
+  cl_api_clLinkProgram                     clLinkProgram;
+  cl_api_clUnloadPlatformCompiler          clUnloadPlatformCompiler;
+  cl_api_clGetKernelArgInfo                clGetKernelArgInfo;
+  cl_api_clEnqueueFillBuffer               clEnqueueFillBuffer;
+  cl_api_clEnqueueFillImage                clEnqueueFillImage;
+  cl_api_clEnqueueMigrateMemObjects        clEnqueueMigrateMemObjects;
+  cl_api_clEnqueueMarkerWithWaitList       clEnqueueMarkerWithWaitList;
+  cl_api_clEnqueueBarrierWithWaitList      clEnqueueBarrierWithWaitList;
   cl_api_clGetExtensionFunctionAddressForPlatform
-      clGetExtensionFunctionAddressForPlatform;
-  cl_api_clCreateFromGLTexture clCreateFromGLTexture;
+                                       clGetExtensionFunctionAddressForPlatform;
+  cl_api_clCreateFromGLTexture         clCreateFromGLTexture;
 
   /* cl_khr_d3d11_sharing */
-  cl_api_clGetDeviceIDsFromD3D11KHR clGetDeviceIDsFromD3D11KHR;
-  cl_api_clCreateFromD3D11BufferKHR clCreateFromD3D11BufferKHR;
+  cl_api_clGetDeviceIDsFromD3D11KHR    clGetDeviceIDsFromD3D11KHR;
+  cl_api_clCreateFromD3D11BufferKHR    clCreateFromD3D11BufferKHR;
   cl_api_clCreateFromD3D11Texture2DKHR clCreateFromD3D11Texture2DKHR;
   cl_api_clCreateFromD3D11Texture3DKHR clCreateFromD3D11Texture3DKHR;
-  cl_api_clCreateFromDX9MediaSurfaceKHR clCreateFromDX9MediaSurfaceKHR;
+  cl_api_clCreateFromDX9MediaSurfaceKHR  clCreateFromDX9MediaSurfaceKHR;
   cl_api_clEnqueueAcquireD3D11ObjectsKHR clEnqueueAcquireD3D11ObjectsKHR;
   cl_api_clEnqueueReleaseD3D11ObjectsKHR clEnqueueReleaseD3D11ObjectsKHR;
 
   /* cl_khr_dx9_media_sharing */
   cl_api_clGetDeviceIDsFromDX9MediaAdapterKHR
-      clGetDeviceIDsFromDX9MediaAdapterKHR;
+    clGetDeviceIDsFromDX9MediaAdapterKHR;
   cl_api_clEnqueueAcquireDX9MediaSurfacesKHR
-      clEnqueueAcquireDX9MediaSurfacesKHR;
+    clEnqueueAcquireDX9MediaSurfacesKHR;
   cl_api_clEnqueueReleaseDX9MediaSurfacesKHR
-      clEnqueueReleaseDX9MediaSurfacesKHR;
+                                            clEnqueueReleaseDX9MediaSurfacesKHR;
 
   /* cl_khr_egl_image */
-  cl_api_clCreateFromEGLImageKHR clCreateFromEGLImageKHR;
-  cl_api_clEnqueueAcquireEGLObjectsKHR clEnqueueAcquireEGLObjectsKHR;
-  cl_api_clEnqueueReleaseEGLObjectsKHR clEnqueueReleaseEGLObjectsKHR;
+  cl_api_clCreateFromEGLImageKHR            clCreateFromEGLImageKHR;
+  cl_api_clEnqueueAcquireEGLObjectsKHR      clEnqueueAcquireEGLObjectsKHR;
+  cl_api_clEnqueueReleaseEGLObjectsKHR      clEnqueueReleaseEGLObjectsKHR;
 
   /* cl_khr_egl_event */
-  cl_api_clCreateEventFromEGLSyncKHR clCreateEventFromEGLSyncKHR;
+  cl_api_clCreateEventFromEGLSyncKHR        clCreateEventFromEGLSyncKHR;
 
   /* OpenCL 2.0 */
   cl_api_clCreateCommandQueueWithProperties clCreateCommandQueueWithProperties;
-  cl_api_clCreatePipe clCreatePipe;
-  cl_api_clGetPipeInfo clGetPipeInfo;
-  cl_api_clSVMAlloc clSVMAlloc;
-  cl_api_clSVMFree clSVMFree;
-  cl_api_clEnqueueSVMFree clEnqueueSVMFree;
-  cl_api_clEnqueueSVMMemcpy clEnqueueSVMMemcpy;
-  cl_api_clEnqueueSVMMemFill clEnqueueSVMMemFill;
-  cl_api_clEnqueueSVMMap clEnqueueSVMMap;
-  cl_api_clEnqueueSVMUnmap clEnqueueSVMUnmap;
-  cl_api_clCreateSamplerWithProperties clCreateSamplerWithProperties;
-  cl_api_clSetKernelArgSVMPointer clSetKernelArgSVMPointer;
-  cl_api_clSetKernelExecInfo clSetKernelExecInfo;
+  cl_api_clCreatePipe                       clCreatePipe;
+  cl_api_clGetPipeInfo                      clGetPipeInfo;
+  cl_api_clSVMAlloc                         clSVMAlloc;
+  cl_api_clSVMFree                          clSVMFree;
+  cl_api_clEnqueueSVMFree                   clEnqueueSVMFree;
+  cl_api_clEnqueueSVMMemcpy                 clEnqueueSVMMemcpy;
+  cl_api_clEnqueueSVMMemFill                clEnqueueSVMMemFill;
+  cl_api_clEnqueueSVMMap                    clEnqueueSVMMap;
+  cl_api_clEnqueueSVMUnmap                  clEnqueueSVMUnmap;
+  cl_api_clCreateSamplerWithProperties      clCreateSamplerWithProperties;
+  cl_api_clSetKernelArgSVMPointer           clSetKernelArgSVMPointer;
+  cl_api_clSetKernelExecInfo                clSetKernelExecInfo;
 
   /* cl_khr_sub_groups */
-  cl_api_clGetKernelSubGroupInfoKHR clGetKernelSubGroupInfoKHR;
+  cl_api_clGetKernelSubGroupInfoKHR         clGetKernelSubGroupInfoKHR;
 
   /* OpenCL 2.1 */
-  cl_api_clCloneKernel clCloneKernel;
-  cl_api_clCreateProgramWithIL clCreateProgramWithIL;
-  cl_api_clEnqueueSVMMigrateMem clEnqueueSVMMigrateMem;
-  cl_api_clGetDeviceAndHostTimer clGetDeviceAndHostTimer;
-  cl_api_clGetHostTimer clGetHostTimer;
-  cl_api_clGetKernelSubGroupInfo clGetKernelSubGroupInfo;
-  cl_api_clSetDefaultDeviceCommandQueue clSetDefaultDeviceCommandQueue;
+  cl_api_clCloneKernel                      clCloneKernel;
+  cl_api_clCreateProgramWithIL              clCreateProgramWithIL;
+  cl_api_clEnqueueSVMMigrateMem             clEnqueueSVMMigrateMem;
+  cl_api_clGetDeviceAndHostTimer            clGetDeviceAndHostTimer;
+  cl_api_clGetHostTimer                     clGetHostTimer;
+  cl_api_clGetKernelSubGroupInfo            clGetKernelSubGroupInfo;
+  cl_api_clSetDefaultDeviceCommandQueue     clSetDefaultDeviceCommandQueue;
 
   /* OpenCL 2.2 */
-  cl_api_clSetProgramReleaseCallback clSetProgramReleaseCallback;
+  cl_api_clSetProgramReleaseCallback        clSetProgramReleaseCallback;
   cl_api_clSetProgramSpecializationConstant clSetProgramSpecializationConstant;
 
   /* OpenCL 3.0 */
-  cl_api_clCreateBufferWithProperties clCreateBufferWithProperties;
-  cl_api_clCreateImageWithProperties clCreateImageWithProperties;
-  cl_api_clSetContextDestructorCallback clSetContextDestructorCallback;
+  cl_api_clCreateBufferWithProperties       clCreateBufferWithProperties;
+  cl_api_clCreateImageWithProperties        clCreateImageWithProperties;
+  cl_api_clSetContextDestructorCallback     clSetContextDestructorCallback;
 
 } cl_icd_dispatch;
 

--- a/CL/cl_layer.h
+++ b/CL/cl_layer.h
@@ -27,32 +27,31 @@ extern "C" {
 
 typedef cl_uint cl_layer_info;
 typedef cl_uint cl_layer_api_version;
-#define CL_LAYER_API_VERSION 0x4240
+#define CL_LAYER_API_VERSION     0x4240
 #define CL_LAYER_API_VERSION_100 100
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetLayerInfo(cl_layer_info  param_name,
-               size_t         param_value_size,
-               void          *param_value,
-               size_t        *param_value_size_ret);
+clGetLayerInfo(cl_layer_info param_name,
+               size_t        param_value_size,
+               void*         param_value,
+               size_t*       param_value_size_ret);
 
-typedef cl_int
-(CL_API_CALL *pfn_clGetLayerInfo)(cl_layer_info  param_name,
-                                  size_t         param_value_size,
-                                  void          *param_value,
-                                  size_t        *param_value_size_ret);
+typedef cl_int(CL_API_CALL* pfn_clGetLayerInfo)(cl_layer_info param_name,
+                                                size_t        param_value_size,
+                                                void*         param_value,
+                                                size_t* param_value_size_ret);
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clInitLayer(cl_uint                 num_entries,
-            const cl_icd_dispatch  *target_dispatch,
-            cl_uint                *num_entries_ret,
-            const cl_icd_dispatch **layer_dispatch_ret);
+            const cl_icd_dispatch*  target_dispatch,
+            cl_uint*                num_entries_ret,
+            const cl_icd_dispatch** layer_dispatch_ret);
 
-typedef cl_int
-(CL_API_CALL *pfn_clInitLayer)(cl_uint                 num_entries,
-                               const cl_icd_dispatch  *target_dispatch,
-                               cl_uint                *num_entries_ret,
-                               const cl_icd_dispatch **layer_dispatch_ret);
+typedef cl_int(CL_API_CALL* pfn_clInitLayer)(
+  cl_uint                 num_entries,
+  const cl_icd_dispatch*  target_dispatch,
+  cl_uint*                num_entries_ret,
+  const cl_icd_dispatch** layer_dispatch_ret);
 
 #ifdef __cplusplus
 }

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -24,25 +24,25 @@ extern "C" {
 #endif
 
 #if defined(_WIN32)
-    #if !defined(CL_API_ENTRY)
-        #define CL_API_ENTRY
-    #endif
-    #if !defined(CL_API_CALL)
-        #define CL_API_CALL     __stdcall
-    #endif
-    #if !defined(CL_CALLBACK)
-        #define CL_CALLBACK     __stdcall
-    #endif
+#if !defined(CL_API_ENTRY)
+#define CL_API_ENTRY
+#endif
+#if !defined(CL_API_CALL)
+#define CL_API_CALL __stdcall
+#endif
+#if !defined(CL_CALLBACK)
+#define CL_CALLBACK __stdcall
+#endif
 #else
-    #if !defined(CL_API_ENTRY)
-        #define CL_API_ENTRY
-    #endif
-    #if !defined(CL_API_CALL)
-        #define CL_API_CALL
-    #endif
-    #if !defined(CL_CALLBACK)
-        #define CL_CALLBACK
-    #endif
+#if !defined(CL_API_ENTRY)
+#define CL_API_ENTRY
+#endif
+#if !defined(CL_API_CALL)
+#define CL_API_CALL
+#endif
+#if !defined(CL_CALLBACK)
+#define CL_CALLBACK
+#endif
 #endif
 
 /*
@@ -61,307 +61,323 @@ extern "C" {
 #define CL_API_PREFIX_USER
 #endif
 
-#define CL_API_SUFFIX_COMMON CL_API_SUFFIX_USER
-#define CL_API_PREFIX_COMMON CL_API_PREFIX_USER
+#define CL_API_SUFFIX_COMMON        CL_API_SUFFIX_USER
+#define CL_API_PREFIX_COMMON        CL_API_PREFIX_USER
 
-#define CL_API_SUFFIX__VERSION_1_0 CL_API_SUFFIX_COMMON
-#define CL_API_SUFFIX__VERSION_1_1 CL_API_SUFFIX_COMMON
-#define CL_API_SUFFIX__VERSION_1_2 CL_API_SUFFIX_COMMON
-#define CL_API_SUFFIX__VERSION_2_0 CL_API_SUFFIX_COMMON
-#define CL_API_SUFFIX__VERSION_2_1 CL_API_SUFFIX_COMMON
-#define CL_API_SUFFIX__VERSION_2_2 CL_API_SUFFIX_COMMON
-#define CL_API_SUFFIX__VERSION_3_0 CL_API_SUFFIX_COMMON
+#define CL_API_SUFFIX__VERSION_1_0  CL_API_SUFFIX_COMMON
+#define CL_API_SUFFIX__VERSION_1_1  CL_API_SUFFIX_COMMON
+#define CL_API_SUFFIX__VERSION_1_2  CL_API_SUFFIX_COMMON
+#define CL_API_SUFFIX__VERSION_2_0  CL_API_SUFFIX_COMMON
+#define CL_API_SUFFIX__VERSION_2_1  CL_API_SUFFIX_COMMON
+#define CL_API_SUFFIX__VERSION_2_2  CL_API_SUFFIX_COMMON
+#define CL_API_SUFFIX__VERSION_3_0  CL_API_SUFFIX_COMMON
 #define CL_API_SUFFIX__EXPERIMENTAL CL_API_SUFFIX_COMMON
 
-
 #ifdef __GNUC__
-  #define CL_API_SUFFIX_DEPRECATED __attribute__((deprecated))
-  #define CL_API_PREFIX_DEPRECATED
+#define CL_API_SUFFIX_DEPRECATED __attribute__((deprecated))
+#define CL_API_PREFIX_DEPRECATED
 #elif defined(_WIN32)
-  #define CL_API_SUFFIX_DEPRECATED
-  #define CL_API_PREFIX_DEPRECATED __declspec(deprecated)
+#define CL_API_SUFFIX_DEPRECATED
+#define CL_API_PREFIX_DEPRECATED __declspec(deprecated)
 #else
-  #define CL_API_SUFFIX_DEPRECATED
-  #define CL_API_PREFIX_DEPRECATED
+#define CL_API_SUFFIX_DEPRECATED
+#define CL_API_PREFIX_DEPRECATED
 #endif
 
 #ifdef CL_USE_DEPRECATED_OPENCL_1_0_APIS
-    #define CL_API_SUFFIX__VERSION_1_0_DEPRECATED CL_API_SUFFIX_COMMON
-    #define CL_API_PREFIX__VERSION_1_0_DEPRECATED CL_API_PREFIX_COMMON
+#define CL_API_SUFFIX__VERSION_1_0_DEPRECATED CL_API_SUFFIX_COMMON
+#define CL_API_PREFIX__VERSION_1_0_DEPRECATED CL_API_PREFIX_COMMON
 #else
-    #define CL_API_SUFFIX__VERSION_1_0_DEPRECATED CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
-    #define CL_API_PREFIX__VERSION_1_0_DEPRECATED CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
+#define CL_API_SUFFIX__VERSION_1_0_DEPRECATED                                  \
+  CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
+#define CL_API_PREFIX__VERSION_1_0_DEPRECATED                                  \
+  CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
 #endif
 
 #ifdef CL_USE_DEPRECATED_OPENCL_1_1_APIS
-    #define CL_API_SUFFIX__VERSION_1_1_DEPRECATED CL_API_SUFFIX_COMMON
-    #define CL_API_PREFIX__VERSION_1_1_DEPRECATED CL_API_PREFIX_COMMON
+#define CL_API_SUFFIX__VERSION_1_1_DEPRECATED CL_API_SUFFIX_COMMON
+#define CL_API_PREFIX__VERSION_1_1_DEPRECATED CL_API_PREFIX_COMMON
 #else
-    #define CL_API_SUFFIX__VERSION_1_1_DEPRECATED CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
-    #define CL_API_PREFIX__VERSION_1_1_DEPRECATED CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
+#define CL_API_SUFFIX__VERSION_1_1_DEPRECATED                                  \
+  CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
+#define CL_API_PREFIX__VERSION_1_1_DEPRECATED                                  \
+  CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
 #endif
 
 #ifdef CL_USE_DEPRECATED_OPENCL_1_2_APIS
-    #define CL_API_SUFFIX__VERSION_1_2_DEPRECATED CL_API_SUFFIX_COMMON
-    #define CL_API_PREFIX__VERSION_1_2_DEPRECATED CL_API_PREFIX_COMMON
+#define CL_API_SUFFIX__VERSION_1_2_DEPRECATED CL_API_SUFFIX_COMMON
+#define CL_API_PREFIX__VERSION_1_2_DEPRECATED CL_API_PREFIX_COMMON
 #else
-    #define CL_API_SUFFIX__VERSION_1_2_DEPRECATED CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
-    #define CL_API_PREFIX__VERSION_1_2_DEPRECATED CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
- #endif
+#define CL_API_SUFFIX__VERSION_1_2_DEPRECATED                                  \
+  CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
+#define CL_API_PREFIX__VERSION_1_2_DEPRECATED                                  \
+  CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
+#endif
 
 #ifdef CL_USE_DEPRECATED_OPENCL_2_0_APIS
-    #define CL_API_SUFFIX__VERSION_2_0_DEPRECATED CL_API_SUFFIX_COMMON
-    #define CL_API_PREFIX__VERSION_2_0_DEPRECATED CL_API_PREFIX_COMMON
+#define CL_API_SUFFIX__VERSION_2_0_DEPRECATED CL_API_SUFFIX_COMMON
+#define CL_API_PREFIX__VERSION_2_0_DEPRECATED CL_API_PREFIX_COMMON
 #else
-    #define CL_API_SUFFIX__VERSION_2_0_DEPRECATED CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
-    #define CL_API_PREFIX__VERSION_2_0_DEPRECATED CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
+#define CL_API_SUFFIX__VERSION_2_0_DEPRECATED                                  \
+  CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
+#define CL_API_PREFIX__VERSION_2_0_DEPRECATED                                  \
+  CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
 #endif
 
 #ifdef CL_USE_DEPRECATED_OPENCL_2_1_APIS
-    #define CL_API_SUFFIX__VERSION_2_1_DEPRECATED CL_API_SUFFIX_COMMON
-    #define CL_API_PREFIX__VERSION_2_1_DEPRECATED CL_API_PREFIX_COMMON
+#define CL_API_SUFFIX__VERSION_2_1_DEPRECATED CL_API_SUFFIX_COMMON
+#define CL_API_PREFIX__VERSION_2_1_DEPRECATED CL_API_PREFIX_COMMON
 #else
-    #define CL_API_SUFFIX__VERSION_2_1_DEPRECATED CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
-    #define CL_API_PREFIX__VERSION_2_1_DEPRECATED CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
+#define CL_API_SUFFIX__VERSION_2_1_DEPRECATED                                  \
+  CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
+#define CL_API_PREFIX__VERSION_2_1_DEPRECATED                                  \
+  CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
 #endif
 
 #ifdef CL_USE_DEPRECATED_OPENCL_2_2_APIS
-    #define CL_API_SUFFIX__VERSION_2_2_DEPRECATED CL_API_SUFFIX_COMMON
-    #define CL_API_PREFIX__VERSION_2_2_DEPRECATED CL_API_PREFIX_COMMON
+#define CL_API_SUFFIX__VERSION_2_2_DEPRECATED CL_API_SUFFIX_COMMON
+#define CL_API_PREFIX__VERSION_2_2_DEPRECATED CL_API_PREFIX_COMMON
 #else
-    #define CL_API_SUFFIX__VERSION_2_2_DEPRECATED CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
-    #define CL_API_PREFIX__VERSION_2_2_DEPRECATED CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
+#define CL_API_SUFFIX__VERSION_2_2_DEPRECATED                                  \
+  CL_API_SUFFIX_COMMON CL_API_SUFFIX_DEPRECATED
+#define CL_API_PREFIX__VERSION_2_2_DEPRECATED                                  \
+  CL_API_PREFIX_COMMON CL_API_PREFIX_DEPRECATED
 #endif
 
-#if (defined (_WIN32) && defined(_MSC_VER))
+#if (defined(_WIN32) && defined(_MSC_VER))
 
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wlanguage-extension-token"
 #endif
 
-/* intptr_t is used in cl.h and provided by stddef.h in Visual C++, but not in clang */
-/* stdint.h was missing before Visual Studio 2010, include it for later versions and for clang */
+/* intptr_t is used in cl.h and provided by stddef.h in Visual C++, but not in
+ * clang */
+/* stdint.h was missing before Visual Studio 2010, include it for later versions
+ * and for clang */
 #if defined(__clang__) || _MSC_VER >= 1600
-    #include <stdint.h>
+#include <stdint.h>
 #endif
 
 /* scalar types  */
-typedef signed   __int8         cl_char;
-typedef unsigned __int8         cl_uchar;
-typedef signed   __int16        cl_short;
-typedef unsigned __int16        cl_ushort;
-typedef signed   __int32        cl_int;
-typedef unsigned __int32        cl_uint;
-typedef signed   __int64        cl_long;
-typedef unsigned __int64        cl_ulong;
+typedef signed __int8    cl_char;
+typedef unsigned __int8  cl_uchar;
+typedef signed __int16   cl_short;
+typedef unsigned __int16 cl_ushort;
+typedef signed __int32   cl_int;
+typedef unsigned __int32 cl_uint;
+typedef signed __int64   cl_long;
+typedef unsigned __int64 cl_ulong;
 
-typedef unsigned __int16        cl_half;
-typedef float                   cl_float;
-typedef double                  cl_double;
+typedef unsigned __int16 cl_half;
+typedef float            cl_float;
+typedef double           cl_double;
 
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 
 /* Macro names and corresponding values defined by OpenCL */
-#define CL_CHAR_BIT         8
-#define CL_SCHAR_MAX        127
-#define CL_SCHAR_MIN        (-127-1)
-#define CL_CHAR_MAX         CL_SCHAR_MAX
-#define CL_CHAR_MIN         CL_SCHAR_MIN
-#define CL_UCHAR_MAX        255
-#define CL_SHRT_MAX         32767
-#define CL_SHRT_MIN         (-32767-1)
-#define CL_USHRT_MAX        65535
-#define CL_INT_MAX          2147483647
-#define CL_INT_MIN          (-2147483647-1)
-#define CL_UINT_MAX         0xffffffffU
-#define CL_LONG_MAX         ((cl_long) 0x7FFFFFFFFFFFFFFFLL)
-#define CL_LONG_MIN         ((cl_long) -0x7FFFFFFFFFFFFFFFLL - 1LL)
-#define CL_ULONG_MAX        ((cl_ulong) 0xFFFFFFFFFFFFFFFFULL)
+#define CL_CHAR_BIT        8
+#define CL_SCHAR_MAX       127
+#define CL_SCHAR_MIN       (-127 - 1)
+#define CL_CHAR_MAX        CL_SCHAR_MAX
+#define CL_CHAR_MIN        CL_SCHAR_MIN
+#define CL_UCHAR_MAX       255
+#define CL_SHRT_MAX        32767
+#define CL_SHRT_MIN        (-32767 - 1)
+#define CL_USHRT_MAX       65535
+#define CL_INT_MAX         2147483647
+#define CL_INT_MIN         (-2147483647 - 1)
+#define CL_UINT_MAX        0xffffffffU
+#define CL_LONG_MAX        ((cl_long)0x7FFFFFFFFFFFFFFFLL)
+#define CL_LONG_MIN        ((cl_long)-0x7FFFFFFFFFFFFFFFLL - 1LL)
+#define CL_ULONG_MAX       ((cl_ulong)0xFFFFFFFFFFFFFFFFULL)
 
-#define CL_FLT_DIG          6
-#define CL_FLT_MANT_DIG     24
-#define CL_FLT_MAX_10_EXP   +38
-#define CL_FLT_MAX_EXP      +128
-#define CL_FLT_MIN_10_EXP   -37
-#define CL_FLT_MIN_EXP      -125
-#define CL_FLT_RADIX        2
-#define CL_FLT_MAX          340282346638528859811704183484516925440.0f
-#define CL_FLT_MIN          1.175494350822287507969e-38f
-#define CL_FLT_EPSILON      1.1920928955078125e-7f
+#define CL_FLT_DIG         6
+#define CL_FLT_MANT_DIG    24
+#define CL_FLT_MAX_10_EXP  +38
+#define CL_FLT_MAX_EXP     +128
+#define CL_FLT_MIN_10_EXP  -37
+#define CL_FLT_MIN_EXP     -125
+#define CL_FLT_RADIX       2
+#define CL_FLT_MAX         340282346638528859811704183484516925440.0f
+#define CL_FLT_MIN         1.175494350822287507969e-38f
+#define CL_FLT_EPSILON     1.1920928955078125e-7f
 
-#define CL_HALF_DIG          3
-#define CL_HALF_MANT_DIG     11
-#define CL_HALF_MAX_10_EXP   +4
-#define CL_HALF_MAX_EXP      +16
-#define CL_HALF_MIN_10_EXP   -4
-#define CL_HALF_MIN_EXP      -13
-#define CL_HALF_RADIX        2
-#define CL_HALF_MAX          65504.0f
-#define CL_HALF_MIN          6.103515625e-05f
-#define CL_HALF_EPSILON      9.765625e-04f
+#define CL_HALF_DIG        3
+#define CL_HALF_MANT_DIG   11
+#define CL_HALF_MAX_10_EXP +4
+#define CL_HALF_MAX_EXP    +16
+#define CL_HALF_MIN_10_EXP -4
+#define CL_HALF_MIN_EXP    -13
+#define CL_HALF_RADIX      2
+#define CL_HALF_MAX        65504.0f
+#define CL_HALF_MIN        6.103515625e-05f
+#define CL_HALF_EPSILON    9.765625e-04f
 
-#define CL_DBL_DIG          15
-#define CL_DBL_MANT_DIG     53
-#define CL_DBL_MAX_10_EXP   +308
-#define CL_DBL_MAX_EXP      +1024
-#define CL_DBL_MIN_10_EXP   -307
-#define CL_DBL_MIN_EXP      -1021
-#define CL_DBL_RADIX        2
-#define CL_DBL_MAX          1.7976931348623158e+308
-#define CL_DBL_MIN          2.225073858507201383090e-308
-#define CL_DBL_EPSILON      2.220446049250313080847e-16
+#define CL_DBL_DIG         15
+#define CL_DBL_MANT_DIG    53
+#define CL_DBL_MAX_10_EXP  +308
+#define CL_DBL_MAX_EXP     +1024
+#define CL_DBL_MIN_10_EXP  -307
+#define CL_DBL_MIN_EXP     -1021
+#define CL_DBL_RADIX       2
+#define CL_DBL_MAX         1.7976931348623158e+308
+#define CL_DBL_MIN         2.225073858507201383090e-308
+#define CL_DBL_EPSILON     2.220446049250313080847e-16
 
-#define CL_M_E              2.7182818284590452354
-#define CL_M_LOG2E          1.4426950408889634074
-#define CL_M_LOG10E         0.43429448190325182765
-#define CL_M_LN2            0.69314718055994530942
-#define CL_M_LN10           2.30258509299404568402
-#define CL_M_PI             3.14159265358979323846
-#define CL_M_PI_2           1.57079632679489661923
-#define CL_M_PI_4           0.78539816339744830962
-#define CL_M_1_PI           0.31830988618379067154
-#define CL_M_2_PI           0.63661977236758134308
-#define CL_M_2_SQRTPI       1.12837916709551257390
-#define CL_M_SQRT2          1.41421356237309504880
-#define CL_M_SQRT1_2        0.70710678118654752440
+#define CL_M_E             2.7182818284590452354
+#define CL_M_LOG2E         1.4426950408889634074
+#define CL_M_LOG10E        0.43429448190325182765
+#define CL_M_LN2           0.69314718055994530942
+#define CL_M_LN10          2.30258509299404568402
+#define CL_M_PI            3.14159265358979323846
+#define CL_M_PI_2          1.57079632679489661923
+#define CL_M_PI_4          0.78539816339744830962
+#define CL_M_1_PI          0.31830988618379067154
+#define CL_M_2_PI          0.63661977236758134308
+#define CL_M_2_SQRTPI      1.12837916709551257390
+#define CL_M_SQRT2         1.41421356237309504880
+#define CL_M_SQRT1_2       0.70710678118654752440
 
-#define CL_M_E_F            2.718281828f
-#define CL_M_LOG2E_F        1.442695041f
-#define CL_M_LOG10E_F       0.434294482f
-#define CL_M_LN2_F          0.693147181f
-#define CL_M_LN10_F         2.302585093f
-#define CL_M_PI_F           3.141592654f
-#define CL_M_PI_2_F         1.570796327f
-#define CL_M_PI_4_F         0.785398163f
-#define CL_M_1_PI_F         0.318309886f
-#define CL_M_2_PI_F         0.636619772f
-#define CL_M_2_SQRTPI_F     1.128379167f
-#define CL_M_SQRT2_F        1.414213562f
-#define CL_M_SQRT1_2_F      0.707106781f
+#define CL_M_E_F           2.718281828f
+#define CL_M_LOG2E_F       1.442695041f
+#define CL_M_LOG10E_F      0.434294482f
+#define CL_M_LN2_F         0.693147181f
+#define CL_M_LN10_F        2.302585093f
+#define CL_M_PI_F          3.141592654f
+#define CL_M_PI_2_F        1.570796327f
+#define CL_M_PI_4_F        0.785398163f
+#define CL_M_1_PI_F        0.318309886f
+#define CL_M_2_PI_F        0.636619772f
+#define CL_M_2_SQRTPI_F    1.128379167f
+#define CL_M_SQRT2_F       1.414213562f
+#define CL_M_SQRT1_2_F     0.707106781f
 
-#define CL_NAN              (CL_INFINITY - CL_INFINITY)
-#define CL_HUGE_VALF        ((cl_float) 1e50)
-#define CL_HUGE_VAL         ((cl_double) 1e500)
-#define CL_MAXFLOAT         CL_FLT_MAX
-#define CL_INFINITY         CL_HUGE_VALF
+#define CL_NAN             (CL_INFINITY - CL_INFINITY)
+#define CL_HUGE_VALF       ((cl_float)1e50)
+#define CL_HUGE_VAL        ((cl_double)1e500)
+#define CL_MAXFLOAT        CL_FLT_MAX
+#define CL_INFINITY        CL_HUGE_VALF
 
 #else
 
 #include <stdint.h>
 
 /* scalar types  */
-typedef int8_t          cl_char;
-typedef uint8_t         cl_uchar;
-typedef int16_t         cl_short;
-typedef uint16_t        cl_ushort;
-typedef int32_t         cl_int;
-typedef uint32_t        cl_uint;
-typedef int64_t         cl_long;
-typedef uint64_t        cl_ulong;
+typedef int8_t   cl_char;
+typedef uint8_t  cl_uchar;
+typedef int16_t  cl_short;
+typedef uint16_t cl_ushort;
+typedef int32_t  cl_int;
+typedef uint32_t cl_uint;
+typedef int64_t  cl_long;
+typedef uint64_t cl_ulong;
 
-typedef uint16_t        cl_half;
-typedef float           cl_float;
-typedef double          cl_double;
+typedef uint16_t cl_half;
+typedef float    cl_float;
+typedef double   cl_double;
 
 /* Macro names and corresponding values defined by OpenCL */
-#define CL_CHAR_BIT         8
-#define CL_SCHAR_MAX        127
-#define CL_SCHAR_MIN        (-127-1)
-#define CL_CHAR_MAX         CL_SCHAR_MAX
-#define CL_CHAR_MIN         CL_SCHAR_MIN
-#define CL_UCHAR_MAX        255
-#define CL_SHRT_MAX         32767
-#define CL_SHRT_MIN         (-32767-1)
-#define CL_USHRT_MAX        65535
-#define CL_INT_MAX          2147483647
-#define CL_INT_MIN          (-2147483647-1)
-#define CL_UINT_MAX         0xffffffffU
-#define CL_LONG_MAX         ((cl_long) 0x7FFFFFFFFFFFFFFFLL)
-#define CL_LONG_MIN         ((cl_long) -0x7FFFFFFFFFFFFFFFLL - 1LL)
-#define CL_ULONG_MAX        ((cl_ulong) 0xFFFFFFFFFFFFFFFFULL)
+#define CL_CHAR_BIT        8
+#define CL_SCHAR_MAX       127
+#define CL_SCHAR_MIN       (-127 - 1)
+#define CL_CHAR_MAX        CL_SCHAR_MAX
+#define CL_CHAR_MIN        CL_SCHAR_MIN
+#define CL_UCHAR_MAX       255
+#define CL_SHRT_MAX        32767
+#define CL_SHRT_MIN        (-32767 - 1)
+#define CL_USHRT_MAX       65535
+#define CL_INT_MAX         2147483647
+#define CL_INT_MIN         (-2147483647 - 1)
+#define CL_UINT_MAX        0xffffffffU
+#define CL_LONG_MAX        ((cl_long)0x7FFFFFFFFFFFFFFFLL)
+#define CL_LONG_MIN        ((cl_long)-0x7FFFFFFFFFFFFFFFLL - 1LL)
+#define CL_ULONG_MAX       ((cl_ulong)0xFFFFFFFFFFFFFFFFULL)
 
-#define CL_FLT_DIG          6
-#define CL_FLT_MANT_DIG     24
-#define CL_FLT_MAX_10_EXP   +38
-#define CL_FLT_MAX_EXP      +128
-#define CL_FLT_MIN_10_EXP   -37
-#define CL_FLT_MIN_EXP      -125
-#define CL_FLT_RADIX        2
-#define CL_FLT_MAX          340282346638528859811704183484516925440.0f
-#define CL_FLT_MIN          1.175494350822287507969e-38f
-#define CL_FLT_EPSILON      1.1920928955078125e-7f
+#define CL_FLT_DIG         6
+#define CL_FLT_MANT_DIG    24
+#define CL_FLT_MAX_10_EXP  +38
+#define CL_FLT_MAX_EXP     +128
+#define CL_FLT_MIN_10_EXP  -37
+#define CL_FLT_MIN_EXP     -125
+#define CL_FLT_RADIX       2
+#define CL_FLT_MAX         340282346638528859811704183484516925440.0f
+#define CL_FLT_MIN         1.175494350822287507969e-38f
+#define CL_FLT_EPSILON     1.1920928955078125e-7f
 
-#define CL_HALF_DIG          3
-#define CL_HALF_MANT_DIG     11
-#define CL_HALF_MAX_10_EXP   +4
-#define CL_HALF_MAX_EXP      +16
-#define CL_HALF_MIN_10_EXP   -4
-#define CL_HALF_MIN_EXP      -13
-#define CL_HALF_RADIX        2
-#define CL_HALF_MAX          65504.0f
-#define CL_HALF_MIN          6.103515625e-05f
-#define CL_HALF_EPSILON      9.765625e-04f
+#define CL_HALF_DIG        3
+#define CL_HALF_MANT_DIG   11
+#define CL_HALF_MAX_10_EXP +4
+#define CL_HALF_MAX_EXP    +16
+#define CL_HALF_MIN_10_EXP -4
+#define CL_HALF_MIN_EXP    -13
+#define CL_HALF_RADIX      2
+#define CL_HALF_MAX        65504.0f
+#define CL_HALF_MIN        6.103515625e-05f
+#define CL_HALF_EPSILON    9.765625e-04f
 
-#define CL_DBL_DIG          15
-#define CL_DBL_MANT_DIG     53
-#define CL_DBL_MAX_10_EXP   +308
-#define CL_DBL_MAX_EXP      +1024
-#define CL_DBL_MIN_10_EXP   -307
-#define CL_DBL_MIN_EXP      -1021
-#define CL_DBL_RADIX        2
-#define CL_DBL_MAX          179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.0
-#define CL_DBL_MIN          2.225073858507201383090e-308
-#define CL_DBL_EPSILON      2.220446049250313080847e-16
+#define CL_DBL_DIG         15
+#define CL_DBL_MANT_DIG    53
+#define CL_DBL_MAX_10_EXP  +308
+#define CL_DBL_MAX_EXP     +1024
+#define CL_DBL_MIN_10_EXP  -307
+#define CL_DBL_MIN_EXP     -1021
+#define CL_DBL_RADIX       2
+#define CL_DBL_MAX                                                             \
+  179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.0
+#define CL_DBL_MIN      2.225073858507201383090e-308
+#define CL_DBL_EPSILON  2.220446049250313080847e-16
 
-#define CL_M_E              2.7182818284590452354
-#define CL_M_LOG2E          1.4426950408889634074
-#define CL_M_LOG10E         0.43429448190325182765
-#define CL_M_LN2            0.69314718055994530942
-#define CL_M_LN10           2.30258509299404568402
-#define CL_M_PI             3.14159265358979323846
-#define CL_M_PI_2           1.57079632679489661923
-#define CL_M_PI_4           0.78539816339744830962
-#define CL_M_1_PI           0.31830988618379067154
-#define CL_M_2_PI           0.63661977236758134308
-#define CL_M_2_SQRTPI       1.12837916709551257390
-#define CL_M_SQRT2          1.41421356237309504880
-#define CL_M_SQRT1_2        0.70710678118654752440
+#define CL_M_E          2.7182818284590452354
+#define CL_M_LOG2E      1.4426950408889634074
+#define CL_M_LOG10E     0.43429448190325182765
+#define CL_M_LN2        0.69314718055994530942
+#define CL_M_LN10       2.30258509299404568402
+#define CL_M_PI         3.14159265358979323846
+#define CL_M_PI_2       1.57079632679489661923
+#define CL_M_PI_4       0.78539816339744830962
+#define CL_M_1_PI       0.31830988618379067154
+#define CL_M_2_PI       0.63661977236758134308
+#define CL_M_2_SQRTPI   1.12837916709551257390
+#define CL_M_SQRT2      1.41421356237309504880
+#define CL_M_SQRT1_2    0.70710678118654752440
 
-#define CL_M_E_F            2.718281828f
-#define CL_M_LOG2E_F        1.442695041f
-#define CL_M_LOG10E_F       0.434294482f
-#define CL_M_LN2_F          0.693147181f
-#define CL_M_LN10_F         2.302585093f
-#define CL_M_PI_F           3.141592654f
-#define CL_M_PI_2_F         1.570796327f
-#define CL_M_PI_4_F         0.785398163f
-#define CL_M_1_PI_F         0.318309886f
-#define CL_M_2_PI_F         0.636619772f
-#define CL_M_2_SQRTPI_F     1.128379167f
-#define CL_M_SQRT2_F        1.414213562f
-#define CL_M_SQRT1_2_F      0.707106781f
+#define CL_M_E_F        2.718281828f
+#define CL_M_LOG2E_F    1.442695041f
+#define CL_M_LOG10E_F   0.434294482f
+#define CL_M_LN2_F      0.693147181f
+#define CL_M_LN10_F     2.302585093f
+#define CL_M_PI_F       3.141592654f
+#define CL_M_PI_2_F     1.570796327f
+#define CL_M_PI_4_F     0.785398163f
+#define CL_M_1_PI_F     0.318309886f
+#define CL_M_2_PI_F     0.636619772f
+#define CL_M_2_SQRTPI_F 1.128379167f
+#define CL_M_SQRT2_F    1.414213562f
+#define CL_M_SQRT1_2_F  0.707106781f
 
-#if defined( __GNUC__ )
-   #define CL_HUGE_VALF     __builtin_huge_valf()
-   #define CL_HUGE_VAL      __builtin_huge_val()
-   #define CL_NAN           __builtin_nanf( "" )
+#if defined(__GNUC__)
+#define CL_HUGE_VALF __builtin_huge_valf()
+#define CL_HUGE_VAL  __builtin_huge_val()
+#define CL_NAN       __builtin_nanf("")
 #else
-   #define CL_HUGE_VALF     ((cl_float) 1e50)
-   #define CL_HUGE_VAL      ((cl_double) 1e500)
-   float nanf( const char * );
-   #define CL_NAN           nanf( "" )
+#define CL_HUGE_VALF ((cl_float)1e50)
+#define CL_HUGE_VAL  ((cl_double)1e500)
+float
+nanf(const char*);
+#define CL_NAN       nanf("")
 #endif
-#define CL_MAXFLOAT         CL_FLT_MAX
-#define CL_INFINITY         CL_HUGE_VALF
+#define CL_MAXFLOAT CL_FLT_MAX
+#define CL_INFINITY CL_HUGE_VALF
 
 #endif
 
 #include <stddef.h>
 
-/* Mirror types to GL types. Mirror types allow us to avoid deciding which 87s to load based on whether we are using GL or GLES here. */
+/* Mirror types to GL types. Mirror types allow us to avoid deciding which 87s
+ * to load based on whether we are using GL or GLES here. */
 typedef unsigned int cl_GLuint;
 typedef int          cl_GLint;
 typedef unsigned int cl_GLenum;
@@ -383,173 +399,175 @@ typedef unsigned int cl_GLenum;
  */
 
 /* Define basic vector types */
-#if defined( __VEC__ )
-  #if !defined(__clang__)
-     #include <altivec.h>   /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
-  #endif
-   typedef __vector unsigned char     __cl_uchar16;
-   typedef __vector signed char       __cl_char16;
-   typedef __vector unsigned short    __cl_ushort8;
-   typedef __vector signed short      __cl_short8;
-   typedef __vector unsigned int      __cl_uint4;
-   typedef __vector signed int        __cl_int4;
-   typedef __vector float             __cl_float4;
-   #define  __CL_UCHAR16__  1
-   #define  __CL_CHAR16__   1
-   #define  __CL_USHORT8__  1
-   #define  __CL_SHORT8__   1
-   #define  __CL_UINT4__    1
-   #define  __CL_INT4__     1
-   #define  __CL_FLOAT4__   1
+#if defined(__VEC__)
+#if !defined(__clang__)
+#include <altivec.h> /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
+#endif
+typedef __vector unsigned char  __cl_uchar16;
+typedef __vector signed char    __cl_char16;
+typedef __vector unsigned short __cl_ushort8;
+typedef __vector signed short   __cl_short8;
+typedef __vector unsigned int   __cl_uint4;
+typedef __vector signed int     __cl_int4;
+typedef __vector float          __cl_float4;
+#define __CL_UCHAR16__ 1
+#define __CL_CHAR16__  1
+#define __CL_USHORT8__ 1
+#define __CL_SHORT8__  1
+#define __CL_UINT4__   1
+#define __CL_INT4__    1
+#define __CL_FLOAT4__  1
 #endif
 
-#if defined( __SSE__ )
-    #if defined( __MINGW64__ )
-        #include <intrin.h>
-    #else
-        #include <xmmintrin.h>
-    #endif
-    #if defined( __GNUC__ )
-        typedef float __cl_float4   __attribute__((vector_size(16)));
-    #else
-        typedef __m128 __cl_float4;
-    #endif
-    #define __CL_FLOAT4__   1
+#if defined(__SSE__)
+#if defined(__MINGW64__)
+#include <intrin.h>
+#else
+#include <xmmintrin.h>
+#endif
+#if defined(__GNUC__)
+typedef float __cl_float4 __attribute__((vector_size(16)));
+#else
+typedef __m128  __cl_float4;
+#endif
+#define __CL_FLOAT4__ 1
 #endif
 
-#if defined( __SSE2__ )
-    #if defined( __MINGW64__ )
-        #include <intrin.h>
-    #else
-        #include <emmintrin.h>
-    #endif
-    #if defined( __GNUC__ )
-        typedef cl_uchar    __cl_uchar16    __attribute__((vector_size(16)));
-        typedef cl_char     __cl_char16     __attribute__((vector_size(16)));
-        typedef cl_ushort   __cl_ushort8    __attribute__((vector_size(16)));
-        typedef cl_short    __cl_short8     __attribute__((vector_size(16)));
-        typedef cl_uint     __cl_uint4      __attribute__((vector_size(16)));
-        typedef cl_int      __cl_int4       __attribute__((vector_size(16)));
-        typedef cl_ulong    __cl_ulong2     __attribute__((vector_size(16)));
-        typedef cl_long     __cl_long2      __attribute__((vector_size(16)));
-        typedef cl_double   __cl_double2    __attribute__((vector_size(16)));
-    #else
-        typedef __m128i __cl_uchar16;
-        typedef __m128i __cl_char16;
-        typedef __m128i __cl_ushort8;
-        typedef __m128i __cl_short8;
-        typedef __m128i __cl_uint4;
-        typedef __m128i __cl_int4;
-        typedef __m128i __cl_ulong2;
-        typedef __m128i __cl_long2;
-        typedef __m128d __cl_double2;
-    #endif
-    #define __CL_UCHAR16__  1
-    #define __CL_CHAR16__   1
-    #define __CL_USHORT8__  1
-    #define __CL_SHORT8__   1
-    #define __CL_INT4__     1
-    #define __CL_UINT4__    1
-    #define __CL_ULONG2__   1
-    #define __CL_LONG2__    1
-    #define __CL_DOUBLE2__  1
+#if defined(__SSE2__)
+#if defined(__MINGW64__)
+#include <intrin.h>
+#else
+#include <emmintrin.h>
+#endif
+#if defined(__GNUC__)
+typedef cl_uchar  __cl_uchar16 __attribute__((vector_size(16)));
+typedef cl_char   __cl_char16 __attribute__((vector_size(16)));
+typedef cl_ushort __cl_ushort8 __attribute__((vector_size(16)));
+typedef cl_short  __cl_short8 __attribute__((vector_size(16)));
+typedef cl_uint   __cl_uint4 __attribute__((vector_size(16)));
+typedef cl_int    __cl_int4 __attribute__((vector_size(16)));
+typedef cl_ulong  __cl_ulong2 __attribute__((vector_size(16)));
+typedef cl_long   __cl_long2 __attribute__((vector_size(16)));
+typedef cl_double __cl_double2 __attribute__((vector_size(16)));
+#else
+typedef __m128i __cl_uchar16;
+typedef __m128i __cl_char16;
+typedef __m128i __cl_ushort8;
+typedef __m128i __cl_short8;
+typedef __m128i __cl_uint4;
+typedef __m128i __cl_int4;
+typedef __m128i __cl_ulong2;
+typedef __m128i __cl_long2;
+typedef __m128d __cl_double2;
+#endif
+#define __CL_UCHAR16__ 1
+#define __CL_CHAR16__  1
+#define __CL_USHORT8__ 1
+#define __CL_SHORT8__  1
+#define __CL_INT4__    1
+#define __CL_UINT4__   1
+#define __CL_ULONG2__  1
+#define __CL_LONG2__   1
+#define __CL_DOUBLE2__ 1
 #endif
 
-#if defined( __MMX__ )
-    #include <mmintrin.h>
-    #if defined( __GNUC__ )
-        typedef cl_uchar    __cl_uchar8     __attribute__((vector_size(8)));
-        typedef cl_char     __cl_char8      __attribute__((vector_size(8)));
-        typedef cl_ushort   __cl_ushort4    __attribute__((vector_size(8)));
-        typedef cl_short    __cl_short4     __attribute__((vector_size(8)));
-        typedef cl_uint     __cl_uint2      __attribute__((vector_size(8)));
-        typedef cl_int      __cl_int2       __attribute__((vector_size(8)));
-        typedef cl_ulong    __cl_ulong1     __attribute__((vector_size(8)));
-        typedef cl_long     __cl_long1      __attribute__((vector_size(8)));
-        typedef cl_float    __cl_float2     __attribute__((vector_size(8)));
-    #else
-        typedef __m64       __cl_uchar8;
-        typedef __m64       __cl_char8;
-        typedef __m64       __cl_ushort4;
-        typedef __m64       __cl_short4;
-        typedef __m64       __cl_uint2;
-        typedef __m64       __cl_int2;
-        typedef __m64       __cl_ulong1;
-        typedef __m64       __cl_long1;
-        typedef __m64       __cl_float2;
-    #endif
-    #define __CL_UCHAR8__   1
-    #define __CL_CHAR8__    1
-    #define __CL_USHORT4__  1
-    #define __CL_SHORT4__   1
-    #define __CL_INT2__     1
-    #define __CL_UINT2__    1
-    #define __CL_ULONG1__   1
-    #define __CL_LONG1__    1
-    #define __CL_FLOAT2__   1
+#if defined(__MMX__)
+#include <mmintrin.h>
+#if defined(__GNUC__)
+typedef cl_uchar  __cl_uchar8 __attribute__((vector_size(8)));
+typedef cl_char   __cl_char8 __attribute__((vector_size(8)));
+typedef cl_ushort __cl_ushort4 __attribute__((vector_size(8)));
+typedef cl_short  __cl_short4 __attribute__((vector_size(8)));
+typedef cl_uint   __cl_uint2 __attribute__((vector_size(8)));
+typedef cl_int    __cl_int2 __attribute__((vector_size(8)));
+typedef cl_ulong  __cl_ulong1 __attribute__((vector_size(8)));
+typedef cl_long   __cl_long1 __attribute__((vector_size(8)));
+typedef cl_float  __cl_float2 __attribute__((vector_size(8)));
+#else
+typedef __m64   __cl_uchar8;
+typedef __m64   __cl_char8;
+typedef __m64   __cl_ushort4;
+typedef __m64   __cl_short4;
+typedef __m64   __cl_uint2;
+typedef __m64   __cl_int2;
+typedef __m64   __cl_ulong1;
+typedef __m64   __cl_long1;
+typedef __m64   __cl_float2;
+#endif
+#define __CL_UCHAR8__  1
+#define __CL_CHAR8__   1
+#define __CL_USHORT4__ 1
+#define __CL_SHORT4__  1
+#define __CL_INT2__    1
+#define __CL_UINT2__   1
+#define __CL_ULONG1__  1
+#define __CL_LONG1__   1
+#define __CL_FLOAT2__  1
 #endif
 
-#if defined( __AVX__ )
-    #if defined( __MINGW64__ )
-        #include <intrin.h>
-    #else
-        #include <immintrin.h>
-    #endif
-    #if defined( __GNUC__ )
-        typedef cl_float    __cl_float8     __attribute__((vector_size(32)));
-        typedef cl_double   __cl_double4    __attribute__((vector_size(32)));
-    #else
-        typedef __m256      __cl_float8;
-        typedef __m256d     __cl_double4;
-    #endif
-    #define __CL_FLOAT8__   1
-    #define __CL_DOUBLE4__  1
+#if defined(__AVX__)
+#if defined(__MINGW64__)
+#include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
+#if defined(__GNUC__)
+typedef cl_float  __cl_float8 __attribute__((vector_size(32)));
+typedef cl_double __cl_double4 __attribute__((vector_size(32)));
+#else
+typedef __m256  __cl_float8;
+typedef __m256d __cl_double4;
+#endif
+#define __CL_FLOAT8__  1
+#define __CL_DOUBLE4__ 1
 #endif
 
 /* Define capabilities for anonymous struct members. */
-#if !defined(__cplusplus) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-#define  __CL_HAS_ANON_STRUCT__ 1
-#define  __CL_ANON_STRUCT__
+#if !defined(__cplusplus) && defined(__STDC_VERSION__) &&                      \
+  __STDC_VERSION__ >= 201112L
+#define __CL_HAS_ANON_STRUCT__ 1
+#define __CL_ANON_STRUCT__
 #elif defined(_WIN32) && defined(_MSC_VER) && !defined(__STDC__)
-#define  __CL_HAS_ANON_STRUCT__ 1
-#define  __CL_ANON_STRUCT__
-#elif defined(__GNUC__) && ! defined(__STRICT_ANSI__)
-#define  __CL_HAS_ANON_STRUCT__ 1
-#define  __CL_ANON_STRUCT__ __extension__
+#define __CL_HAS_ANON_STRUCT__ 1
+#define __CL_ANON_STRUCT__
+#elif defined(__GNUC__) && !defined(__STRICT_ANSI__)
+#define __CL_HAS_ANON_STRUCT__ 1
+#define __CL_ANON_STRUCT__     __extension__
 #elif defined(__clang__)
-#define  __CL_HAS_ANON_STRUCT__ 1
-#define  __CL_ANON_STRUCT__ __extension__
+#define __CL_HAS_ANON_STRUCT__ 1
+#define __CL_ANON_STRUCT__     __extension__
 #else
-#define  __CL_HAS_ANON_STRUCT__ 0
-#define  __CL_ANON_STRUCT__
+#define __CL_HAS_ANON_STRUCT__ 0
+#define __CL_ANON_STRUCT__
 #endif
 
 #if defined(_WIN32) && defined(_MSC_VER) && __CL_HAS_ANON_STRUCT__
-   /* Disable warning C4201: nonstandard extension used : nameless struct/union */
-    #pragma warning( push )
-    #pragma warning( disable : 4201 )
+/* Disable warning C4201: nonstandard extension used : nameless struct/union */
+#pragma warning(push)
+#pragma warning(disable : 4201)
 #endif
 
 /* Define alignment keys */
-#if defined( __GNUC__ ) || defined(__INTEGRITY)
-    #define CL_ALIGNED(_x)          __attribute__ ((aligned(_x)))
-#elif defined( _WIN32) && (_MSC_VER)
-    /* Alignment keys neutered on windows because MSVC can't swallow function arguments with alignment requirements     */
-    /* http://msdn.microsoft.com/en-us/library/373ak2y1%28VS.71%29.aspx                                                 */
-    /* #include <crtdefs.h>                                                                                             */
-    /* #define CL_ALIGNED(_x)          _CRT_ALIGN(_x)                                                                   */
-    #define CL_ALIGNED(_x)
+#if defined(__GNUC__) || defined(__INTEGRITY)
+#define CL_ALIGNED(_x) __attribute__((aligned(_x)))
+#elif defined(_WIN32) && (_MSC_VER)
+/* Alignment keys neutered on windows because MSVC can't swallow function
+ * arguments with alignment requirements     */
+/* http://msdn.microsoft.com/en-us/library/373ak2y1%28VS.71%29.aspx */
+/* #include <crtdefs.h> */
+/* #define CL_ALIGNED(_x)          _CRT_ALIGN(_x) */
+#define CL_ALIGNED(_x)
 #else
-   #warning  Need to implement some method to align data here
-   #define  CL_ALIGNED(_x)
+#warning Need to implement some method to align data here
+#define CL_ALIGNED(_x)
 #endif
 
 /* Indicate whether .xyzw, .s0123 and .hi.lo are supported */
 #if __CL_HAS_ANON_STRUCT__
-    /* .xyzw and .s0123...{f|F} are supported */
-    #define CL_HAS_NAMED_VECTOR_FIELDS 1
-    /* .hi and .lo are supported */
-    #define CL_HAS_HI_LO_VECTOR_FIELDS 1
+/* .xyzw and .s0123...{f|F} are supported */
+#define CL_HAS_NAMED_VECTOR_FIELDS 1
+/* .hi and .lo are supported */
+#define CL_HAS_HI_LO_VECTOR_FIELDS 1
 #endif
 
 /* Define cl_vector types */
@@ -557,830 +575,1241 @@ typedef unsigned int cl_GLenum;
 /* ---- cl_charn ---- */
 typedef union
 {
-    cl_char  CL_ALIGNED(2) s[2];
+  cl_char CL_ALIGNED(2) s[2];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_char  x, y; };
-   __CL_ANON_STRUCT__ struct{ cl_char  s0, s1; };
-   __CL_ANON_STRUCT__ struct{ cl_char  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char lo, hi;
+  };
 #endif
-#if defined( __CL_CHAR2__)
-    __cl_char2     v2;
+#if defined(__CL_CHAR2__)
+  __cl_char2 v2;
 #endif
-}cl_char2;
+} cl_char2;
 
 typedef union
 {
-    cl_char  CL_ALIGNED(4) s[4];
+  cl_char CL_ALIGNED(4) s[4];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_char  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_char  s0, s1, s2, s3; };
-   __CL_ANON_STRUCT__ struct{ cl_char2 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char2 lo, hi;
+  };
 #endif
-#if defined( __CL_CHAR2__)
-    __cl_char2     v2[2];
+#if defined(__CL_CHAR2__)
+  __cl_char2 v2[2];
 #endif
-#if defined( __CL_CHAR4__)
-    __cl_char4     v4;
+#if defined(__CL_CHAR4__)
+  __cl_char4 v4;
 #endif
-}cl_char4;
+} cl_char4;
 
-/* cl_char3 is identical in size, alignment and behavior to cl_char4. See section 6.1.5. */
-typedef  cl_char4  cl_char3;
+/* cl_char3 is identical in size, alignment and behavior to cl_char4. See
+ * section 6.1.5. */
+typedef cl_char4 cl_char3;
 
 typedef union
 {
-    cl_char   CL_ALIGNED(8) s[8];
+  cl_char CL_ALIGNED(8) s[8];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_char  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_char  s0, s1, s2, s3, s4, s5, s6, s7; };
-   __CL_ANON_STRUCT__ struct{ cl_char4 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char4 lo, hi;
+  };
 #endif
-#if defined( __CL_CHAR2__)
-    __cl_char2     v2[4];
+#if defined(__CL_CHAR2__)
+  __cl_char2 v2[4];
 #endif
-#if defined( __CL_CHAR4__)
-    __cl_char4     v4[2];
+#if defined(__CL_CHAR4__)
+  __cl_char4 v4[2];
 #endif
-#if defined( __CL_CHAR8__ )
-    __cl_char8     v8;
+#if defined(__CL_CHAR8__)
+  __cl_char8 v8;
 #endif
-}cl_char8;
+} cl_char8;
 
 typedef union
 {
-    cl_char  CL_ALIGNED(16) s[16];
+  cl_char CL_ALIGNED(16) s[16];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_char  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-   __CL_ANON_STRUCT__ struct{ cl_char  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-   __CL_ANON_STRUCT__ struct{ cl_char8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_char8 lo, hi;
+  };
 #endif
-#if defined( __CL_CHAR2__)
-    __cl_char2     v2[8];
+#if defined(__CL_CHAR2__)
+  __cl_char2 v2[8];
 #endif
-#if defined( __CL_CHAR4__)
-    __cl_char4     v4[4];
+#if defined(__CL_CHAR4__)
+  __cl_char4 v4[4];
 #endif
-#if defined( __CL_CHAR8__ )
-    __cl_char8     v8[2];
+#if defined(__CL_CHAR8__)
+  __cl_char8 v8[2];
 #endif
-#if defined( __CL_CHAR16__ )
-    __cl_char16    v16;
+#if defined(__CL_CHAR16__)
+  __cl_char16 v16;
 #endif
-}cl_char16;
-
+} cl_char16;
 
 /* ---- cl_ucharn ---- */
 typedef union
 {
-    cl_uchar  CL_ALIGNED(2) s[2];
+  cl_uchar CL_ALIGNED(2) s[2];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_uchar  x, y; };
-   __CL_ANON_STRUCT__ struct{ cl_uchar  s0, s1; };
-   __CL_ANON_STRUCT__ struct{ cl_uchar  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar lo, hi;
+  };
 #endif
-#if defined( __cl_uchar2__)
-    __cl_uchar2     v2;
+#if defined(__cl_uchar2__)
+  __cl_uchar2 v2;
 #endif
-}cl_uchar2;
+} cl_uchar2;
 
 typedef union
 {
-    cl_uchar  CL_ALIGNED(4) s[4];
+  cl_uchar CL_ALIGNED(4) s[4];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_uchar  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_uchar  s0, s1, s2, s3; };
-   __CL_ANON_STRUCT__ struct{ cl_uchar2 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar2 lo, hi;
+  };
 #endif
-#if defined( __CL_UCHAR2__)
-    __cl_uchar2     v2[2];
+#if defined(__CL_UCHAR2__)
+  __cl_uchar2 v2[2];
 #endif
-#if defined( __CL_UCHAR4__)
-    __cl_uchar4     v4;
+#if defined(__CL_UCHAR4__)
+  __cl_uchar4 v4;
 #endif
-}cl_uchar4;
+} cl_uchar4;
 
-/* cl_uchar3 is identical in size, alignment and behavior to cl_uchar4. See section 6.1.5. */
-typedef  cl_uchar4  cl_uchar3;
+/* cl_uchar3 is identical in size, alignment and behavior to cl_uchar4. See
+ * section 6.1.5. */
+typedef cl_uchar4 cl_uchar3;
 
 typedef union
 {
-    cl_uchar   CL_ALIGNED(8) s[8];
+  cl_uchar CL_ALIGNED(8) s[8];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_uchar  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_uchar  s0, s1, s2, s3, s4, s5, s6, s7; };
-   __CL_ANON_STRUCT__ struct{ cl_uchar4 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar4 lo, hi;
+  };
 #endif
-#if defined( __CL_UCHAR2__)
-    __cl_uchar2     v2[4];
+#if defined(__CL_UCHAR2__)
+  __cl_uchar2 v2[4];
 #endif
-#if defined( __CL_UCHAR4__)
-    __cl_uchar4     v4[2];
+#if defined(__CL_UCHAR4__)
+  __cl_uchar4 v4[2];
 #endif
-#if defined( __CL_UCHAR8__ )
-    __cl_uchar8     v8;
+#if defined(__CL_UCHAR8__)
+  __cl_uchar8 v8;
 #endif
-}cl_uchar8;
+} cl_uchar8;
 
 typedef union
 {
-    cl_uchar  CL_ALIGNED(16) s[16];
+  cl_uchar CL_ALIGNED(16) s[16];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_uchar  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-   __CL_ANON_STRUCT__ struct{ cl_uchar  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-   __CL_ANON_STRUCT__ struct{ cl_uchar8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uchar8 lo, hi;
+  };
 #endif
-#if defined( __CL_UCHAR2__)
-    __cl_uchar2     v2[8];
+#if defined(__CL_UCHAR2__)
+  __cl_uchar2 v2[8];
 #endif
-#if defined( __CL_UCHAR4__)
-    __cl_uchar4     v4[4];
+#if defined(__CL_UCHAR4__)
+  __cl_uchar4 v4[4];
 #endif
-#if defined( __CL_UCHAR8__ )
-    __cl_uchar8     v8[2];
+#if defined(__CL_UCHAR8__)
+  __cl_uchar8 v8[2];
 #endif
-#if defined( __CL_UCHAR16__ )
-    __cl_uchar16    v16;
+#if defined(__CL_UCHAR16__)
+  __cl_uchar16 v16;
 #endif
-}cl_uchar16;
-
+} cl_uchar16;
 
 /* ---- cl_shortn ---- */
 typedef union
 {
-    cl_short  CL_ALIGNED(4) s[2];
+  cl_short CL_ALIGNED(4) s[2];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_short  x, y; };
-   __CL_ANON_STRUCT__ struct{ cl_short  s0, s1; };
-   __CL_ANON_STRUCT__ struct{ cl_short  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short lo, hi;
+  };
 #endif
-#if defined( __CL_SHORT2__)
-    __cl_short2     v2;
+#if defined(__CL_SHORT2__)
+  __cl_short2 v2;
 #endif
-}cl_short2;
+} cl_short2;
 
 typedef union
 {
-    cl_short  CL_ALIGNED(8) s[4];
+  cl_short CL_ALIGNED(8) s[4];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_short  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_short  s0, s1, s2, s3; };
-   __CL_ANON_STRUCT__ struct{ cl_short2 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short2 lo, hi;
+  };
 #endif
-#if defined( __CL_SHORT2__)
-    __cl_short2     v2[2];
+#if defined(__CL_SHORT2__)
+  __cl_short2 v2[2];
 #endif
-#if defined( __CL_SHORT4__)
-    __cl_short4     v4;
+#if defined(__CL_SHORT4__)
+  __cl_short4 v4;
 #endif
-}cl_short4;
+} cl_short4;
 
-/* cl_short3 is identical in size, alignment and behavior to cl_short4. See section 6.1.5. */
-typedef  cl_short4  cl_short3;
+/* cl_short3 is identical in size, alignment and behavior to cl_short4. See
+ * section 6.1.5. */
+typedef cl_short4 cl_short3;
 
 typedef union
 {
-    cl_short   CL_ALIGNED(16) s[8];
+  cl_short CL_ALIGNED(16) s[8];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_short  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_short  s0, s1, s2, s3, s4, s5, s6, s7; };
-   __CL_ANON_STRUCT__ struct{ cl_short4 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short4 lo, hi;
+  };
 #endif
-#if defined( __CL_SHORT2__)
-    __cl_short2     v2[4];
+#if defined(__CL_SHORT2__)
+  __cl_short2 v2[4];
 #endif
-#if defined( __CL_SHORT4__)
-    __cl_short4     v4[2];
+#if defined(__CL_SHORT4__)
+  __cl_short4 v4[2];
 #endif
-#if defined( __CL_SHORT8__ )
-    __cl_short8     v8;
+#if defined(__CL_SHORT8__)
+  __cl_short8 v8;
 #endif
-}cl_short8;
+} cl_short8;
 
 typedef union
 {
-    cl_short  CL_ALIGNED(32) s[16];
+  cl_short CL_ALIGNED(32) s[16];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_short  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-   __CL_ANON_STRUCT__ struct{ cl_short  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-   __CL_ANON_STRUCT__ struct{ cl_short8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_short8 lo, hi;
+  };
 #endif
-#if defined( __CL_SHORT2__)
-    __cl_short2     v2[8];
+#if defined(__CL_SHORT2__)
+  __cl_short2 v2[8];
 #endif
-#if defined( __CL_SHORT4__)
-    __cl_short4     v4[4];
+#if defined(__CL_SHORT4__)
+  __cl_short4 v4[4];
 #endif
-#if defined( __CL_SHORT8__ )
-    __cl_short8     v8[2];
+#if defined(__CL_SHORT8__)
+  __cl_short8 v8[2];
 #endif
-#if defined( __CL_SHORT16__ )
-    __cl_short16    v16;
+#if defined(__CL_SHORT16__)
+  __cl_short16 v16;
 #endif
-}cl_short16;
-
+} cl_short16;
 
 /* ---- cl_ushortn ---- */
 typedef union
 {
-    cl_ushort  CL_ALIGNED(4) s[2];
+  cl_ushort CL_ALIGNED(4) s[2];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_ushort  x, y; };
-   __CL_ANON_STRUCT__ struct{ cl_ushort  s0, s1; };
-   __CL_ANON_STRUCT__ struct{ cl_ushort  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort lo, hi;
+  };
 #endif
-#if defined( __CL_USHORT2__)
-    __cl_ushort2     v2;
+#if defined(__CL_USHORT2__)
+  __cl_ushort2 v2;
 #endif
-}cl_ushort2;
+} cl_ushort2;
 
 typedef union
 {
-    cl_ushort  CL_ALIGNED(8) s[4];
+  cl_ushort CL_ALIGNED(8) s[4];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_ushort  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_ushort  s0, s1, s2, s3; };
-   __CL_ANON_STRUCT__ struct{ cl_ushort2 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort2 lo, hi;
+  };
 #endif
-#if defined( __CL_USHORT2__)
-    __cl_ushort2     v2[2];
+#if defined(__CL_USHORT2__)
+  __cl_ushort2 v2[2];
 #endif
-#if defined( __CL_USHORT4__)
-    __cl_ushort4     v4;
+#if defined(__CL_USHORT4__)
+  __cl_ushort4 v4;
 #endif
-}cl_ushort4;
+} cl_ushort4;
 
-/* cl_ushort3 is identical in size, alignment and behavior to cl_ushort4. See section 6.1.5. */
-typedef  cl_ushort4  cl_ushort3;
+/* cl_ushort3 is identical in size, alignment and behavior to cl_ushort4. See
+ * section 6.1.5. */
+typedef cl_ushort4 cl_ushort3;
 
 typedef union
 {
-    cl_ushort   CL_ALIGNED(16) s[8];
+  cl_ushort CL_ALIGNED(16) s[8];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_ushort  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_ushort  s0, s1, s2, s3, s4, s5, s6, s7; };
-   __CL_ANON_STRUCT__ struct{ cl_ushort4 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort4 lo, hi;
+  };
 #endif
-#if defined( __CL_USHORT2__)
-    __cl_ushort2     v2[4];
+#if defined(__CL_USHORT2__)
+  __cl_ushort2 v2[4];
 #endif
-#if defined( __CL_USHORT4__)
-    __cl_ushort4     v4[2];
+#if defined(__CL_USHORT4__)
+  __cl_ushort4 v4[2];
 #endif
-#if defined( __CL_USHORT8__ )
-    __cl_ushort8     v8;
+#if defined(__CL_USHORT8__)
+  __cl_ushort8 v8;
 #endif
-}cl_ushort8;
+} cl_ushort8;
 
 typedef union
 {
-    cl_ushort  CL_ALIGNED(32) s[16];
+  cl_ushort CL_ALIGNED(32) s[16];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_ushort  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-   __CL_ANON_STRUCT__ struct{ cl_ushort  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-   __CL_ANON_STRUCT__ struct{ cl_ushort8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ushort8 lo, hi;
+  };
 #endif
-#if defined( __CL_USHORT2__)
-    __cl_ushort2     v2[8];
+#if defined(__CL_USHORT2__)
+  __cl_ushort2 v2[8];
 #endif
-#if defined( __CL_USHORT4__)
-    __cl_ushort4     v4[4];
+#if defined(__CL_USHORT4__)
+  __cl_ushort4 v4[4];
 #endif
-#if defined( __CL_USHORT8__ )
-    __cl_ushort8     v8[2];
+#if defined(__CL_USHORT8__)
+  __cl_ushort8 v8[2];
 #endif
-#if defined( __CL_USHORT16__ )
-    __cl_ushort16    v16;
+#if defined(__CL_USHORT16__)
+  __cl_ushort16 v16;
 #endif
-}cl_ushort16;
-
+} cl_ushort16;
 
 /* ---- cl_halfn ---- */
 typedef union
 {
-    cl_half  CL_ALIGNED(4) s[2];
+  cl_half CL_ALIGNED(4) s[2];
 #if __CL_HAS_ANON_STRUCT__
-    __CL_ANON_STRUCT__ struct{ cl_half  x, y; };
-    __CL_ANON_STRUCT__ struct{ cl_half  s0, s1; };
-    __CL_ANON_STRUCT__ struct{ cl_half  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half lo, hi;
+  };
 #endif
-#if defined( __CL_HALF2__)
-    __cl_half2     v2;
+#if defined(__CL_HALF2__)
+  __cl_half2 v2;
 #endif
-}cl_half2;
+} cl_half2;
 
 typedef union
 {
-    cl_half  CL_ALIGNED(8) s[4];
+  cl_half CL_ALIGNED(8) s[4];
 #if __CL_HAS_ANON_STRUCT__
-    __CL_ANON_STRUCT__ struct{ cl_half  x, y, z, w; };
-    __CL_ANON_STRUCT__ struct{ cl_half  s0, s1, s2, s3; };
-    __CL_ANON_STRUCT__ struct{ cl_half2 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half2 lo, hi;
+  };
 #endif
-#if defined( __CL_HALF2__)
-    __cl_half2     v2[2];
+#if defined(__CL_HALF2__)
+  __cl_half2 v2[2];
 #endif
-#if defined( __CL_HALF4__)
-    __cl_half4     v4;
+#if defined(__CL_HALF4__)
+  __cl_half4 v4;
 #endif
-}cl_half4;
+} cl_half4;
 
-/* cl_half3 is identical in size, alignment and behavior to cl_half4. See section 6.1.5. */
-typedef  cl_half4  cl_half3;
-
-typedef union
-{
-    cl_half   CL_ALIGNED(16) s[8];
-#if __CL_HAS_ANON_STRUCT__
-    __CL_ANON_STRUCT__ struct{ cl_half  x, y, z, w; };
-    __CL_ANON_STRUCT__ struct{ cl_half  s0, s1, s2, s3, s4, s5, s6, s7; };
-    __CL_ANON_STRUCT__ struct{ cl_half4 lo, hi; };
-#endif
-#if defined( __CL_HALF2__)
-    __cl_half2     v2[4];
-#endif
-#if defined( __CL_HALF4__)
-    __cl_half4     v4[2];
-#endif
-#if defined( __CL_HALF8__ )
-    __cl_half8     v8;
-#endif
-}cl_half8;
+/* cl_half3 is identical in size, alignment and behavior to cl_half4. See
+ * section 6.1.5. */
+typedef cl_half4 cl_half3;
 
 typedef union
 {
-    cl_half  CL_ALIGNED(32) s[16];
+  cl_half CL_ALIGNED(16) s[8];
 #if __CL_HAS_ANON_STRUCT__
-    __CL_ANON_STRUCT__ struct{ cl_half  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-    __CL_ANON_STRUCT__ struct{ cl_half  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-    __CL_ANON_STRUCT__ struct{ cl_half8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half4 lo, hi;
+  };
 #endif
-#if defined( __CL_HALF2__)
-    __cl_half2     v2[8];
+#if defined(__CL_HALF2__)
+  __cl_half2 v2[4];
 #endif
-#if defined( __CL_HALF4__)
-    __cl_half4     v4[4];
+#if defined(__CL_HALF4__)
+  __cl_half4 v4[2];
 #endif
-#if defined( __CL_HALF8__ )
-    __cl_half8     v8[2];
+#if defined(__CL_HALF8__)
+  __cl_half8 v8;
 #endif
-#if defined( __CL_HALF16__ )
-    __cl_half16    v16;
+} cl_half8;
+
+typedef union
+{
+  cl_half CL_ALIGNED(32) s[16];
+#if __CL_HAS_ANON_STRUCT__
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_half8 lo, hi;
+  };
 #endif
-}cl_half16;
+#if defined(__CL_HALF2__)
+  __cl_half2 v2[8];
+#endif
+#if defined(__CL_HALF4__)
+  __cl_half4 v4[4];
+#endif
+#if defined(__CL_HALF8__)
+  __cl_half8 v8[2];
+#endif
+#if defined(__CL_HALF16__)
+  __cl_half16 v16;
+#endif
+} cl_half16;
 
 /* ---- cl_intn ---- */
 typedef union
 {
-    cl_int  CL_ALIGNED(8) s[2];
+  cl_int CL_ALIGNED(8) s[2];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_int  x, y; };
-   __CL_ANON_STRUCT__ struct{ cl_int  s0, s1; };
-   __CL_ANON_STRUCT__ struct{ cl_int  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int lo, hi;
+  };
 #endif
-#if defined( __CL_INT2__)
-    __cl_int2     v2;
+#if defined(__CL_INT2__)
+  __cl_int2 v2;
 #endif
-}cl_int2;
+} cl_int2;
 
 typedef union
 {
-    cl_int  CL_ALIGNED(16) s[4];
+  cl_int CL_ALIGNED(16) s[4];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_int  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_int  s0, s1, s2, s3; };
-   __CL_ANON_STRUCT__ struct{ cl_int2 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int2 lo, hi;
+  };
 #endif
-#if defined( __CL_INT2__)
-    __cl_int2     v2[2];
+#if defined(__CL_INT2__)
+  __cl_int2 v2[2];
 #endif
-#if defined( __CL_INT4__)
-    __cl_int4     v4;
+#if defined(__CL_INT4__)
+  __cl_int4 v4;
 #endif
-}cl_int4;
+} cl_int4;
 
-/* cl_int3 is identical in size, alignment and behavior to cl_int4. See section 6.1.5. */
-typedef  cl_int4  cl_int3;
+/* cl_int3 is identical in size, alignment and behavior to cl_int4. See
+ * section 6.1.5. */
+typedef cl_int4 cl_int3;
 
 typedef union
 {
-    cl_int   CL_ALIGNED(32) s[8];
+  cl_int CL_ALIGNED(32) s[8];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_int  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_int  s0, s1, s2, s3, s4, s5, s6, s7; };
-   __CL_ANON_STRUCT__ struct{ cl_int4 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int4 lo, hi;
+  };
 #endif
-#if defined( __CL_INT2__)
-    __cl_int2     v2[4];
+#if defined(__CL_INT2__)
+  __cl_int2 v2[4];
 #endif
-#if defined( __CL_INT4__)
-    __cl_int4     v4[2];
+#if defined(__CL_INT4__)
+  __cl_int4 v4[2];
 #endif
-#if defined( __CL_INT8__ )
-    __cl_int8     v8;
+#if defined(__CL_INT8__)
+  __cl_int8 v8;
 #endif
-}cl_int8;
+} cl_int8;
 
 typedef union
 {
-    cl_int  CL_ALIGNED(64) s[16];
+  cl_int CL_ALIGNED(64) s[16];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_int  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-   __CL_ANON_STRUCT__ struct{ cl_int  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-   __CL_ANON_STRUCT__ struct{ cl_int8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_int8 lo, hi;
+  };
 #endif
-#if defined( __CL_INT2__)
-    __cl_int2     v2[8];
+#if defined(__CL_INT2__)
+  __cl_int2 v2[8];
 #endif
-#if defined( __CL_INT4__)
-    __cl_int4     v4[4];
+#if defined(__CL_INT4__)
+  __cl_int4 v4[4];
 #endif
-#if defined( __CL_INT8__ )
-    __cl_int8     v8[2];
+#if defined(__CL_INT8__)
+  __cl_int8 v8[2];
 #endif
-#if defined( __CL_INT16__ )
-    __cl_int16    v16;
+#if defined(__CL_INT16__)
+  __cl_int16 v16;
 #endif
-}cl_int16;
-
+} cl_int16;
 
 /* ---- cl_uintn ---- */
 typedef union
 {
-    cl_uint  CL_ALIGNED(8) s[2];
+  cl_uint CL_ALIGNED(8) s[2];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_uint  x, y; };
-   __CL_ANON_STRUCT__ struct{ cl_uint  s0, s1; };
-   __CL_ANON_STRUCT__ struct{ cl_uint  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint lo, hi;
+  };
 #endif
-#if defined( __CL_UINT2__)
-    __cl_uint2     v2;
+#if defined(__CL_UINT2__)
+  __cl_uint2 v2;
 #endif
-}cl_uint2;
+} cl_uint2;
 
 typedef union
 {
-    cl_uint  CL_ALIGNED(16) s[4];
+  cl_uint CL_ALIGNED(16) s[4];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_uint  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_uint  s0, s1, s2, s3; };
-   __CL_ANON_STRUCT__ struct{ cl_uint2 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint2 lo, hi;
+  };
 #endif
-#if defined( __CL_UINT2__)
-    __cl_uint2     v2[2];
+#if defined(__CL_UINT2__)
+  __cl_uint2 v2[2];
 #endif
-#if defined( __CL_UINT4__)
-    __cl_uint4     v4;
+#if defined(__CL_UINT4__)
+  __cl_uint4 v4;
 #endif
-}cl_uint4;
+} cl_uint4;
 
-/* cl_uint3 is identical in size, alignment and behavior to cl_uint4. See section 6.1.5. */
-typedef  cl_uint4  cl_uint3;
-
-typedef union
-{
-    cl_uint   CL_ALIGNED(32) s[8];
-#if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_uint  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_uint  s0, s1, s2, s3, s4, s5, s6, s7; };
-   __CL_ANON_STRUCT__ struct{ cl_uint4 lo, hi; };
-#endif
-#if defined( __CL_UINT2__)
-    __cl_uint2     v2[4];
-#endif
-#if defined( __CL_UINT4__)
-    __cl_uint4     v4[2];
-#endif
-#if defined( __CL_UINT8__ )
-    __cl_uint8     v8;
-#endif
-}cl_uint8;
+/* cl_uint3 is identical in size, alignment and behavior to cl_uint4. See
+ * section 6.1.5. */
+typedef cl_uint4 cl_uint3;
 
 typedef union
 {
-    cl_uint  CL_ALIGNED(64) s[16];
+  cl_uint CL_ALIGNED(32) s[8];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_uint  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-   __CL_ANON_STRUCT__ struct{ cl_uint  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-   __CL_ANON_STRUCT__ struct{ cl_uint8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint4 lo, hi;
+  };
 #endif
-#if defined( __CL_UINT2__)
-    __cl_uint2     v2[8];
+#if defined(__CL_UINT2__)
+  __cl_uint2 v2[4];
 #endif
-#if defined( __CL_UINT4__)
-    __cl_uint4     v4[4];
+#if defined(__CL_UINT4__)
+  __cl_uint4 v4[2];
 #endif
-#if defined( __CL_UINT8__ )
-    __cl_uint8     v8[2];
+#if defined(__CL_UINT8__)
+  __cl_uint8 v8;
 #endif
-#if defined( __CL_UINT16__ )
-    __cl_uint16    v16;
+} cl_uint8;
+
+typedef union
+{
+  cl_uint CL_ALIGNED(64) s[16];
+#if __CL_HAS_ANON_STRUCT__
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_uint8 lo, hi;
+  };
 #endif
-}cl_uint16;
+#if defined(__CL_UINT2__)
+  __cl_uint2 v2[8];
+#endif
+#if defined(__CL_UINT4__)
+  __cl_uint4 v4[4];
+#endif
+#if defined(__CL_UINT8__)
+  __cl_uint8 v8[2];
+#endif
+#if defined(__CL_UINT16__)
+  __cl_uint16 v16;
+#endif
+} cl_uint16;
 
 /* ---- cl_longn ---- */
 typedef union
 {
-    cl_long  CL_ALIGNED(16) s[2];
+  cl_long CL_ALIGNED(16) s[2];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_long  x, y; };
-   __CL_ANON_STRUCT__ struct{ cl_long  s0, s1; };
-   __CL_ANON_STRUCT__ struct{ cl_long  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long lo, hi;
+  };
 #endif
-#if defined( __CL_LONG2__)
-    __cl_long2     v2;
+#if defined(__CL_LONG2__)
+  __cl_long2 v2;
 #endif
-}cl_long2;
+} cl_long2;
 
 typedef union
 {
-    cl_long  CL_ALIGNED(32) s[4];
+  cl_long CL_ALIGNED(32) s[4];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_long  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_long  s0, s1, s2, s3; };
-   __CL_ANON_STRUCT__ struct{ cl_long2 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long2 lo, hi;
+  };
 #endif
-#if defined( __CL_LONG2__)
-    __cl_long2     v2[2];
+#if defined(__CL_LONG2__)
+  __cl_long2 v2[2];
 #endif
-#if defined( __CL_LONG4__)
-    __cl_long4     v4;
+#if defined(__CL_LONG4__)
+  __cl_long4 v4;
 #endif
-}cl_long4;
+} cl_long4;
 
-/* cl_long3 is identical in size, alignment and behavior to cl_long4. See section 6.1.5. */
-typedef  cl_long4  cl_long3;
+/* cl_long3 is identical in size, alignment and behavior to cl_long4. See
+ * section 6.1.5. */
+typedef cl_long4 cl_long3;
 
 typedef union
 {
-    cl_long   CL_ALIGNED(64) s[8];
+  cl_long CL_ALIGNED(64) s[8];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_long  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_long  s0, s1, s2, s3, s4, s5, s6, s7; };
-   __CL_ANON_STRUCT__ struct{ cl_long4 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long4 lo, hi;
+  };
 #endif
-#if defined( __CL_LONG2__)
-    __cl_long2     v2[4];
+#if defined(__CL_LONG2__)
+  __cl_long2 v2[4];
 #endif
-#if defined( __CL_LONG4__)
-    __cl_long4     v4[2];
+#if defined(__CL_LONG4__)
+  __cl_long4 v4[2];
 #endif
-#if defined( __CL_LONG8__ )
-    __cl_long8     v8;
+#if defined(__CL_LONG8__)
+  __cl_long8 v8;
 #endif
-}cl_long8;
+} cl_long8;
 
 typedef union
 {
-    cl_long  CL_ALIGNED(128) s[16];
+  cl_long CL_ALIGNED(128) s[16];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_long  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-   __CL_ANON_STRUCT__ struct{ cl_long  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-   __CL_ANON_STRUCT__ struct{ cl_long8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_long8 lo, hi;
+  };
 #endif
-#if defined( __CL_LONG2__)
-    __cl_long2     v2[8];
+#if defined(__CL_LONG2__)
+  __cl_long2 v2[8];
 #endif
-#if defined( __CL_LONG4__)
-    __cl_long4     v4[4];
+#if defined(__CL_LONG4__)
+  __cl_long4 v4[4];
 #endif
-#if defined( __CL_LONG8__ )
-    __cl_long8     v8[2];
+#if defined(__CL_LONG8__)
+  __cl_long8 v8[2];
 #endif
-#if defined( __CL_LONG16__ )
-    __cl_long16    v16;
+#if defined(__CL_LONG16__)
+  __cl_long16 v16;
 #endif
-}cl_long16;
-
+} cl_long16;
 
 /* ---- cl_ulongn ---- */
 typedef union
 {
-    cl_ulong  CL_ALIGNED(16) s[2];
+  cl_ulong CL_ALIGNED(16) s[2];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_ulong  x, y; };
-   __CL_ANON_STRUCT__ struct{ cl_ulong  s0, s1; };
-   __CL_ANON_STRUCT__ struct{ cl_ulong  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong lo, hi;
+  };
 #endif
-#if defined( __CL_ULONG2__)
-    __cl_ulong2     v2;
+#if defined(__CL_ULONG2__)
+  __cl_ulong2 v2;
 #endif
-}cl_ulong2;
+} cl_ulong2;
 
 typedef union
 {
-    cl_ulong  CL_ALIGNED(32) s[4];
+  cl_ulong CL_ALIGNED(32) s[4];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_ulong  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_ulong  s0, s1, s2, s3; };
-   __CL_ANON_STRUCT__ struct{ cl_ulong2 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong2 lo, hi;
+  };
 #endif
-#if defined( __CL_ULONG2__)
-    __cl_ulong2     v2[2];
+#if defined(__CL_ULONG2__)
+  __cl_ulong2 v2[2];
 #endif
-#if defined( __CL_ULONG4__)
-    __cl_ulong4     v4;
+#if defined(__CL_ULONG4__)
+  __cl_ulong4 v4;
 #endif
-}cl_ulong4;
+} cl_ulong4;
 
-/* cl_ulong3 is identical in size, alignment and behavior to cl_ulong4. See section 6.1.5. */
-typedef  cl_ulong4  cl_ulong3;
+/* cl_ulong3 is identical in size, alignment and behavior to cl_ulong4. See
+ * section 6.1.5. */
+typedef cl_ulong4 cl_ulong3;
 
 typedef union
 {
-    cl_ulong   CL_ALIGNED(64) s[8];
+  cl_ulong CL_ALIGNED(64) s[8];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_ulong  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_ulong  s0, s1, s2, s3, s4, s5, s6, s7; };
-   __CL_ANON_STRUCT__ struct{ cl_ulong4 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong4 lo, hi;
+  };
 #endif
-#if defined( __CL_ULONG2__)
-    __cl_ulong2     v2[4];
+#if defined(__CL_ULONG2__)
+  __cl_ulong2 v2[4];
 #endif
-#if defined( __CL_ULONG4__)
-    __cl_ulong4     v4[2];
+#if defined(__CL_ULONG4__)
+  __cl_ulong4 v4[2];
 #endif
-#if defined( __CL_ULONG8__ )
-    __cl_ulong8     v8;
+#if defined(__CL_ULONG8__)
+  __cl_ulong8 v8;
 #endif
-}cl_ulong8;
+} cl_ulong8;
 
 typedef union
 {
-    cl_ulong  CL_ALIGNED(128) s[16];
+  cl_ulong CL_ALIGNED(128) s[16];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_ulong  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-   __CL_ANON_STRUCT__ struct{ cl_ulong  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-   __CL_ANON_STRUCT__ struct{ cl_ulong8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_ulong8 lo, hi;
+  };
 #endif
-#if defined( __CL_ULONG2__)
-    __cl_ulong2     v2[8];
+#if defined(__CL_ULONG2__)
+  __cl_ulong2 v2[8];
 #endif
-#if defined( __CL_ULONG4__)
-    __cl_ulong4     v4[4];
+#if defined(__CL_ULONG4__)
+  __cl_ulong4 v4[4];
 #endif
-#if defined( __CL_ULONG8__ )
-    __cl_ulong8     v8[2];
+#if defined(__CL_ULONG8__)
+  __cl_ulong8 v8[2];
 #endif
-#if defined( __CL_ULONG16__ )
-    __cl_ulong16    v16;
+#if defined(__CL_ULONG16__)
+  __cl_ulong16 v16;
 #endif
-}cl_ulong16;
-
+} cl_ulong16;
 
 /* --- cl_floatn ---- */
 
 typedef union
 {
-    cl_float  CL_ALIGNED(8) s[2];
+  cl_float CL_ALIGNED(8) s[2];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_float  x, y; };
-   __CL_ANON_STRUCT__ struct{ cl_float  s0, s1; };
-   __CL_ANON_STRUCT__ struct{ cl_float  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float lo, hi;
+  };
 #endif
-#if defined( __CL_FLOAT2__)
-    __cl_float2     v2;
+#if defined(__CL_FLOAT2__)
+  __cl_float2 v2;
 #endif
-}cl_float2;
+} cl_float2;
 
 typedef union
 {
-    cl_float  CL_ALIGNED(16) s[4];
+  cl_float CL_ALIGNED(16) s[4];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_float   x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_float   s0, s1, s2, s3; };
-   __CL_ANON_STRUCT__ struct{ cl_float2  lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float2 lo, hi;
+  };
 #endif
-#if defined( __CL_FLOAT2__)
-    __cl_float2     v2[2];
+#if defined(__CL_FLOAT2__)
+  __cl_float2 v2[2];
 #endif
-#if defined( __CL_FLOAT4__)
-    __cl_float4     v4;
+#if defined(__CL_FLOAT4__)
+  __cl_float4 v4;
 #endif
-}cl_float4;
+} cl_float4;
 
-/* cl_float3 is identical in size, alignment and behavior to cl_float4. See section 6.1.5. */
-typedef  cl_float4  cl_float3;
-
-typedef union
-{
-    cl_float   CL_ALIGNED(32) s[8];
-#if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_float   x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_float   s0, s1, s2, s3, s4, s5, s6, s7; };
-   __CL_ANON_STRUCT__ struct{ cl_float4  lo, hi; };
-#endif
-#if defined( __CL_FLOAT2__)
-    __cl_float2     v2[4];
-#endif
-#if defined( __CL_FLOAT4__)
-    __cl_float4     v4[2];
-#endif
-#if defined( __CL_FLOAT8__ )
-    __cl_float8     v8;
-#endif
-}cl_float8;
+/* cl_float3 is identical in size, alignment and behavior to cl_float4. See
+ * section 6.1.5. */
+typedef cl_float4 cl_float3;
 
 typedef union
 {
-    cl_float  CL_ALIGNED(64) s[16];
+  cl_float CL_ALIGNED(32) s[8];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_float  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-   __CL_ANON_STRUCT__ struct{ cl_float  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-   __CL_ANON_STRUCT__ struct{ cl_float8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float4 lo, hi;
+  };
 #endif
-#if defined( __CL_FLOAT2__)
-    __cl_float2     v2[8];
+#if defined(__CL_FLOAT2__)
+  __cl_float2 v2[4];
 #endif
-#if defined( __CL_FLOAT4__)
-    __cl_float4     v4[4];
+#if defined(__CL_FLOAT4__)
+  __cl_float4 v4[2];
 #endif
-#if defined( __CL_FLOAT8__ )
-    __cl_float8     v8[2];
+#if defined(__CL_FLOAT8__)
+  __cl_float8 v8;
 #endif
-#if defined( __CL_FLOAT16__ )
-    __cl_float16    v16;
+} cl_float8;
+
+typedef union
+{
+  cl_float CL_ALIGNED(64) s[16];
+#if __CL_HAS_ANON_STRUCT__
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_float8 lo, hi;
+  };
 #endif
-}cl_float16;
+#if defined(__CL_FLOAT2__)
+  __cl_float2 v2[8];
+#endif
+#if defined(__CL_FLOAT4__)
+  __cl_float4 v4[4];
+#endif
+#if defined(__CL_FLOAT8__)
+  __cl_float8 v8[2];
+#endif
+#if defined(__CL_FLOAT16__)
+  __cl_float16 v16;
+#endif
+} cl_float16;
 
 /* --- cl_doublen ---- */
 
 typedef union
 {
-    cl_double  CL_ALIGNED(16) s[2];
+  cl_double CL_ALIGNED(16) s[2];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_double  x, y; };
-   __CL_ANON_STRUCT__ struct{ cl_double s0, s1; };
-   __CL_ANON_STRUCT__ struct{ cl_double lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double x, y;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double s0, s1;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double lo, hi;
+  };
 #endif
-#if defined( __CL_DOUBLE2__)
-    __cl_double2     v2;
+#if defined(__CL_DOUBLE2__)
+  __cl_double2 v2;
 #endif
-}cl_double2;
+} cl_double2;
 
 typedef union
 {
-    cl_double  CL_ALIGNED(32) s[4];
+  cl_double CL_ALIGNED(32) s[4];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_double  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_double  s0, s1, s2, s3; };
-   __CL_ANON_STRUCT__ struct{ cl_double2 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double s0, s1, s2, s3;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double2 lo, hi;
+  };
 #endif
-#if defined( __CL_DOUBLE2__)
-    __cl_double2     v2[2];
+#if defined(__CL_DOUBLE2__)
+  __cl_double2 v2[2];
 #endif
-#if defined( __CL_DOUBLE4__)
-    __cl_double4     v4;
+#if defined(__CL_DOUBLE4__)
+  __cl_double4 v4;
 #endif
-}cl_double4;
+} cl_double4;
 
-/* cl_double3 is identical in size, alignment and behavior to cl_double4. See section 6.1.5. */
-typedef  cl_double4  cl_double3;
-
-typedef union
-{
-    cl_double   CL_ALIGNED(64) s[8];
-#if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_double  x, y, z, w; };
-   __CL_ANON_STRUCT__ struct{ cl_double  s0, s1, s2, s3, s4, s5, s6, s7; };
-   __CL_ANON_STRUCT__ struct{ cl_double4 lo, hi; };
-#endif
-#if defined( __CL_DOUBLE2__)
-    __cl_double2     v2[4];
-#endif
-#if defined( __CL_DOUBLE4__)
-    __cl_double4     v4[2];
-#endif
-#if defined( __CL_DOUBLE8__ )
-    __cl_double8     v8;
-#endif
-}cl_double8;
+/* cl_double3 is identical in size, alignment and behavior to cl_double4. See
+ * section 6.1.5. */
+typedef cl_double4 cl_double3;
 
 typedef union
 {
-    cl_double  CL_ALIGNED(128) s[16];
+  cl_double CL_ALIGNED(64) s[8];
 #if __CL_HAS_ANON_STRUCT__
-   __CL_ANON_STRUCT__ struct{ cl_double  x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8, __spacer9, sa, sb, sc, sd, se, sf; };
-   __CL_ANON_STRUCT__ struct{ cl_double  s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF; };
-   __CL_ANON_STRUCT__ struct{ cl_double8 lo, hi; };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double x, y, z, w;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double s0, s1, s2, s3, s4, s5, s6, s7;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double4 lo, hi;
+  };
 #endif
-#if defined( __CL_DOUBLE2__)
-    __cl_double2     v2[8];
+#if defined(__CL_DOUBLE2__)
+  __cl_double2 v2[4];
 #endif
-#if defined( __CL_DOUBLE4__)
-    __cl_double4     v4[4];
+#if defined(__CL_DOUBLE4__)
+  __cl_double4 v4[2];
 #endif
-#if defined( __CL_DOUBLE8__ )
-    __cl_double8     v8[2];
+#if defined(__CL_DOUBLE8__)
+  __cl_double8 v8;
 #endif
-#if defined( __CL_DOUBLE16__ )
-    __cl_double16    v16;
+} cl_double8;
+
+typedef union
+{
+  cl_double CL_ALIGNED(128) s[16];
+#if __CL_HAS_ANON_STRUCT__
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double x, y, z, w, __spacer4, __spacer5, __spacer6, __spacer7, __spacer8,
+      __spacer9, sa, sb, sc, sd, se, sf;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, sA, sB, sC, sD, sE, sF;
+  };
+  __CL_ANON_STRUCT__ struct
+  {
+    cl_double8 lo, hi;
+  };
 #endif
-}cl_double16;
+#if defined(__CL_DOUBLE2__)
+  __cl_double2 v2[8];
+#endif
+#if defined(__CL_DOUBLE4__)
+  __cl_double4 v4[4];
+#endif
+#if defined(__CL_DOUBLE8__)
+  __cl_double8 v8[2];
+#endif
+#if defined(__CL_DOUBLE16__)
+  __cl_double16 v16;
+#endif
+} cl_double16;
 
 /* Macro to facilitate debugging
  * Usage:
- *   Place CL_PROGRAM_STRING_DEBUG_INFO on the line before the first line of your source.
- *   The first line ends with:   CL_PROGRAM_STRING_DEBUG_INFO \"
+ *   Place CL_PROGRAM_STRING_DEBUG_INFO on the line before the first line of
+ * your source. The first line ends with:   CL_PROGRAM_STRING_DEBUG_INFO \"
  *   Each line thereafter of OpenCL C source must end with: \n\
  *   The last line ends in ";
  *
@@ -1394,19 +1823,20 @@ typedef union
  *   }                                               \n\
  *   ";
  *
- * This should correctly set up the line, (column) and file information for your source
- * string so you can do source level debugging.
+ * This should correctly set up the line, (column) and file information for your
+ * source string so you can do source level debugging.
  */
-#define  __CL_STRINGIFY( _x )               # _x
-#define  _CL_STRINGIFY( _x )                __CL_STRINGIFY( _x )
-#define  CL_PROGRAM_STRING_DEBUG_INFO       "#line "  _CL_STRINGIFY(__LINE__) " \"" __FILE__ "\" \n\n"
+#define __CL_STRINGIFY(_x) #_x
+#define _CL_STRINGIFY(_x)  __CL_STRINGIFY(_x)
+#define CL_PROGRAM_STRING_DEBUG_INFO                                           \
+  "#line " _CL_STRINGIFY(__LINE__) " \"" __FILE__ "\" \n\n"
 
 #ifdef __cplusplus
 }
 #endif
 
 #if defined(_WIN32) && defined(_MSC_VER) && __CL_HAS_ANON_STRUCT__
-    #pragma warning( pop )
+#pragma warning(pop)
 #endif
 
-#endif  /* __CL_PLATFORM_H  */
+#endif /* __CL_PLATFORM_H  */

--- a/CL/cl_va_api_media_sharing_intel.h
+++ b/CL/cl_va_api_media_sharing_intel.h
@@ -26,138 +26,135 @@ extern "C" {
 #endif
 
 /***************************************************************
-* cl_intel_sharing_format_query_va_api
-***************************************************************/
+ * cl_intel_sharing_format_query_va_api
+ ***************************************************************/
 #define cl_intel_sharing_format_query_va_api 1
 
 /* when cl_intel_va_api_media_sharing is supported */
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clGetSupportedVA_APIMediaSurfaceFormatsINTEL(
-    cl_context context,
-    cl_mem_flags flags,
-    cl_mem_object_type image_type,
-    cl_uint plane,
-    cl_uint num_entries,
-    VAImageFormat* va_api_formats,
-    cl_uint* num_surface_formats) ;
+clGetSupportedVA_APIMediaSurfaceFormatsINTEL(cl_context         context,
+                                             cl_mem_flags       flags,
+                                             cl_mem_object_type image_type,
+                                             cl_uint            plane,
+                                             cl_uint            num_entries,
+                                             VAImageFormat*     va_api_formats,
+                                             cl_uint* num_surface_formats);
 
-typedef cl_int (CL_API_CALL *
-clGetSupportedVA_APIMediaSurfaceFormatsINTEL_fn)(
-    cl_context context,
-    cl_mem_flags flags,
-    cl_mem_object_type image_type,
-    cl_uint plane,
-    cl_uint num_entries,
-    VAImageFormat* va_api_formats,
-    cl_uint* num_surface_formats) ;
+typedef cl_int(CL_API_CALL* clGetSupportedVA_APIMediaSurfaceFormatsINTEL_fn)(
+  cl_context         context,
+  cl_mem_flags       flags,
+  cl_mem_object_type image_type,
+  cl_uint            plane,
+  cl_uint            num_entries,
+  VAImageFormat*     va_api_formats,
+  cl_uint*           num_surface_formats);
 
 /******************************************
-* cl_intel_va_api_media_sharing extension *
-*******************************************/
+ * cl_intel_va_api_media_sharing extension *
+ *******************************************/
 
-#define cl_intel_va_api_media_sharing 1
+#define cl_intel_va_api_media_sharing                  1
 
 /* error codes */
-#define CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL               -1098
-#define CL_INVALID_VA_API_MEDIA_SURFACE_INTEL               -1099
-#define CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL      -1100
-#define CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL          -1101
+#define CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL          -1098
+#define CL_INVALID_VA_API_MEDIA_SURFACE_INTEL          -1099
+#define CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL -1100
+#define CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL     -1101
 
 /* cl_va_api_device_source_intel */
-#define CL_VA_API_DISPLAY_INTEL                             0x4094
+#define CL_VA_API_DISPLAY_INTEL                        0x4094
 
 /* cl_va_api_device_set_intel */
-#define CL_PREFERRED_DEVICES_FOR_VA_API_INTEL               0x4095
-#define CL_ALL_DEVICES_FOR_VA_API_INTEL                     0x4096
+#define CL_PREFERRED_DEVICES_FOR_VA_API_INTEL          0x4095
+#define CL_ALL_DEVICES_FOR_VA_API_INTEL                0x4096
 
 /* cl_context_info */
-#define CL_CONTEXT_VA_API_DISPLAY_INTEL                     0x4097
+#define CL_CONTEXT_VA_API_DISPLAY_INTEL                0x4097
 
 /* cl_mem_info */
-#define CL_MEM_VA_API_MEDIA_SURFACE_INTEL                   0x4098
+#define CL_MEM_VA_API_MEDIA_SURFACE_INTEL              0x4098
 
 /* cl_image_info */
-#define CL_IMAGE_VA_API_PLANE_INTEL                         0x4099
+#define CL_IMAGE_VA_API_PLANE_INTEL                    0x4099
 
 /* cl_command_type */
-#define CL_COMMAND_ACQUIRE_VA_API_MEDIA_SURFACES_INTEL      0x409A
-#define CL_COMMAND_RELEASE_VA_API_MEDIA_SURFACES_INTEL      0x409B
+#define CL_COMMAND_ACQUIRE_VA_API_MEDIA_SURFACES_INTEL 0x409A
+#define CL_COMMAND_RELEASE_VA_API_MEDIA_SURFACES_INTEL 0x409B
 
 typedef cl_uint cl_va_api_device_source_intel;
 typedef cl_uint cl_va_api_device_set_intel;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clGetDeviceIDsFromVA_APIMediaAdapterINTEL(
-    cl_platform_id                platform,
-    cl_va_api_device_source_intel media_adapter_type,
-    void*                         media_adapter,
-    cl_va_api_device_set_intel    media_adapter_set,
-    cl_uint                       num_entries,
-    cl_device_id*                 devices,
-    cl_uint*                      num_devices) CL_API_SUFFIX__VERSION_1_2;
+  cl_platform_id                platform,
+  cl_va_api_device_source_intel media_adapter_type,
+  void*                         media_adapter,
+  cl_va_api_device_set_intel    media_adapter_set,
+  cl_uint                       num_entries,
+  cl_device_id*                 devices,
+  cl_uint*                      num_devices) CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL * clGetDeviceIDsFromVA_APIMediaAdapterINTEL_fn)(
-    cl_platform_id                platform,
-    cl_va_api_device_source_intel media_adapter_type,
-    void*                         media_adapter,
-    cl_va_api_device_set_intel    media_adapter_set,
-    cl_uint                       num_entries,
-    cl_device_id*                 devices,
-    cl_uint*                      num_devices) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clGetDeviceIDsFromVA_APIMediaAdapterINTEL_fn)(
+  cl_platform_id                platform,
+  cl_va_api_device_source_intel media_adapter_type,
+  void*                         media_adapter,
+  cl_va_api_device_set_intel    media_adapter_set,
+  cl_uint                       num_entries,
+  cl_device_id*                 devices,
+  cl_uint*                      num_devices) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateFromVA_APIMediaSurfaceINTEL(
-    cl_context                    context,
-    cl_mem_flags                  flags,
-    VASurfaceID*                  surface,
-    cl_uint                       plane,
-    cl_int*                       errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+clCreateFromVA_APIMediaSurfaceINTEL(cl_context   context,
+                                    cl_mem_flags flags,
+                                    VASurfaceID* surface,
+                                    cl_uint      plane,
+                                    cl_int*      errcode_ret)
+  CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_mem (CL_API_CALL * clCreateFromVA_APIMediaSurfaceINTEL_fn)(
-    cl_context                    context,
-    cl_mem_flags                  flags,
-    VASurfaceID*                  surface,
-    cl_uint                       plane,
-    cl_int*                       errcode_ret) CL_API_SUFFIX__VERSION_1_2;
-
-extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueAcquireVA_APIMediaSurfacesINTEL(
-    cl_command_queue              command_queue,
-    cl_uint                       num_objects,
-    const cl_mem*                 mem_objects,
-    cl_uint                       num_events_in_wait_list,
-    const cl_event*               event_wait_list,
-    cl_event*                     event) CL_API_SUFFIX__VERSION_1_2;
-
-typedef cl_int (CL_API_CALL *clEnqueueAcquireVA_APIMediaSurfacesINTEL_fn)(
-    cl_command_queue              command_queue,
-    cl_uint                       num_objects,
-    const cl_mem*                 mem_objects,
-    cl_uint                       num_events_in_wait_list,
-    const cl_event*               event_wait_list,
-    cl_event*                     event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_mem(CL_API_CALL* clCreateFromVA_APIMediaSurfaceINTEL_fn)(
+  cl_context   context,
+  cl_mem_flags flags,
+  VASurfaceID* surface,
+  cl_uint      plane,
+  cl_int*      errcode_ret) CL_API_SUFFIX__VERSION_1_2;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clEnqueueReleaseVA_APIMediaSurfacesINTEL(
-    cl_command_queue              command_queue,
-    cl_uint                       num_objects,
-    const cl_mem*                 mem_objects,
-    cl_uint                       num_events_in_wait_list,
-    const cl_event*               event_wait_list,
-    cl_event*                     event) CL_API_SUFFIX__VERSION_1_2;
+clEnqueueAcquireVA_APIMediaSurfacesINTEL(cl_command_queue command_queue,
+                                         cl_uint          num_objects,
+                                         const cl_mem*    mem_objects,
+                                         cl_uint num_events_in_wait_list,
+                                         const cl_event* event_wait_list,
+                                         cl_event*       event)
+  CL_API_SUFFIX__VERSION_1_2;
 
-typedef cl_int (CL_API_CALL *clEnqueueReleaseVA_APIMediaSurfacesINTEL_fn)(
-    cl_command_queue              command_queue,
-    cl_uint                       num_objects,
-    const cl_mem*                 mem_objects,
-    cl_uint                       num_events_in_wait_list,
-    const cl_event*               event_wait_list,
-    cl_event*                     event) CL_API_SUFFIX__VERSION_1_2;
+typedef cl_int(CL_API_CALL* clEnqueueAcquireVA_APIMediaSurfacesINTEL_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueReleaseVA_APIMediaSurfacesINTEL(cl_command_queue command_queue,
+                                         cl_uint          num_objects,
+                                         const cl_mem*    mem_objects,
+                                         cl_uint num_events_in_wait_list,
+                                         const cl_event* event_wait_list,
+                                         cl_event*       event)
+  CL_API_SUFFIX__VERSION_1_2;
+
+typedef cl_int(CL_API_CALL* clEnqueueReleaseVA_APIMediaSurfacesINTEL_fn)(
+  cl_command_queue command_queue,
+  cl_uint          num_objects,
+  const cl_mem*    mem_objects,
+  cl_uint          num_events_in_wait_list,
+  const cl_event*  event_wait_list,
+  cl_event*        event) CL_API_SUFFIX__VERSION_1_2;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  /* __OPENCL_CL_VA_API_MEDIA_SHARING_INTEL_H */
-
+#endif /* __OPENCL_CL_VA_API_MEDIA_SHARING_INTEL_H */

--- a/CL/cl_version.h
+++ b/CL/cl_version.h
@@ -19,63 +19,67 @@
 
 /* Detect which version to target */
 #if !defined(CL_TARGET_OPENCL_VERSION)
-#pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 300 (OpenCL 3.0)")
+#pragma message(                                                               \
+  "cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 300 (OpenCL 3.0)")
 #define CL_TARGET_OPENCL_VERSION 300
 #endif
-#if CL_TARGET_OPENCL_VERSION != 100 && \
-    CL_TARGET_OPENCL_VERSION != 110 && \
-    CL_TARGET_OPENCL_VERSION != 120 && \
-    CL_TARGET_OPENCL_VERSION != 200 && \
-    CL_TARGET_OPENCL_VERSION != 210 && \
-    CL_TARGET_OPENCL_VERSION != 220 && \
-    CL_TARGET_OPENCL_VERSION != 300
-#pragma message("cl_version: CL_TARGET_OPENCL_VERSION is not a valid value (100, 110, 120, 200, 210, 220, 300). Defaulting to 300 (OpenCL 3.0)")
+#if CL_TARGET_OPENCL_VERSION != 100 && CL_TARGET_OPENCL_VERSION != 110 &&      \
+  CL_TARGET_OPENCL_VERSION != 120 && CL_TARGET_OPENCL_VERSION != 200 &&        \
+  CL_TARGET_OPENCL_VERSION != 210 && CL_TARGET_OPENCL_VERSION != 220 &&        \
+  CL_TARGET_OPENCL_VERSION != 300
+#pragma message(                                                               \
+  "cl_version: CL_TARGET_OPENCL_VERSION is not a valid value (100, 110, 120, 200, 210, 220, 300). Defaulting to 300 (OpenCL 3.0)")
 #undef CL_TARGET_OPENCL_VERSION
 #define CL_TARGET_OPENCL_VERSION 300
 #endif
 
-
 /* OpenCL Version */
 #if CL_TARGET_OPENCL_VERSION >= 300 && !defined(CL_VERSION_3_0)
-#define CL_VERSION_3_0  1
+#define CL_VERSION_3_0 1
 #endif
 #if CL_TARGET_OPENCL_VERSION >= 220 && !defined(CL_VERSION_2_2)
-#define CL_VERSION_2_2  1
+#define CL_VERSION_2_2 1
 #endif
 #if CL_TARGET_OPENCL_VERSION >= 210 && !defined(CL_VERSION_2_1)
-#define CL_VERSION_2_1  1
+#define CL_VERSION_2_1 1
 #endif
 #if CL_TARGET_OPENCL_VERSION >= 200 && !defined(CL_VERSION_2_0)
-#define CL_VERSION_2_0  1
+#define CL_VERSION_2_0 1
 #endif
 #if CL_TARGET_OPENCL_VERSION >= 120 && !defined(CL_VERSION_1_2)
-#define CL_VERSION_1_2  1
+#define CL_VERSION_1_2 1
 #endif
 #if CL_TARGET_OPENCL_VERSION >= 110 && !defined(CL_VERSION_1_1)
-#define CL_VERSION_1_1  1
+#define CL_VERSION_1_1 1
 #endif
 #if CL_TARGET_OPENCL_VERSION >= 100 && !defined(CL_VERSION_1_0)
-#define CL_VERSION_1_0  1
+#define CL_VERSION_1_0 1
 #endif
 
 /* Allow deprecated APIs for older OpenCL versions. */
-#if CL_TARGET_OPENCL_VERSION <= 220 && !defined(CL_USE_DEPRECATED_OPENCL_2_2_APIS)
+#if CL_TARGET_OPENCL_VERSION <= 220 &&                                         \
+  !defined(CL_USE_DEPRECATED_OPENCL_2_2_APIS)
 #define CL_USE_DEPRECATED_OPENCL_2_2_APIS
 #endif
-#if CL_TARGET_OPENCL_VERSION <= 210 && !defined(CL_USE_DEPRECATED_OPENCL_2_1_APIS)
+#if CL_TARGET_OPENCL_VERSION <= 210 &&                                         \
+  !defined(CL_USE_DEPRECATED_OPENCL_2_1_APIS)
 #define CL_USE_DEPRECATED_OPENCL_2_1_APIS
 #endif
-#if CL_TARGET_OPENCL_VERSION <= 200 && !defined(CL_USE_DEPRECATED_OPENCL_2_0_APIS)
+#if CL_TARGET_OPENCL_VERSION <= 200 &&                                         \
+  !defined(CL_USE_DEPRECATED_OPENCL_2_0_APIS)
 #define CL_USE_DEPRECATED_OPENCL_2_0_APIS
 #endif
-#if CL_TARGET_OPENCL_VERSION <= 120 && !defined(CL_USE_DEPRECATED_OPENCL_1_2_APIS)
+#if CL_TARGET_OPENCL_VERSION <= 120 &&                                         \
+  !defined(CL_USE_DEPRECATED_OPENCL_1_2_APIS)
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 #endif
-#if CL_TARGET_OPENCL_VERSION <= 110 && !defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
+#if CL_TARGET_OPENCL_VERSION <= 110 &&                                         \
+  !defined(CL_USE_DEPRECATED_OPENCL_1_1_APIS)
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #endif
-#if CL_TARGET_OPENCL_VERSION <= 100 && !defined(CL_USE_DEPRECATED_OPENCL_1_0_APIS)
+#if CL_TARGET_OPENCL_VERSION <= 100 &&                                         \
+  !defined(CL_USE_DEPRECATED_OPENCL_1_0_APIS)
 #define CL_USE_DEPRECATED_OPENCL_1_0_APIS
 #endif
 
-#endif  /* __CL_VERSION_H */
+#endif /* __CL_VERSION_H */

--- a/CL/opencl.h
+++ b/CL/opencl.h
@@ -22,11 +22,11 @@ extern "C" {
 #endif
 
 #include <CL/cl.h>
-#include <CL/cl_gl.h>
 #include <CL/cl_ext.h>
+#include <CL/cl_gl.h>
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  /* __OPENCL_H   */
+#endif /* __OPENCL_H   */

--- a/tests/test_cl.h.c
+++ b/tests/test_cl.h.c
@@ -18,7 +18,8 @@
 
 #include "CL/cl.h"
 
-int main( void )
+int
+main(void)
 {
   printf("cl.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_d3d10.h.c
+++ b/tests/test_cl_d3d10.h.c
@@ -20,7 +20,8 @@
 #include "CL/cl_d3d10.h"
 #endif
 
-int main( void )
+int
+main(void)
 {
   printf("cl_d3d10.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_d3d11.h.c
+++ b/tests/test_cl_d3d11.h.c
@@ -20,7 +20,8 @@
 #include "CL/cl_d3d11.h"
 #endif
 
-int main( void )
+int
+main(void)
 {
   printf("cl_d3d11.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_dx9_media_sharing.h.c
+++ b/tests/test_cl_dx9_media_sharing.h.c
@@ -20,7 +20,8 @@
 #include "CL/cl_dx9_media_sharing.h"
 #endif
 
-int main( void )
+int
+main(void)
 {
   printf("cl_dx9_media_sharing.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_dx9_media_sharing_intel.h.c
+++ b/tests/test_cl_dx9_media_sharing_intel.h.c
@@ -20,7 +20,8 @@
 #include "CL/cl_dx9_media_sharing_intel.h"
 #endif
 
-int main( void )
+int
+main(void)
 {
   printf("cl_dx9_media_sharing_intel.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_egl.h.c
+++ b/tests/test_cl_egl.h.c
@@ -18,7 +18,8 @@
 
 #include "CL/cl_egl.h"
 
-int main( void )
+int
+main(void)
 {
   printf("cl_egl.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_ext.h.c
+++ b/tests/test_cl_ext.h.c
@@ -18,7 +18,8 @@
 
 #include "CL/cl_ext.h"
 
-int main( void )
+int
+main(void)
 {
   printf("cl_ext.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_ext_intel.h.c
+++ b/tests/test_cl_ext_intel.h.c
@@ -18,7 +18,8 @@
 
 #include "CL/cl_ext_intel.h"
 
-int main( void )
+int
+main(void)
 {
   printf("cl_ext_intel.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_gl.h.c
+++ b/tests/test_cl_gl.h.c
@@ -18,7 +18,8 @@
 
 #include "CL/cl_gl.h"
 
-int main( void )
+int
+main(void)
 {
   printf("cl_gl.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_gl_ext.h.c
+++ b/tests/test_cl_gl_ext.h.c
@@ -18,7 +18,8 @@
 
 #include "CL/cl_gl_ext.h"
 
-int main( void )
+int
+main(void)
 {
   printf("cl_gl_ext.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_half.h.c
+++ b/tests/test_cl_half.h.c
@@ -19,12 +19,14 @@
 
 #include "CL/cl_half.h"
 
-union FI {
-  float f;
+union FI
+{
+  float    f;
   uint32_t i;
 };
 
-int test_half_to_float(cl_half h, cl_float ref)
+int
+test_half_to_float(cl_half h, cl_float ref)
 {
   cl_float f = cl_half_to_float(h);
   if (f != ref) {
@@ -32,14 +34,19 @@ int test_half_to_float(cl_half h, cl_float ref)
     f_i.f = f;
     ref_i.f = ref;
     printf("\nERROR: converting 0x%04x to float: expected 0x%08x, got 0x%08x\n",
-           h, ref_i.i, f_i.i);
+           h,
+           ref_i.i,
+           f_i.i);
     return 0;
   }
   return 1;
 }
 
-int test_half_from_float(cl_float f, cl_half ref,
-                         cl_half_rounding_mode mode, const char *mode_str)
+int
+test_half_from_float(cl_float              f,
+                     cl_half               ref,
+                     cl_half_rounding_mode mode,
+                     const char*           mode_str)
 {
   cl_half h = cl_half_from_float(f, mode);
   if (h != ref) {
@@ -47,20 +54,24 @@ int test_half_from_float(cl_float f, cl_half ref,
     f_i.f = f;
     printf(
       "\nERROR: converting 0x%08x to half (%s): expected 0x%04x, got 0x%04x\n",
-      f_i.i, mode_str, ref, h);
+      f_i.i,
+      mode_str,
+      ref,
+      h);
     return 0;
   }
   return 1;
 }
 
-int main(void)
+int
+main(void)
 {
   printf("\nChecking conversion routines in cl_half.h\n");
 
-#define CHECK_TO_FLOAT(h, ref)                     \
-  if (!test_half_to_float(h, ref)) {               \
-    printf("Test failed on line %d.\n", __LINE__); \
-    return 1;                                      \
+#define CHECK_TO_FLOAT(h, ref)                                                 \
+  if (!test_half_to_float(h, ref)) {                                           \
+    printf("Test failed on line %d.\n", __LINE__);                             \
+    return 1;                                                                  \
   }
 
   // Check a handful of values
@@ -70,11 +81,10 @@ int main(void)
   CHECK_TO_FLOAT(0x7c00, INFINITY);
   CHECK_TO_FLOAT(0xfc00, -INFINITY);
 
-
-#define CHECK_FROM_FLOAT(f, ref, mode)                         \
-  if (!test_half_from_float(f, ref, CL_HALF_##mode, #mode)) {  \
-    printf("Test failed on line %d.\n", __LINE__);             \
-    return 1;                                                  \
+#define CHECK_FROM_FLOAT(f, ref, mode)                                         \
+  if (!test_half_from_float(f, ref, CL_HALF_##mode, #mode)) {                  \
+    printf("Test failed on line %d.\n", __LINE__);                             \
+    return 1;                                                                  \
   }
 
   // Check a handful of normal values

--- a/tests/test_cl_icd.h.c
+++ b/tests/test_cl_icd.h.c
@@ -24,7 +24,8 @@
 #define CL_USE_DEPRECATED_OPENCL_2_2_APIS
 #include "CL/cl_icd.h"
 
-int main( void )
+int
+main(void)
 {
   printf("cl_icd.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_layer.h.c
+++ b/tests/test_cl_layer.h.c
@@ -24,7 +24,8 @@
 #define CL_USE_DEPRECATED_OPENCL_2_2_APIS
 #include "CL/cl_layer.h"
 
-int main( void )
+int
+main(void)
 {
   printf("cl_icd_layer.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_platform.h.c
+++ b/tests/test_cl_platform.h.c
@@ -18,7 +18,8 @@
 
 #include "CL/cl_platform.h"
 
-int main( void )
+int
+main(void)
 {
   printf("cl_platform.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_cl_version.h.c
+++ b/tests/test_cl_version.h.c
@@ -18,7 +18,8 @@
 
 #include "CL/cl_version.h"
 
-int main( void )
+int
+main(void)
 {
   printf("cl_version.h standalone test PASSED.\n");
   return 0;

--- a/tests/test_headers.c
+++ b/tests/test_headers.c
@@ -29,611 +29,1182 @@ will use inttypes.h for C compiles and cinttypes for C++ compiles.
 
 #include "CL/cl.h"
 
-int test_char()
+int
+test_char()
 {
-/* char */
-    /* Constructor */
-    cl_char a = 0;
-    cl_char2 a2 = {{ 0, 1 }};
-    cl_char4 a4 = {{ 0, 1, 2, 3 }};
-    cl_char8 a8 = {{ 0, 1, 2, 3, 4, 5, 6, 7 }};
-    cl_char16 a16 = {{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }};
+  /* char */
+  /* Constructor */
+  cl_char   a = 0;
+  cl_char2  a2 = { { 0, 1 } };
+  cl_char4  a4 = { { 0, 1, 2, 3 } };
+  cl_char8  a8 = { { 0, 1, 2, 3, 4, 5, 6, 7 } };
+  cl_char16 a16 = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 } };
 
-    /* assignment */
-    cl_char    b = a;
-    cl_char2   b2 = a2;
-    cl_char4   b4 = a4;
-    cl_char8   b8 = a8;
-    cl_char16  b16 = a16;
+  /* assignment */
+  cl_char   b = a;
+  cl_char2  b2 = a2;
+  cl_char4  b4 = a4;
+  cl_char8  b8 = a8;
+  cl_char16 b16 = a16;
 
-    printf("\nVerifying assignment:\n" );
-    printf("b:   %d\n", b );
-    printf("b2:  %d %d \n", b2.s[0], b2.s[1] );
-    printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3] );
-    printf("b8:  %d %d %d %d %d %d %d %d\n", b8.s[0], b8.s[1], b8.s[2], b8.s[3], b8.s[4], b8.s[5], b8.s[6], b8.s[7] );
-    printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n", b16.s[0], b16.s[1], b16.s[2], b16.s[3], b16.s[4], b16.s[5], b16.s[6], b16.s[7],
-                                                                     b16.s[8], b16.s[9], b16.s[10], b16.s[11], b16.s[12], b16.s[13], b16.s[14], b16.s[15]);
+  printf("\nVerifying assignment:\n");
+  printf("b:   %d\n", b);
+  printf("b2:  %d %d \n", b2.s[0], b2.s[1]);
+  printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3]);
+  printf("b8:  %d %d %d %d %d %d %d %d\n",
+         b8.s[0],
+         b8.s[1],
+         b8.s[2],
+         b8.s[3],
+         b8.s[4],
+         b8.s[5],
+         b8.s[6],
+         b8.s[7]);
+  printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+         b16.s[0],
+         b16.s[1],
+         b16.s[2],
+         b16.s[3],
+         b16.s[4],
+         b16.s[5],
+         b16.s[6],
+         b16.s[7],
+         b16.s[8],
+         b16.s[9],
+         b16.s[10],
+         b16.s[11],
+         b16.s[12],
+         b16.s[13],
+         b16.s[14],
+         b16.s[15]);
 
-    /* vector access */
-    printf("\nVerifying vector access:\n" );
-#if defined( __CL_CHAR2__ )
-    __cl_char2 v2 = b2.v2;
-    printf("__cl_char2:  %d %d \n", ((cl_char*)&v2)[0], ((cl_char*)&v2)[1] );
+  /* vector access */
+  printf("\nVerifying vector access:\n");
+#if defined(__CL_CHAR2__)
+  __cl_char2 v2 = b2.v2;
+  printf("__cl_char2:  %d %d \n", ((cl_char*)&v2)[0], ((cl_char*)&v2)[1]);
 #else
-    printf( "__cl_char2 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_char2 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_CHAR4__ )
-    __cl_char4 v4 = b4.v4;
-    printf("__cl_char4:  %d %d %d %d \n", ((cl_char*)&v4)[0], ((cl_char*)&v4)[1], ((cl_char*)&v4)[2], ((cl_char*)&v4)[3] );
+#if defined(__CL_CHAR4__)
+  __cl_char4 v4 = b4.v4;
+  printf("__cl_char4:  %d %d %d %d \n",
+         ((cl_char*)&v4)[0],
+         ((cl_char*)&v4)[1],
+         ((cl_char*)&v4)[2],
+         ((cl_char*)&v4)[3]);
 #else
-    printf( "__cl_char4 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_char4 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_CHAR8__ )
-    __cl_char8 v8 = b8.v8;
-    printf("__cl_char8:  %d %d %d %d %d %d %d %d \n", ((cl_char*)&v8)[0], ((cl_char*)&v8)[1], ((cl_char*)&v8)[2], ((cl_char*)&v8)[3], ((cl_char*)&v8)[4], ((cl_char*)&v8)[5], ((cl_char*)&v8)[6], ((cl_char*)&v8)[7] );
+#if defined(__CL_CHAR8__)
+  __cl_char8 v8 = b8.v8;
+  printf("__cl_char8:  %d %d %d %d %d %d %d %d \n",
+         ((cl_char*)&v8)[0],
+         ((cl_char*)&v8)[1],
+         ((cl_char*)&v8)[2],
+         ((cl_char*)&v8)[3],
+         ((cl_char*)&v8)[4],
+         ((cl_char*)&v8)[5],
+         ((cl_char*)&v8)[6],
+         ((cl_char*)&v8)[7]);
 #else
-    printf( "__cl_char8 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_char8 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_CHAR16__ )
-    __cl_char16 v16 = b16.v16;
-    printf("__cl_char16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n", ((cl_char*)&v16)[0], ((cl_char*)&v16)[1], ((cl_char*)&v16)[2], ((cl_char*)&v16)[3], ((cl_char*)&v16)[4], ((cl_char*)&v16)[5], ((cl_char*)&v16)[6], ((cl_char*)&v16)[7],
-                                                                      ((cl_char*)&v16)[8], ((cl_char*)&v16)[9], ((cl_char*)&v16)[10], ((cl_char*)&v16)[11], ((cl_char*)&v16)[12], ((cl_char*)&v16)[13], ((cl_char*)&v16)[14], ((cl_char*)&v16)[15]);
+#if defined(__CL_CHAR16__)
+  __cl_char16 v16 = b16.v16;
+  printf("__cl_char16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n",
+         ((cl_char*)&v16)[0],
+         ((cl_char*)&v16)[1],
+         ((cl_char*)&v16)[2],
+         ((cl_char*)&v16)[3],
+         ((cl_char*)&v16)[4],
+         ((cl_char*)&v16)[5],
+         ((cl_char*)&v16)[6],
+         ((cl_char*)&v16)[7],
+         ((cl_char*)&v16)[8],
+         ((cl_char*)&v16)[9],
+         ((cl_char*)&v16)[10],
+         ((cl_char*)&v16)[11],
+         ((cl_char*)&v16)[12],
+         ((cl_char*)&v16)[13],
+         ((cl_char*)&v16)[14],
+         ((cl_char*)&v16)[15]);
 #else
-    printf( "__cl_char16 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_char16 SIMD vectors not supported on this architecture.\n");
 #endif
 
-    printf( "\n" );
-    return 0;
+  printf("\n");
+  return 0;
 }
 
-int test_uchar()
+int
+test_uchar()
 {
-/* uchar */
-    /* Constructor */
-    cl_uchar a = 0;
-    cl_uchar2 a2 = {{ 0, 1 }};
-    cl_uchar4 a4 = {{ 0, 1, 2, 3 }};
-    cl_uchar8 a8 = {{ 0, 1, 2, 3, 4, 5, 6, 7 }};
-    cl_uchar16 a16 = {{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }};
+  /* uchar */
+  /* Constructor */
+  cl_uchar   a = 0;
+  cl_uchar2  a2 = { { 0, 1 } };
+  cl_uchar4  a4 = { { 0, 1, 2, 3 } };
+  cl_uchar8  a8 = { { 0, 1, 2, 3, 4, 5, 6, 7 } };
+  cl_uchar16 a16 = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 } };
 
-    /* assignment */
-    cl_uchar    b = a;
-    cl_uchar2   b2 = a2;
-    cl_uchar4   b4 = a4;
-    cl_uchar8   b8 = a8;
-    cl_uchar16  b16 = a16;
+  /* assignment */
+  cl_uchar   b = a;
+  cl_uchar2  b2 = a2;
+  cl_uchar4  b4 = a4;
+  cl_uchar8  b8 = a8;
+  cl_uchar16 b16 = a16;
 
-    printf("\nVerifying assignment:\n" );
-    printf("b:   %d\n", b );
-    printf("b2:  %d %d \n", b2.s[0], b2.s[1] );
-    printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3] );
-    printf("b8:  %d %d %d %d %d %d %d %d\n", b8.s[0], b8.s[1], b8.s[2], b8.s[3], b8.s[4], b8.s[5], b8.s[6], b8.s[7] );
-    printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n", b16.s[0], b16.s[1], b16.s[2], b16.s[3], b16.s[4], b16.s[5], b16.s[6], b16.s[7],
-                                                                     b16.s[8], b16.s[9], b16.s[10], b16.s[11], b16.s[12], b16.s[13], b16.s[14], b16.s[15]);
+  printf("\nVerifying assignment:\n");
+  printf("b:   %d\n", b);
+  printf("b2:  %d %d \n", b2.s[0], b2.s[1]);
+  printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3]);
+  printf("b8:  %d %d %d %d %d %d %d %d\n",
+         b8.s[0],
+         b8.s[1],
+         b8.s[2],
+         b8.s[3],
+         b8.s[4],
+         b8.s[5],
+         b8.s[6],
+         b8.s[7]);
+  printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+         b16.s[0],
+         b16.s[1],
+         b16.s[2],
+         b16.s[3],
+         b16.s[4],
+         b16.s[5],
+         b16.s[6],
+         b16.s[7],
+         b16.s[8],
+         b16.s[9],
+         b16.s[10],
+         b16.s[11],
+         b16.s[12],
+         b16.s[13],
+         b16.s[14],
+         b16.s[15]);
 
-    /* vector access */
-    printf("\nVerifying vector access:\n" );
-#if defined( __CL_UCHAR2__ )
-    __cl_uchar2 v2 = b2.v2;
-    printf("__cl_uchar2:  %d %d \n", ((uchar*)&v2)[0], ((cl_uchar*)&v2)[1] );
+  /* vector access */
+  printf("\nVerifying vector access:\n");
+#if defined(__CL_UCHAR2__)
+  __cl_uchar2 v2 = b2.v2;
+  printf("__cl_uchar2:  %d %d \n", ((uchar*)&v2)[0], ((cl_uchar*)&v2)[1]);
 #else
-    printf( "__cl_uchar2 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_uchar2 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_UCHAR4__ )
-    __cl_uchar4 v4 = b4.v4;
-    printf("__cl_uchar4:  %d %d %d %d \n", ((uchar*)&v4)[0], ((cl_uchar*)&v4)[1], ((cl_uchar*)&v4)[2], ((cl_uchar*)&v4)[3] );
+#if defined(__CL_UCHAR4__)
+  __cl_uchar4 v4 = b4.v4;
+  printf("__cl_uchar4:  %d %d %d %d \n",
+         ((uchar*)&v4)[0],
+         ((cl_uchar*)&v4)[1],
+         ((cl_uchar*)&v4)[2],
+         ((cl_uchar*)&v4)[3]);
 #else
-    printf( "__cl_uchar4 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_uchar4 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_UCHAR8__ )
-    __cl_uchar8 v8 = b8.v8;
-    printf("__cl_uchar8:  %d %d %d %d %d %d %d %d \n", ((cl_uchar*)&v8)[0], ((cl_uchar*)&v8)[1], ((cl_uchar*)&v8)[2], ((cl_uchar*)&v8)[3], ((cl_uchar*)&v8)[4], ((cl_uchar*)&v8)[5], ((cl_uchar*)&v8)[6], ((cl_uchar*)&v8)[7] );
+#if defined(__CL_UCHAR8__)
+  __cl_uchar8 v8 = b8.v8;
+  printf("__cl_uchar8:  %d %d %d %d %d %d %d %d \n",
+         ((cl_uchar*)&v8)[0],
+         ((cl_uchar*)&v8)[1],
+         ((cl_uchar*)&v8)[2],
+         ((cl_uchar*)&v8)[3],
+         ((cl_uchar*)&v8)[4],
+         ((cl_uchar*)&v8)[5],
+         ((cl_uchar*)&v8)[6],
+         ((cl_uchar*)&v8)[7]);
 #else
-    printf( "__cl_uchar8 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_uchar8 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_UCHAR16__ )
-    __cl_uchar16 v16 = b16.v16;
-    printf("__cl_uchar16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n", ((cl_uchar*)&v16)[0], ((cl_uchar*)&v16)[1], ((cl_uchar*)&v16)[2], ((cl_uchar*)&v16)[3], ((cl_uchar*)&v16)[4], ((cl_uchar*)&v16)[5], ((cl_uchar*)&v16)[6], ((cl_uchar*)&v16)[7],
-                                                                      ((cl_uchar*)&v16)[8], ((cl_uchar*)&v16)[9], ((cl_uchar*)&v16)[10], ((cl_uchar*)&v16)[11], ((cl_uchar*)&v16)[12], ((cl_uchar*)&v16)[13], ((cl_uchar*)&v16)[14], ((cl_uchar*)&v16)[15]);
+#if defined(__CL_UCHAR16__)
+  __cl_uchar16 v16 = b16.v16;
+  printf("__cl_uchar16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n",
+         ((cl_uchar*)&v16)[0],
+         ((cl_uchar*)&v16)[1],
+         ((cl_uchar*)&v16)[2],
+         ((cl_uchar*)&v16)[3],
+         ((cl_uchar*)&v16)[4],
+         ((cl_uchar*)&v16)[5],
+         ((cl_uchar*)&v16)[6],
+         ((cl_uchar*)&v16)[7],
+         ((cl_uchar*)&v16)[8],
+         ((cl_uchar*)&v16)[9],
+         ((cl_uchar*)&v16)[10],
+         ((cl_uchar*)&v16)[11],
+         ((cl_uchar*)&v16)[12],
+         ((cl_uchar*)&v16)[13],
+         ((cl_uchar*)&v16)[14],
+         ((cl_uchar*)&v16)[15]);
 #else
-    printf( "__cl_uchar16 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_uchar16 SIMD vectors not supported on this architecture.\n");
 #endif
 
-    printf( "\n" );
-    return 0;
+  printf("\n");
+  return 0;
 }
 
-int test_short()
+int
+test_short()
 {
-/* short */
-    /* Constructor */
-    cl_short a = 0;
-    cl_short2 a2 = {{ 0, 1 }};
-    cl_short4 a4 = {{ 0, 1, 2, 3 }};
-    cl_short8 a8 = {{ 0, 1, 2, 3, 4, 5, 6, 7 }};
-    cl_short16 a16 = {{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }};
+  /* short */
+  /* Constructor */
+  cl_short   a = 0;
+  cl_short2  a2 = { { 0, 1 } };
+  cl_short4  a4 = { { 0, 1, 2, 3 } };
+  cl_short8  a8 = { { 0, 1, 2, 3, 4, 5, 6, 7 } };
+  cl_short16 a16 = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 } };
 
-    /* assignment */
-    cl_short    b = a;
-    cl_short2   b2 = a2;
-    cl_short4   b4 = a4;
-    cl_short8   b8 = a8;
-    cl_short16  b16 = a16;
+  /* assignment */
+  cl_short   b = a;
+  cl_short2  b2 = a2;
+  cl_short4  b4 = a4;
+  cl_short8  b8 = a8;
+  cl_short16 b16 = a16;
 
-    printf("\nVerifying assignment:\n" );
-    printf("b:   %d\n", b );
-    printf("b2:  %d %d \n", b2.s[0], b2.s[1] );
-    printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3] );
-    printf("b8:  %d %d %d %d %d %d %d %d\n", b8.s[0], b8.s[1], b8.s[2], b8.s[3], b8.s[4], b8.s[5], b8.s[6], b8.s[7] );
-    printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n", b16.s[0], b16.s[1], b16.s[2], b16.s[3], b16.s[4], b16.s[5], b16.s[6], b16.s[7],
-                                                                     b16.s[8], b16.s[9], b16.s[10], b16.s[11], b16.s[12], b16.s[13], b16.s[14], b16.s[15]);
+  printf("\nVerifying assignment:\n");
+  printf("b:   %d\n", b);
+  printf("b2:  %d %d \n", b2.s[0], b2.s[1]);
+  printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3]);
+  printf("b8:  %d %d %d %d %d %d %d %d\n",
+         b8.s[0],
+         b8.s[1],
+         b8.s[2],
+         b8.s[3],
+         b8.s[4],
+         b8.s[5],
+         b8.s[6],
+         b8.s[7]);
+  printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+         b16.s[0],
+         b16.s[1],
+         b16.s[2],
+         b16.s[3],
+         b16.s[4],
+         b16.s[5],
+         b16.s[6],
+         b16.s[7],
+         b16.s[8],
+         b16.s[9],
+         b16.s[10],
+         b16.s[11],
+         b16.s[12],
+         b16.s[13],
+         b16.s[14],
+         b16.s[15]);
 
-    /* vector access */
-    printf("\nVerifying vector access:\n" );
-#if defined( __CL_SHORT2__ )
-    __cl_short2 v2 = b2.v2;
-    printf("__cl_short2:  %d %d \n", ((cl_short*)&v2)[0], ((cl_short*)&v2)[1] );
+  /* vector access */
+  printf("\nVerifying vector access:\n");
+#if defined(__CL_SHORT2__)
+  __cl_short2 v2 = b2.v2;
+  printf("__cl_short2:  %d %d \n", ((cl_short*)&v2)[0], ((cl_short*)&v2)[1]);
 #else
-    printf( "__cl_short2 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_short2 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_SHORT4__ )
-    __cl_short4 v4 = b4.v4;
-    printf("__cl_short4:  %d %d %d %d \n", ((cl_short*)&v4)[0], ((cl_short*)&v4)[1], ((cl_short*)&v4)[2], ((cl_short*)&v4)[3] );
+#if defined(__CL_SHORT4__)
+  __cl_short4 v4 = b4.v4;
+  printf("__cl_short4:  %d %d %d %d \n",
+         ((cl_short*)&v4)[0],
+         ((cl_short*)&v4)[1],
+         ((cl_short*)&v4)[2],
+         ((cl_short*)&v4)[3]);
 #else
-    printf( "__cl_short4 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_short4 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_SHORT8__ )
-    __cl_short8 v8 = b8.v8;
-    printf("__cl_short8:  %d %d %d %d %d %d %d %d \n", ((cl_short*)&v8)[0], ((cl_short*)&v8)[1], ((cl_short*)&v8)[2], ((cl_short*)&v8)[3], ((cl_short*)&v8)[4], ((cl_short*)&v8)[5], ((cl_short*)&v8)[6], ((cl_short*)&v8)[7] );
+#if defined(__CL_SHORT8__)
+  __cl_short8 v8 = b8.v8;
+  printf("__cl_short8:  %d %d %d %d %d %d %d %d \n",
+         ((cl_short*)&v8)[0],
+         ((cl_short*)&v8)[1],
+         ((cl_short*)&v8)[2],
+         ((cl_short*)&v8)[3],
+         ((cl_short*)&v8)[4],
+         ((cl_short*)&v8)[5],
+         ((cl_short*)&v8)[6],
+         ((cl_short*)&v8)[7]);
 #else
-    printf( "__cl_short8 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_short8 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_SHORT16__ )
-    __cl_short16 v16 = b16.v16;
-    printf("__cl_short16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n", ((cl_short*)&v16)[0], ((cl_short*)&v16)[1], ((cl_short*)&v16)[2], ((cl_short*)&v16)[3], ((cl_short*)&v16)[4], ((cl_short*)&v16)[5], ((cl_short*)&v16)[6], ((cl_short*)&v16)[7],
-                                                                      ((cl_short*)&v16)[8], ((cl_short*)&v16)[9], ((cl_short*)&v16)[10], ((cl_short*)&v16)[11], ((cl_short*)&v16)[12], ((cl_short*)&v16)[13], ((cl_short*)&v16)[14], ((cl_short*)&v16)[15]);
+#if defined(__CL_SHORT16__)
+  __cl_short16 v16 = b16.v16;
+  printf("__cl_short16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n",
+         ((cl_short*)&v16)[0],
+         ((cl_short*)&v16)[1],
+         ((cl_short*)&v16)[2],
+         ((cl_short*)&v16)[3],
+         ((cl_short*)&v16)[4],
+         ((cl_short*)&v16)[5],
+         ((cl_short*)&v16)[6],
+         ((cl_short*)&v16)[7],
+         ((cl_short*)&v16)[8],
+         ((cl_short*)&v16)[9],
+         ((cl_short*)&v16)[10],
+         ((cl_short*)&v16)[11],
+         ((cl_short*)&v16)[12],
+         ((cl_short*)&v16)[13],
+         ((cl_short*)&v16)[14],
+         ((cl_short*)&v16)[15]);
 #else
-    printf( "__cl_short16 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_short16 SIMD vectors not supported on this architecture.\n");
 #endif
 
-    printf( "\n" );
-    return 0;
+  printf("\n");
+  return 0;
 }
 
-int test_ushort()
+int
+test_ushort()
 {
-/* ushort */
-    /* Constructor */
-    cl_ushort a = 0;
-    cl_ushort2 a2 = {{ 0, 1 }};
-    cl_ushort4 a4 = {{ 0, 1, 2, 3 }};
-    cl_ushort8 a8 = {{ 0, 1, 2, 3, 4, 5, 6, 7 }};
-    cl_ushort16 a16 = {{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }};
+  /* ushort */
+  /* Constructor */
+  cl_ushort   a = 0;
+  cl_ushort2  a2 = { { 0, 1 } };
+  cl_ushort4  a4 = { { 0, 1, 2, 3 } };
+  cl_ushort8  a8 = { { 0, 1, 2, 3, 4, 5, 6, 7 } };
+  cl_ushort16 a16 = {
+    { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }
+  };
 
-    /* assignment */
-    cl_ushort    b = a;
-    cl_ushort2   b2 = a2;
-    cl_ushort4   b4 = a4;
-    cl_ushort8   b8 = a8;
-    cl_ushort16  b16 = a16;
+  /* assignment */
+  cl_ushort   b = a;
+  cl_ushort2  b2 = a2;
+  cl_ushort4  b4 = a4;
+  cl_ushort8  b8 = a8;
+  cl_ushort16 b16 = a16;
 
-    printf("\nVerifying assignment:\n" );
-    printf("b:   %d\n", b );
-    printf("b2:  %d %d \n", b2.s[0], b2.s[1] );
-    printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3] );
-    printf("b8:  %d %d %d %d %d %d %d %d\n", b8.s[0], b8.s[1], b8.s[2], b8.s[3], b8.s[4], b8.s[5], b8.s[6], b8.s[7] );
-    printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n", b16.s[0], b16.s[1], b16.s[2], b16.s[3], b16.s[4], b16.s[5], b16.s[6], b16.s[7],
-                                                                     b16.s[8], b16.s[9], b16.s[10], b16.s[11], b16.s[12], b16.s[13], b16.s[14], b16.s[15]);
+  printf("\nVerifying assignment:\n");
+  printf("b:   %d\n", b);
+  printf("b2:  %d %d \n", b2.s[0], b2.s[1]);
+  printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3]);
+  printf("b8:  %d %d %d %d %d %d %d %d\n",
+         b8.s[0],
+         b8.s[1],
+         b8.s[2],
+         b8.s[3],
+         b8.s[4],
+         b8.s[5],
+         b8.s[6],
+         b8.s[7]);
+  printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+         b16.s[0],
+         b16.s[1],
+         b16.s[2],
+         b16.s[3],
+         b16.s[4],
+         b16.s[5],
+         b16.s[6],
+         b16.s[7],
+         b16.s[8],
+         b16.s[9],
+         b16.s[10],
+         b16.s[11],
+         b16.s[12],
+         b16.s[13],
+         b16.s[14],
+         b16.s[15]);
 
-    /* vector access */
-    printf("\nVerifying vector access:\n" );
-#if defined( __CL_USHORT2__ )
-    __cl_ushort2 v2 = b2.v2;
-    printf("__cl_ushort2:  %d %d \n", ((unsigned short*)&v2)[0], ((unsigned short*)&v2)[1] );
+  /* vector access */
+  printf("\nVerifying vector access:\n");
+#if defined(__CL_USHORT2__)
+  __cl_ushort2 v2 = b2.v2;
+  printf("__cl_ushort2:  %d %d \n",
+         ((unsigned short*)&v2)[0],
+         ((unsigned short*)&v2)[1]);
 #else
-    printf( "__cl_ushort2 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_ushort2 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_USHORT4__ )
-    __cl_ushort4 v4 = b4.v4;
-    printf("__cl_ushort4:  %d %d %d %d \n", ((unsigned short*)&v4)[0], ((unsigned short*)&v4)[1], ((unsigned short*)&v4)[2], ((unsigned short*)&v4)[3] );
+#if defined(__CL_USHORT4__)
+  __cl_ushort4 v4 = b4.v4;
+  printf("__cl_ushort4:  %d %d %d %d \n",
+         ((unsigned short*)&v4)[0],
+         ((unsigned short*)&v4)[1],
+         ((unsigned short*)&v4)[2],
+         ((unsigned short*)&v4)[3]);
 #else
-    printf( "__cl_ushort4 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_ushort4 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_USHORT8__ )
-    __cl_ushort8 v8 = b8.v8;
-    printf("__cl_ushort8:  %d %d %d %d %d %d %d %d \n", ((unsigned short*)&v8)[0], ((unsigned short*)&v8)[1], ((unsigned short*)&v8)[2], ((unsigned short*)&v8)[3], ((unsigned short*)&v8)[4], ((unsigned short*)&v8)[5], ((unsigned short*)&v8)[6], ((unsigned short*)&v8)[7] );
+#if defined(__CL_USHORT8__)
+  __cl_ushort8 v8 = b8.v8;
+  printf("__cl_ushort8:  %d %d %d %d %d %d %d %d \n",
+         ((unsigned short*)&v8)[0],
+         ((unsigned short*)&v8)[1],
+         ((unsigned short*)&v8)[2],
+         ((unsigned short*)&v8)[3],
+         ((unsigned short*)&v8)[4],
+         ((unsigned short*)&v8)[5],
+         ((unsigned short*)&v8)[6],
+         ((unsigned short*)&v8)[7]);
 #else
-    printf( "__cl_ushort8 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_ushort8 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_USHORT16__ )
-    __cl_ushort16 v16 = b16.v16;
-    printf("__cl_ushort16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n", ((unsigned short*)&v16)[0], ((unsigned short*)&v16)[1], ((unsigned short*)&v16)[2], ((unsigned short*)&v16)[3], ((unsigned short*)&v16)[4], ((unsigned short*)&v16)[5], ((unsigned short*)&v16)[6], ((unsigned short*)&v16)[7],
-                                                                      ((unsigned short*)&v16)[8], ((unsigned short*)&v16)[9], ((unsigned short*)&v16)[10], ((unsigned short*)&v16)[11], ((unsigned short*)&v16)[12], ((unsigned short*)&v16)[13], ((unsigned short*)&v16)[14], ((unsigned short*)&v16)[15]);
+#if defined(__CL_USHORT16__)
+  __cl_ushort16 v16 = b16.v16;
+  printf("__cl_ushort16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n",
+         ((unsigned short*)&v16)[0],
+         ((unsigned short*)&v16)[1],
+         ((unsigned short*)&v16)[2],
+         ((unsigned short*)&v16)[3],
+         ((unsigned short*)&v16)[4],
+         ((unsigned short*)&v16)[5],
+         ((unsigned short*)&v16)[6],
+         ((unsigned short*)&v16)[7],
+         ((unsigned short*)&v16)[8],
+         ((unsigned short*)&v16)[9],
+         ((unsigned short*)&v16)[10],
+         ((unsigned short*)&v16)[11],
+         ((unsigned short*)&v16)[12],
+         ((unsigned short*)&v16)[13],
+         ((unsigned short*)&v16)[14],
+         ((unsigned short*)&v16)[15]);
 #else
-    printf( "__cl_ushort16 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_ushort16 SIMD vectors not supported on this architecture.\n");
 #endif
 
-    printf( "\n" );
-    return 0;
+  printf("\n");
+  return 0;
 }
 
-int test_int()
+int
+test_int()
 {
-/* int */
-    /* Constructor */
-    cl_int a = 0;
-    cl_int2 a2 = {{ 0, 1 }};
-    cl_int4 a4 = {{ 0, 1, 2, 3 }};
-    cl_int8 a8 = {{ 0, 1, 2, 3, 4, 5, 6, 7 }};
-    cl_int16 a16 = {{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }};
+  /* int */
+  /* Constructor */
+  cl_int   a = 0;
+  cl_int2  a2 = { { 0, 1 } };
+  cl_int4  a4 = { { 0, 1, 2, 3 } };
+  cl_int8  a8 = { { 0, 1, 2, 3, 4, 5, 6, 7 } };
+  cl_int16 a16 = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 } };
 
-    /* assignment */
-    cl_int    b = a;
-    cl_int2   b2 = a2;
-    cl_int4   b4 = a4;
-    cl_int8   b8 = a8;
-    cl_int16  b16 = a16;
+  /* assignment */
+  cl_int   b = a;
+  cl_int2  b2 = a2;
+  cl_int4  b4 = a4;
+  cl_int8  b8 = a8;
+  cl_int16 b16 = a16;
 
-    printf("\nVerifying assignment:\n" );
-    printf("b:   %d\n", b );
-    printf("b2:  %d %d \n", b2.s[0], b2.s[1] );
-    printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3] );
-    printf("b8:  %d %d %d %d %d %d %d %d\n", b8.s[0], b8.s[1], b8.s[2], b8.s[3], b8.s[4], b8.s[5], b8.s[6], b8.s[7] );
-    printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n", b16.s[0], b16.s[1], b16.s[2], b16.s[3], b16.s[4], b16.s[5], b16.s[6], b16.s[7],
-                                                                     b16.s[8], b16.s[9], b16.s[10], b16.s[11], b16.s[12], b16.s[13], b16.s[14], b16.s[15]);
+  printf("\nVerifying assignment:\n");
+  printf("b:   %d\n", b);
+  printf("b2:  %d %d \n", b2.s[0], b2.s[1]);
+  printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3]);
+  printf("b8:  %d %d %d %d %d %d %d %d\n",
+         b8.s[0],
+         b8.s[1],
+         b8.s[2],
+         b8.s[3],
+         b8.s[4],
+         b8.s[5],
+         b8.s[6],
+         b8.s[7]);
+  printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+         b16.s[0],
+         b16.s[1],
+         b16.s[2],
+         b16.s[3],
+         b16.s[4],
+         b16.s[5],
+         b16.s[6],
+         b16.s[7],
+         b16.s[8],
+         b16.s[9],
+         b16.s[10],
+         b16.s[11],
+         b16.s[12],
+         b16.s[13],
+         b16.s[14],
+         b16.s[15]);
 
-    /* vector access */
-    printf("\nVerifying vector access:\n" );
-#if defined( __CL_INT2__ )
-    __cl_int2 v2 = b2.v2;
-    printf("__cl_int2:  %d %d \n", ((cl_int*)&v2)[0], ((cl_int*)&v2)[1] );
+  /* vector access */
+  printf("\nVerifying vector access:\n");
+#if defined(__CL_INT2__)
+  __cl_int2 v2 = b2.v2;
+  printf("__cl_int2:  %d %d \n", ((cl_int*)&v2)[0], ((cl_int*)&v2)[1]);
 #else
-    printf( "__cl_int2 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_int2 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_INT4__ )
-    __cl_int4 v4 = b4.v4;
-    printf("__cl_int4:  %d %d %d %d \n", ((cl_int*)&v4)[0], ((cl_int*)&v4)[1], ((cl_int*)&v4)[2], ((cl_int*)&v4)[3] );
+#if defined(__CL_INT4__)
+  __cl_int4 v4 = b4.v4;
+  printf("__cl_int4:  %d %d %d %d \n",
+         ((cl_int*)&v4)[0],
+         ((cl_int*)&v4)[1],
+         ((cl_int*)&v4)[2],
+         ((cl_int*)&v4)[3]);
 #else
-    printf( "__cl_int4 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_int4 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_INT8__ )
-    __cl_int8 v8 = b8.v8;
-    printf("__cl_int8:  %d %d %d %d %d %d %d %d \n", ((cl_int*)&v8)[0], ((cl_int*)&v8)[1], ((cl_int*)&v8)[2], ((cl_int*)&v8)[3], ((cl_int*)&v8)[4], ((cl_int*)&v8)[5], ((cl_int*)&v8)[6], ((cl_int*)&v8)[7] );
+#if defined(__CL_INT8__)
+  __cl_int8 v8 = b8.v8;
+  printf("__cl_int8:  %d %d %d %d %d %d %d %d \n",
+         ((cl_int*)&v8)[0],
+         ((cl_int*)&v8)[1],
+         ((cl_int*)&v8)[2],
+         ((cl_int*)&v8)[3],
+         ((cl_int*)&v8)[4],
+         ((cl_int*)&v8)[5],
+         ((cl_int*)&v8)[6],
+         ((cl_int*)&v8)[7]);
 #else
-    printf( "__cl_int8 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_int8 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_INT16__ )
-    __cl_int16 v16 = b16.v16;
-    printf("__cl_int16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n", ((cl_int*)&v16)[0], ((cl_int*)&v16)[1], ((cl_int*)&v16)[2], ((cl_int*)&v16)[3], ((cl_int*)&v16)[4], ((cl_int*)&v16)[5], ((cl_int*)&v16)[6], ((cl_int*)&v16)[7],
-                                                                      ((cl_int*)&v16)[8], ((cl_int*)&v16)[9], ((cl_int*)&v16)[10], ((cl_int*)&v16)[11], ((cl_int*)&v16)[12], ((cl_int*)&v16)[13], ((cl_int*)&v16)[14], ((cl_int*)&v16)[15]);
+#if defined(__CL_INT16__)
+  __cl_int16 v16 = b16.v16;
+  printf("__cl_int16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n",
+         ((cl_int*)&v16)[0],
+         ((cl_int*)&v16)[1],
+         ((cl_int*)&v16)[2],
+         ((cl_int*)&v16)[3],
+         ((cl_int*)&v16)[4],
+         ((cl_int*)&v16)[5],
+         ((cl_int*)&v16)[6],
+         ((cl_int*)&v16)[7],
+         ((cl_int*)&v16)[8],
+         ((cl_int*)&v16)[9],
+         ((cl_int*)&v16)[10],
+         ((cl_int*)&v16)[11],
+         ((cl_int*)&v16)[12],
+         ((cl_int*)&v16)[13],
+         ((cl_int*)&v16)[14],
+         ((cl_int*)&v16)[15]);
 #else
-    printf( "__cl_int16 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_int16 SIMD vectors not supported on this architecture.\n");
 #endif
 
-    printf( "\n" );
-    return 0;
+  printf("\n");
+  return 0;
 }
 
-int test_uint()
+int
+test_uint()
 {
-/* uint */
-    /* Constructor */
-    cl_uint a = 0;
-    cl_uint2 a2 = {{ 0, 1 }};
-    cl_uint4 a4 = {{ 0, 1, 2, 3 }};
-    cl_uint8 a8 = {{ 0, 1, 2, 3, 4, 5, 6, 7 }};
-    cl_uint16 a16 = {{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }};
+  /* uint */
+  /* Constructor */
+  cl_uint   a = 0;
+  cl_uint2  a2 = { { 0, 1 } };
+  cl_uint4  a4 = { { 0, 1, 2, 3 } };
+  cl_uint8  a8 = { { 0, 1, 2, 3, 4, 5, 6, 7 } };
+  cl_uint16 a16 = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 } };
 
-    /* assignment */
-    cl_uint    b = a;
-    cl_uint2   b2 = a2;
-    cl_uint4   b4 = a4;
-    cl_uint8   b8 = a8;
-    cl_uint16  b16 = a16;
+  /* assignment */
+  cl_uint   b = a;
+  cl_uint2  b2 = a2;
+  cl_uint4  b4 = a4;
+  cl_uint8  b8 = a8;
+  cl_uint16 b16 = a16;
 
-    printf("\nVerifying assignment:\n" );
-    printf("b:   %d\n", b );
-    printf("b2:  %d %d \n", b2.s[0], b2.s[1] );
-    printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3] );
-    printf("b8:  %d %d %d %d %d %d %d %d\n", b8.s[0], b8.s[1], b8.s[2], b8.s[3], b8.s[4], b8.s[5], b8.s[6], b8.s[7] );
-    printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n", b16.s[0], b16.s[1], b16.s[2], b16.s[3], b16.s[4], b16.s[5], b16.s[6], b16.s[7],
-                                                                     b16.s[8], b16.s[9], b16.s[10], b16.s[11], b16.s[12], b16.s[13], b16.s[14], b16.s[15]);
+  printf("\nVerifying assignment:\n");
+  printf("b:   %d\n", b);
+  printf("b2:  %d %d \n", b2.s[0], b2.s[1]);
+  printf("b4:  %d %d %d %d\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3]);
+  printf("b8:  %d %d %d %d %d %d %d %d\n",
+         b8.s[0],
+         b8.s[1],
+         b8.s[2],
+         b8.s[3],
+         b8.s[4],
+         b8.s[5],
+         b8.s[6],
+         b8.s[7]);
+  printf("b16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+         b16.s[0],
+         b16.s[1],
+         b16.s[2],
+         b16.s[3],
+         b16.s[4],
+         b16.s[5],
+         b16.s[6],
+         b16.s[7],
+         b16.s[8],
+         b16.s[9],
+         b16.s[10],
+         b16.s[11],
+         b16.s[12],
+         b16.s[13],
+         b16.s[14],
+         b16.s[15]);
 
-    /* vector access */
-    printf("\nVerifying vector access:\n" );
-#if defined( __CL_UINT2__ )
-    __cl_uint2 v2 = b2.v2;
-    printf("__cl_uint2:  %d %d \n", ((cl_uint*)&v2)[0], ((cl_uint*)&v2)[1] );
+  /* vector access */
+  printf("\nVerifying vector access:\n");
+#if defined(__CL_UINT2__)
+  __cl_uint2 v2 = b2.v2;
+  printf("__cl_uint2:  %d %d \n", ((cl_uint*)&v2)[0], ((cl_uint*)&v2)[1]);
 #else
-    printf( "__cl_uint2 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_uint2 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_UINT4__ )
-    __cl_uint4 v4 = b4.v4;
-    printf("__cl_uint4:  %d %d %d %d \n", ((cl_uint*)&v4)[0], ((cl_uint*)&v4)[1], ((cl_uint*)&v4)[2], ((cl_uint*)&v4)[3] );
+#if defined(__CL_UINT4__)
+  __cl_uint4 v4 = b4.v4;
+  printf("__cl_uint4:  %d %d %d %d \n",
+         ((cl_uint*)&v4)[0],
+         ((cl_uint*)&v4)[1],
+         ((cl_uint*)&v4)[2],
+         ((cl_uint*)&v4)[3]);
 #else
-    printf( "__cl_uint4 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_uint4 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_UINT8__ )
-    __cl_uint8 v8 = b8.v8;
-    printf("__cl_uint8:  %d %d %d %d %d %d %d %d \n", ((cl_uint*)&v8)[0], ((cl_uint*)&v8)[1], ((cl_uint*)&v8)[2], ((cl_uint*)&v8)[3], ((cl_uint*)&v8)[4], ((cl_uint*)&v8)[5], ((cl_uint*)&v8)[6], ((cl_uint*)&v8)[7] );
+#if defined(__CL_UINT8__)
+  __cl_uint8 v8 = b8.v8;
+  printf("__cl_uint8:  %d %d %d %d %d %d %d %d \n",
+         ((cl_uint*)&v8)[0],
+         ((cl_uint*)&v8)[1],
+         ((cl_uint*)&v8)[2],
+         ((cl_uint*)&v8)[3],
+         ((cl_uint*)&v8)[4],
+         ((cl_uint*)&v8)[5],
+         ((cl_uint*)&v8)[6],
+         ((cl_uint*)&v8)[7]);
 #else
-    printf( "__cl_uint8 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_uint8 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_UINT16__ )
-    __cl_uint16 v16 = b16.v16;
-    printf("__cl_uint16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n", ((cl_uint*)&v16)[0], ((cl_uint*)&v16)[1], ((cl_uint*)&v16)[2], ((cl_uint*)&v16)[3], ((cl_uint*)&v16)[4], ((cl_uint*)&v16)[5], ((cl_uint*)&v16)[6], ((cl_uint*)&v16)[7],
-                                                                      ((cl_uint*)&v16)[8], ((cl_uint*)&v16)[9], ((cl_uint*)&v16)[10], ((cl_uint*)&v16)[11], ((cl_uint*)&v16)[12], ((cl_uint*)&v16)[13], ((cl_uint*)&v16)[14], ((cl_uint*)&v16)[15]);
+#if defined(__CL_UINT16__)
+  __cl_uint16 v16 = b16.v16;
+  printf("__cl_uint16: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d \n",
+         ((cl_uint*)&v16)[0],
+         ((cl_uint*)&v16)[1],
+         ((cl_uint*)&v16)[2],
+         ((cl_uint*)&v16)[3],
+         ((cl_uint*)&v16)[4],
+         ((cl_uint*)&v16)[5],
+         ((cl_uint*)&v16)[6],
+         ((cl_uint*)&v16)[7],
+         ((cl_uint*)&v16)[8],
+         ((cl_uint*)&v16)[9],
+         ((cl_uint*)&v16)[10],
+         ((cl_uint*)&v16)[11],
+         ((cl_uint*)&v16)[12],
+         ((cl_uint*)&v16)[13],
+         ((cl_uint*)&v16)[14],
+         ((cl_uint*)&v16)[15]);
 #else
-    printf( "__cl_uint16 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_uint16 SIMD vectors not supported on this architecture.\n");
 #endif
 
-    printf( "\n" );
-    return 0;
+  printf("\n");
+  return 0;
 }
 
-int test_long()
+int
+test_long()
 {
-/* long */
-    /* Constructor */
-    cl_long a = 0;
-    cl_long2 a2 = {{ 0, 1 }};
-    cl_long4 a4 = {{ 0, 1, 2, 3 }};
-    cl_long8 a8 = {{ 0, 1, 2, 3, 4, 5, 6, 7 }};
-    cl_long16 a16 = {{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }};
+  /* long */
+  /* Constructor */
+  cl_long   a = 0;
+  cl_long2  a2 = { { 0, 1 } };
+  cl_long4  a4 = { { 0, 1, 2, 3 } };
+  cl_long8  a8 = { { 0, 1, 2, 3, 4, 5, 6, 7 } };
+  cl_long16 a16 = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 } };
 
-    /* assignment */
-    cl_long    b = a;
-    cl_long2   b2 = a2;
-    cl_long4   b4 = a4;
-    cl_long8   b8 = a8;
-    cl_long16  b16 = a16;
+  /* assignment */
+  cl_long   b = a;
+  cl_long2  b2 = a2;
+  cl_long4  b4 = a4;
+  cl_long8  b8 = a8;
+  cl_long16 b16 = a16;
 
-    printf("\nVerifying assignment:\n" );
-    printf("b:   %" PRId64 "\n", b );
-    printf("b2:  %" PRId64 " %" PRId64 " \n", b2.s[0], b2.s[1] );
-    printf("b4:  %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3] );
-    printf("b8:  %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "\n", b8.s[0], b8.s[1], b8.s[2], b8.s[3], b8.s[4], b8.s[5], b8.s[6], b8.s[7] );
-    printf("b16: %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "\n", b16.s[0], b16.s[1], b16.s[2], b16.s[3], b16.s[4], b16.s[5], b16.s[6], b16.s[7],
-                                                                     b16.s[8], b16.s[9], b16.s[10], b16.s[11], b16.s[12], b16.s[13], b16.s[14], b16.s[15]);
+  printf("\nVerifying assignment:\n");
+  printf("b:   %" PRId64 "\n", b);
+  printf("b2:  %" PRId64 " %" PRId64 " \n", b2.s[0], b2.s[1]);
+  printf("b4:  %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "\n",
+         b4.s[0],
+         b4.s[1],
+         b4.s[2],
+         b4.s[3]);
+  printf("b8:  %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64
+         " %" PRId64 " %" PRId64 " %" PRId64 "\n",
+         b8.s[0],
+         b8.s[1],
+         b8.s[2],
+         b8.s[3],
+         b8.s[4],
+         b8.s[5],
+         b8.s[6],
+         b8.s[7]);
+  printf("b16: %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64
+         " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64
+         " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 "\n",
+         b16.s[0],
+         b16.s[1],
+         b16.s[2],
+         b16.s[3],
+         b16.s[4],
+         b16.s[5],
+         b16.s[6],
+         b16.s[7],
+         b16.s[8],
+         b16.s[9],
+         b16.s[10],
+         b16.s[11],
+         b16.s[12],
+         b16.s[13],
+         b16.s[14],
+         b16.s[15]);
 
-    /* vector access */
-    printf("\nVerifying vector access:\n" );
-#if defined( __CL_LONG2__ )
-    __cl_long2 v2 = b2.v2;
-    printf("__cl_long2:  %" PRId64 " %" PRId64 " \n", ((cl_long*)&v2)[0], ((cl_long*)&v2)[1] );
+  /* vector access */
+  printf("\nVerifying vector access:\n");
+#if defined(__CL_LONG2__)
+  __cl_long2 v2 = b2.v2;
+  printf("__cl_long2:  %" PRId64 " %" PRId64 " \n",
+         ((cl_long*)&v2)[0],
+         ((cl_long*)&v2)[1]);
 #else
-    printf( "__cl_long2 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_long2 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_LONG4__ )
-    __cl_long4 v4 = b4.v4;
-    printf("__cl_long4:  %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " \n", ((cl_long*)&v4)[0], ((cl_long*)&v4)[1], ((cl_long*)&v4)[2], ((cl_long*)&v4)[3] );
+#if defined(__CL_LONG4__)
+  __cl_long4 v4 = b4.v4;
+  printf("__cl_long4:  %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " \n",
+         ((cl_long*)&v4)[0],
+         ((cl_long*)&v4)[1],
+         ((cl_long*)&v4)[2],
+         ((cl_long*)&v4)[3]);
 #else
-    printf( "__cl_long4 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_long4 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_LONG8__ )
-    __cl_long8 v8 = b8.v8;
-    printf("__cl_long8:  %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " \n", ((cl_long*)&v8)[0], ((cl_long*)&v8)[1], ((cl_long*)&v8)[2], ((cl_long*)&v8)[3], ((cl_long*)&v8)[4], ((cl_long*)&v8)[5], ((cl_long*)&v8)[6], ((cl_long*)&v8)[7] );
+#if defined(__CL_LONG8__)
+  __cl_long8 v8 = b8.v8;
+  printf("__cl_long8:  %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64
+         " %" PRId64 " %" PRId64 " %" PRId64 " \n",
+         ((cl_long*)&v8)[0],
+         ((cl_long*)&v8)[1],
+         ((cl_long*)&v8)[2],
+         ((cl_long*)&v8)[3],
+         ((cl_long*)&v8)[4],
+         ((cl_long*)&v8)[5],
+         ((cl_long*)&v8)[6],
+         ((cl_long*)&v8)[7]);
 #else
-    printf( "__cl_long8 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_long8 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_LONG16__ )
-    __cl_long16 v16 = b16.v16;
-    printf("__cl_long16: %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " \n", ((cl_long*)&v16)[0], ((cl_long*)&v16)[1], ((cl_long*)&v16)[2], ((cl_long*)&v16)[3], ((cl_long*)&v16)[4], ((cl_long*)&v16)[5], ((cl_long*)&v16)[6], ((cl_long*)&v16)[7],
-                                                                      ((cl_long*)&v16)[8], ((cl_long*)&v16)[9], ((cl_long*)&v16)[10], ((cl_long*)&v16)[11], ((cl_long*)&v16)[12], ((cl_long*)&v16)[13], ((cl_long*)&v16)[14], ((cl_long*)&v16)[15]);
+#if defined(__CL_LONG16__)
+  __cl_long16 v16 = b16.v16;
+  printf("__cl_long16: %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64
+         " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64
+         " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " %" PRId64 " \n",
+         ((cl_long*)&v16)[0],
+         ((cl_long*)&v16)[1],
+         ((cl_long*)&v16)[2],
+         ((cl_long*)&v16)[3],
+         ((cl_long*)&v16)[4],
+         ((cl_long*)&v16)[5],
+         ((cl_long*)&v16)[6],
+         ((cl_long*)&v16)[7],
+         ((cl_long*)&v16)[8],
+         ((cl_long*)&v16)[9],
+         ((cl_long*)&v16)[10],
+         ((cl_long*)&v16)[11],
+         ((cl_long*)&v16)[12],
+         ((cl_long*)&v16)[13],
+         ((cl_long*)&v16)[14],
+         ((cl_long*)&v16)[15]);
 #else
-    printf( "__cl_long16 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_long16 SIMD vectors not supported on this architecture.\n");
 #endif
 
-    printf( "\n" );
-    return 0;
+  printf("\n");
+  return 0;
 }
 
-int test_ulong()
+int
+test_ulong()
 {
-/* ulong */
-    /* Constructor */
-    cl_ulong a = 0;
-    cl_ulong2 a2 = {{ 0, 1 }};
-    cl_ulong4 a4 = {{ 0, 1, 2, 3 }};
-    cl_ulong8 a8 = {{ 0, 1, 2, 3, 4, 5, 6, 7 }};
-    cl_ulong16 a16 = {{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }};
+  /* ulong */
+  /* Constructor */
+  cl_ulong   a = 0;
+  cl_ulong2  a2 = { { 0, 1 } };
+  cl_ulong4  a4 = { { 0, 1, 2, 3 } };
+  cl_ulong8  a8 = { { 0, 1, 2, 3, 4, 5, 6, 7 } };
+  cl_ulong16 a16 = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 } };
 
-    /* assignment */
-    cl_ulong    b = a;
-    cl_ulong2   b2 = a2;
-    cl_ulong4   b4 = a4;
-    cl_ulong8   b8 = a8;
-    cl_ulong16  b16 = a16;
+  /* assignment */
+  cl_ulong   b = a;
+  cl_ulong2  b2 = a2;
+  cl_ulong4  b4 = a4;
+  cl_ulong8  b8 = a8;
+  cl_ulong16 b16 = a16;
 
-    printf("\nVerifying assignment:\n" );
-    printf("b:   %" PRIu64 "\n", b );
-    printf("b2:  %" PRIu64 " %" PRIu64 " \n", b2.s[0], b2.s[1] );
-    printf("b4:  %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3] );
-    printf("b8:  %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", b8.s[0], b8.s[1], b8.s[2], b8.s[3], b8.s[4], b8.s[5], b8.s[6], b8.s[7] );
-    printf("b16: %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", b16.s[0], b16.s[1], b16.s[2], b16.s[3], b16.s[4], b16.s[5], b16.s[6], b16.s[7],
-                                                                     b16.s[8], b16.s[9], b16.s[10], b16.s[11], b16.s[12], b16.s[13], b16.s[14], b16.s[15]);
+  printf("\nVerifying assignment:\n");
+  printf("b:   %" PRIu64 "\n", b);
+  printf("b2:  %" PRIu64 " %" PRIu64 " \n", b2.s[0], b2.s[1]);
+  printf("b4:  %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 "\n",
+         b4.s[0],
+         b4.s[1],
+         b4.s[2],
+         b4.s[3]);
+  printf("b8:  %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64
+         " %" PRIu64 " %" PRIu64 " %" PRIu64 "\n",
+         b8.s[0],
+         b8.s[1],
+         b8.s[2],
+         b8.s[3],
+         b8.s[4],
+         b8.s[5],
+         b8.s[6],
+         b8.s[7]);
+  printf("b16: %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64
+         " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64
+         " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 "\n",
+         b16.s[0],
+         b16.s[1],
+         b16.s[2],
+         b16.s[3],
+         b16.s[4],
+         b16.s[5],
+         b16.s[6],
+         b16.s[7],
+         b16.s[8],
+         b16.s[9],
+         b16.s[10],
+         b16.s[11],
+         b16.s[12],
+         b16.s[13],
+         b16.s[14],
+         b16.s[15]);
 
-    /* vector access */
-    printf("\nVerifying vector access:\n" );
-#if defined( __CL_ULONG2__ )
-    __cl_ulong2 v2 = b2.v2;
-    printf("__cl_ulong2:  %" PRIu64 " %" PRIu64 " \n", ((cl_ulong*)&v2)[0], ((cl_ulong*)&v2)[1] );
+  /* vector access */
+  printf("\nVerifying vector access:\n");
+#if defined(__CL_ULONG2__)
+  __cl_ulong2 v2 = b2.v2;
+  printf("__cl_ulong2:  %" PRIu64 " %" PRIu64 " \n",
+         ((cl_ulong*)&v2)[0],
+         ((cl_ulong*)&v2)[1]);
 #else
-    printf( "__cl_ulong2 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_ulong2 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_ULONG4__ )
-    __cl_ulong4 v4 = b4.v4;
-    printf("__cl_ulong4:  %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " \n", ((cl_ulong*)&v4)[0], ((cl_ulong*)&v4)[1], ((cl_ulong*)&v4)[2], ((cl_ulong*)&v4)[3] );
+#if defined(__CL_ULONG4__)
+  __cl_ulong4 v4 = b4.v4;
+  printf("__cl_ulong4:  %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " \n",
+         ((cl_ulong*)&v4)[0],
+         ((cl_ulong*)&v4)[1],
+         ((cl_ulong*)&v4)[2],
+         ((cl_ulong*)&v4)[3]);
 #else
-    printf( "__cl_ulong4 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_ulong4 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_ULONG8__ )
-    __cl_ulong8 v8 = b8.v8;
-    printf("__cl_ulong8:  %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " \n", ((cl_ulong*)&v8)[0], ((cl_ulong*)&v8)[1], ((cl_ulong*)&v8)[2], ((cl_ulong*)&v8)[3], ((cl_ulong*)&v8)[4], ((cl_ulong*)&v8)[5], ((cl_ulong*)&v8)[6], ((cl_ulong*)&v8)[7] );
+#if defined(__CL_ULONG8__)
+  __cl_ulong8 v8 = b8.v8;
+  printf("__cl_ulong8:  %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64
+         " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " \n",
+         ((cl_ulong*)&v8)[0],
+         ((cl_ulong*)&v8)[1],
+         ((cl_ulong*)&v8)[2],
+         ((cl_ulong*)&v8)[3],
+         ((cl_ulong*)&v8)[4],
+         ((cl_ulong*)&v8)[5],
+         ((cl_ulong*)&v8)[6],
+         ((cl_ulong*)&v8)[7]);
 #else
-    printf( "__cl_ulong8 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_ulong8 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_ULONG16__ )
-    __cl_ulong16 v16 = b16.v16;
-    printf("__cl_ulong16: %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " \n", ((cl_ulong*)&v16)[0], ((cl_ulong*)&v16)[1], ((cl_ulong*)&v16)[2], ((cl_ulong*)&v16)[3], ((cl_ulong*)&v16)[4], ((cl_ulong*)&v16)[5], ((cl_ulong*)&v16)[6], ((cl_ulong*)&v16)[7],
-                                                                      ((cl_ulong*)&v16)[8], ((cl_ulong*)&v16)[9], ((cl_ulong*)&v16)[10], ((cl_ulong*)&v16)[11], ((cl_ulong*)&v16)[12], ((cl_ulong*)&v16)[13], ((cl_ulong*)&v16)[14], ((cl_ulong*)&v16)[15]);
+#if defined(__CL_ULONG16__)
+  __cl_ulong16 v16 = b16.v16;
+  printf("__cl_ulong16: %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64
+         " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64
+         " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64
+         " \n",
+         ((cl_ulong*)&v16)[0],
+         ((cl_ulong*)&v16)[1],
+         ((cl_ulong*)&v16)[2],
+         ((cl_ulong*)&v16)[3],
+         ((cl_ulong*)&v16)[4],
+         ((cl_ulong*)&v16)[5],
+         ((cl_ulong*)&v16)[6],
+         ((cl_ulong*)&v16)[7],
+         ((cl_ulong*)&v16)[8],
+         ((cl_ulong*)&v16)[9],
+         ((cl_ulong*)&v16)[10],
+         ((cl_ulong*)&v16)[11],
+         ((cl_ulong*)&v16)[12],
+         ((cl_ulong*)&v16)[13],
+         ((cl_ulong*)&v16)[14],
+         ((cl_ulong*)&v16)[15]);
 #else
-    printf( "__cl_ulong16 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_ulong16 SIMD vectors not supported on this architecture.\n");
 #endif
 
-    printf( "\n" );
-    return 0;
+  printf("\n");
+  return 0;
 }
 
-int test_float()
+int
+test_float()
 {
-/* float */
-    /* Constructor */
-    cl_float a = 0.0f;
-    cl_float2 a2 = {{ 0.0f, 1.0f }};
-    cl_float4 a4 = {{ 0.0f, 1.0f, 2.0f, 3.0f }};
-    cl_float8 a8 = {{ 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f }};
-    cl_float16 a16 = {{ 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f }};
+  /* float */
+  /* Constructor */
+  cl_float   a = 0.0f;
+  cl_float2  a2 = { { 0.0f, 1.0f } };
+  cl_float4  a4 = { { 0.0f, 1.0f, 2.0f, 3.0f } };
+  cl_float8  a8 = { { 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f } };
+  cl_float16 a16 = { { 0.0f,
+                       1.0f,
+                       2.0f,
+                       3.0f,
+                       4.0f,
+                       5.0f,
+                       6.0f,
+                       7.0f,
+                       8.0f,
+                       9.0f,
+                       10.0f,
+                       11.0f,
+                       12.0f,
+                       13.0f,
+                       14.0f,
+                       15.0f } };
 
-    /* assignment */
-    cl_float    b = a;
-    cl_float2   b2 = a2;
-    cl_float4   b4 = a4;
-    cl_float8   b8 = a8;
-    cl_float16  b16 = a16;
+  /* assignment */
+  cl_float   b = a;
+  cl_float2  b2 = a2;
+  cl_float4  b4 = a4;
+  cl_float8  b8 = a8;
+  cl_float16 b16 = a16;
 
-    printf("\nVerifying assignment:\n" );
-    printf("b:   %f\n", b );
-    printf("b2:  %f %f \n", b2.s[0], b2.s[1] );
-    printf("b4:  %f %f %f %f\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3] );
-    printf("b8:  %f %f %f %f %f %f %f %f\n", b8.s[0], b8.s[1], b8.s[2], b8.s[3], b8.s[4], b8.s[5], b8.s[6], b8.s[7] );
-    printf("b16: %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n", b16.s[0], b16.s[1], b16.s[2], b16.s[3], b16.s[4], b16.s[5], b16.s[6], b16.s[7],
-                                                                     b16.s[8], b16.s[9], b16.s[10], b16.s[11], b16.s[12], b16.s[13], b16.s[14], b16.s[15]);
+  printf("\nVerifying assignment:\n");
+  printf("b:   %f\n", b);
+  printf("b2:  %f %f \n", b2.s[0], b2.s[1]);
+  printf("b4:  %f %f %f %f\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3]);
+  printf("b8:  %f %f %f %f %f %f %f %f\n",
+         b8.s[0],
+         b8.s[1],
+         b8.s[2],
+         b8.s[3],
+         b8.s[4],
+         b8.s[5],
+         b8.s[6],
+         b8.s[7]);
+  printf("b16: %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n",
+         b16.s[0],
+         b16.s[1],
+         b16.s[2],
+         b16.s[3],
+         b16.s[4],
+         b16.s[5],
+         b16.s[6],
+         b16.s[7],
+         b16.s[8],
+         b16.s[9],
+         b16.s[10],
+         b16.s[11],
+         b16.s[12],
+         b16.s[13],
+         b16.s[14],
+         b16.s[15]);
 
-    /* vector access */
-    printf("\nVerifying vector access:\n" );
-#if defined( __CL_FLOAT2__ )
-    __cl_float2 v2 = b2.v2;
-    printf("__cl_float2:  %f %f \n", ((cl_float*)&v2)[0], ((cl_float*)&v2)[1] );
+  /* vector access */
+  printf("\nVerifying vector access:\n");
+#if defined(__CL_FLOAT2__)
+  __cl_float2 v2 = b2.v2;
+  printf("__cl_float2:  %f %f \n", ((cl_float*)&v2)[0], ((cl_float*)&v2)[1]);
 #else
-    printf( "__cl_float2 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_float2 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_FLOAT4__ )
-    {
-        __cl_float4 v4 = b4.v4;
-        printf("__cl_float4:  %f %f %f %f \n", ((cl_float*)&v4)[0], ((cl_float*)&v4)[1], ((cl_float*)&v4)[2], ((cl_float*)&v4)[3] );
-    }
+#if defined(__CL_FLOAT4__)
+  {
+    __cl_float4 v4 = b4.v4;
+    printf("__cl_float4:  %f %f %f %f \n",
+           ((cl_float*)&v4)[0],
+           ((cl_float*)&v4)[1],
+           ((cl_float*)&v4)[2],
+           ((cl_float*)&v4)[3]);
+  }
 #else
-    printf( "__cl_float4 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_float4 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_FLOAT8__ )
-    __cl_float8 v8 = b8.v8;
-    printf("__cl_float8:  %f %f %f %f %f %f %f %f \n", ((cl_float*)&v8)[0], ((cl_float*)&v8)[1], ((cl_float*)&v8)[2], ((cl_float*)&v8)[3], ((cl_float*)&v8)[4], ((cl_float*)&v8)[5], ((cl_float*)&v8)[6], ((cl_float*)&v8)[7] );
+#if defined(__CL_FLOAT8__)
+  __cl_float8 v8 = b8.v8;
+  printf("__cl_float8:  %f %f %f %f %f %f %f %f \n",
+         ((cl_float*)&v8)[0],
+         ((cl_float*)&v8)[1],
+         ((cl_float*)&v8)[2],
+         ((cl_float*)&v8)[3],
+         ((cl_float*)&v8)[4],
+         ((cl_float*)&v8)[5],
+         ((cl_float*)&v8)[6],
+         ((cl_float*)&v8)[7]);
 #else
-    printf( "__cl_float8 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_float8 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_FLOAT16__ )
-    __cl_float16 v16 = b16.v16;
-    printf("__cl_float16: %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f \n", ((cl_float*)&v16)[0], ((cl_float*)&v16)[1], ((cl_float*)&v16)[2], ((cl_float*)&v16)[3], ((cl_float*)&v16)[4], ((cl_float*)&v16)[5], ((cl_float*)&v16)[6], ((cl_float*)&v16)[7],
-                                                                      ((cl_float*)&v16)[8], ((cl_float*)&v16)[9], ((cl_float*)&v16)[10], ((cl_float*)&v16)[11], ((cl_float*)&v16)[12], ((cl_float*)&v16)[13], ((cl_float*)&v16)[14], ((cl_float*)&v16)[15]);
+#if defined(__CL_FLOAT16__)
+  __cl_float16 v16 = b16.v16;
+  printf("__cl_float16: %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f \n",
+         ((cl_float*)&v16)[0],
+         ((cl_float*)&v16)[1],
+         ((cl_float*)&v16)[2],
+         ((cl_float*)&v16)[3],
+         ((cl_float*)&v16)[4],
+         ((cl_float*)&v16)[5],
+         ((cl_float*)&v16)[6],
+         ((cl_float*)&v16)[7],
+         ((cl_float*)&v16)[8],
+         ((cl_float*)&v16)[9],
+         ((cl_float*)&v16)[10],
+         ((cl_float*)&v16)[11],
+         ((cl_float*)&v16)[12],
+         ((cl_float*)&v16)[13],
+         ((cl_float*)&v16)[14],
+         ((cl_float*)&v16)[15]);
 #else
-    printf( "__cl_float16 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_float16 SIMD vectors not supported on this architecture.\n");
 #endif
 
-    printf( "\n" );
-    return 0;
+  printf("\n");
+  return 0;
 }
 
-int test_double()
+int
+test_double()
 {
-/* double */
-    /* Constructor */
-    cl_double a = 0.0f;
-    cl_double2 a2 = {{ 0.0f, 1.0f }};
-    cl_double4 a4 = {{ 0.0f, 1.0f, 2.0f, 3.0f }};
-    cl_double8 a8 = {{ 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f }};
-    cl_double16 a16 = {{ 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f }};
+  /* double */
+  /* Constructor */
+  cl_double   a = 0.0f;
+  cl_double2  a2 = { { 0.0f, 1.0f } };
+  cl_double4  a4 = { { 0.0f, 1.0f, 2.0f, 3.0f } };
+  cl_double8  a8 = { { 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f } };
+  cl_double16 a16 = { { 0.0f,
+                        1.0f,
+                        2.0f,
+                        3.0f,
+                        4.0f,
+                        5.0f,
+                        6.0f,
+                        7.0f,
+                        8.0f,
+                        9.0f,
+                        10.0f,
+                        11.0f,
+                        12.0f,
+                        13.0f,
+                        14.0f,
+                        15.0f } };
 
-    /* assignment */
-    cl_double    b = a;
-    cl_double2   b2 = a2;
-    cl_double4   b4 = a4;
-    cl_double8   b8 = a8;
-    cl_double16  b16 = a16;
+  /* assignment */
+  cl_double   b = a;
+  cl_double2  b2 = a2;
+  cl_double4  b4 = a4;
+  cl_double8  b8 = a8;
+  cl_double16 b16 = a16;
 
-    printf("\nVerifying assignment:\n" );
-    printf("b:   %f\n", b );
-    printf("b2:  %f %f \n", b2.s[0], b2.s[1] );
-    printf("b4:  %f %f %f %f\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3] );
-    printf("b8:  %f %f %f %f %f %f %f %f\n", b8.s[0], b8.s[1], b8.s[2], b8.s[3], b8.s[4], b8.s[5], b8.s[6], b8.s[7] );
-    printf("b16: %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n", b16.s[0], b16.s[1], b16.s[2], b16.s[3], b16.s[4], b16.s[5], b16.s[6], b16.s[7],
-                                                                     b16.s[8], b16.s[9], b16.s[10], b16.s[11], b16.s[12], b16.s[13], b16.s[14], b16.s[15]);
+  printf("\nVerifying assignment:\n");
+  printf("b:   %f\n", b);
+  printf("b2:  %f %f \n", b2.s[0], b2.s[1]);
+  printf("b4:  %f %f %f %f\n", b4.s[0], b4.s[1], b4.s[2], b4.s[3]);
+  printf("b8:  %f %f %f %f %f %f %f %f\n",
+         b8.s[0],
+         b8.s[1],
+         b8.s[2],
+         b8.s[3],
+         b8.s[4],
+         b8.s[5],
+         b8.s[6],
+         b8.s[7]);
+  printf("b16: %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n",
+         b16.s[0],
+         b16.s[1],
+         b16.s[2],
+         b16.s[3],
+         b16.s[4],
+         b16.s[5],
+         b16.s[6],
+         b16.s[7],
+         b16.s[8],
+         b16.s[9],
+         b16.s[10],
+         b16.s[11],
+         b16.s[12],
+         b16.s[13],
+         b16.s[14],
+         b16.s[15]);
 
-    /* vector access */
-    printf("\nVerifying vector access:\n" );
-#if defined( __CL_DOUBLE2__ )
-    __cl_double2 v2 = b2.v2;
-    printf("__cl_double2:  %f %f \n", ((cl_double*)&v2)[0], ((cl_double*)&v2)[1] );
+  /* vector access */
+  printf("\nVerifying vector access:\n");
+#if defined(__CL_DOUBLE2__)
+  __cl_double2 v2 = b2.v2;
+  printf("__cl_double2:  %f %f \n", ((cl_double*)&v2)[0], ((cl_double*)&v2)[1]);
 #else
-    printf( "__cl_double2 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_double2 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_DOUBLE4__ )
-    __cl_double4 v4 = b4.v4;
-    printf("__cl_double4:  %f %f %f %f \n", ((cl_double*)&v4)[0], ((cl_double*)&v4)[1], ((cl_double*)&v4)[2], ((cl_double*)&v4)[3] );
+#if defined(__CL_DOUBLE4__)
+  __cl_double4 v4 = b4.v4;
+  printf("__cl_double4:  %f %f %f %f \n",
+         ((cl_double*)&v4)[0],
+         ((cl_double*)&v4)[1],
+         ((cl_double*)&v4)[2],
+         ((cl_double*)&v4)[3]);
 #else
-    printf( "__cl_double4 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_double4 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_DOUBLE8__ )
-    __cl_double8 v8 = b8.v8;
-    printf("__cl_double8:  %f %f %f %f %f %f %f %f \n", ((cl_double*)&v8)[0], ((cl_double*)&v8)[1], ((cl_double*)&v8)[2], ((cl_double*)&v8)[3], ((cl_double*)&v8)[4], ((cl_double*)&v8)[5], ((cl_double*)&v8)[6], ((cl_double*)&v8)[7] );
+#if defined(__CL_DOUBLE8__)
+  __cl_double8 v8 = b8.v8;
+  printf("__cl_double8:  %f %f %f %f %f %f %f %f \n",
+         ((cl_double*)&v8)[0],
+         ((cl_double*)&v8)[1],
+         ((cl_double*)&v8)[2],
+         ((cl_double*)&v8)[3],
+         ((cl_double*)&v8)[4],
+         ((cl_double*)&v8)[5],
+         ((cl_double*)&v8)[6],
+         ((cl_double*)&v8)[7]);
 #else
-    printf( "__cl_double8 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_double8 SIMD vectors not supported on this architecture.\n");
 #endif
 
-#if defined( __CL_DOUBLE16__ )
-    __cl_double16 v16 = b16.v16;
-    printf("__cl_double16: %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f \n", ((cl_double*)&v16)[0], ((cl_double*)&v16)[1], ((cl_double*)&v16)[2], ((cl_double*)&v16)[3], ((cl_double*)&v16)[4], ((cl_double*)&v16)[5], ((cl_double*)&v16)[6], ((cl_double*)&v16)[7],
-                                                                      ((cl_double*)&v16)[8], ((cl_double*)&v16)[9], ((cl_double*)&v16)[10], ((cl_double*)&v16)[11], ((cl_double*)&v16)[12], ((cl_double*)&v16)[13], ((cl_double*)&v16)[14], ((cl_double*)&v16)[15]);
+#if defined(__CL_DOUBLE16__)
+  __cl_double16 v16 = b16.v16;
+  printf("__cl_double16: %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f \n",
+         ((cl_double*)&v16)[0],
+         ((cl_double*)&v16)[1],
+         ((cl_double*)&v16)[2],
+         ((cl_double*)&v16)[3],
+         ((cl_double*)&v16)[4],
+         ((cl_double*)&v16)[5],
+         ((cl_double*)&v16)[6],
+         ((cl_double*)&v16)[7],
+         ((cl_double*)&v16)[8],
+         ((cl_double*)&v16)[9],
+         ((cl_double*)&v16)[10],
+         ((cl_double*)&v16)[11],
+         ((cl_double*)&v16)[12],
+         ((cl_double*)&v16)[13],
+         ((cl_double*)&v16)[14],
+         ((cl_double*)&v16)[15]);
 #else
-    printf( "__cl_double16 SIMD vectors not supported on this architecture.\n" );
+  printf("__cl_double16 SIMD vectors not supported on this architecture.\n");
 #endif
 
-    printf( "\n" );
-    return 0;
+  printf("\n");
+  return 0;
 }
 
-int main(void)
+int
+main(void)
 {
-  printf( "\nChecking operations on cl_types.\nNumbers, where presented, should walk upward from 0, with step of 1:\n" );
+  printf("\nChecking operations on cl_types.\nNumbers, where presented, should "
+         "walk upward from 0, with step of 1:\n");
 
   test_char();
   test_uchar();

--- a/tests/test_opencl.h.c
+++ b/tests/test_opencl.h.c
@@ -18,7 +18,8 @@
 
 #include "CL/opencl.h"
 
-int main( void )
+int
+main(void)
 {
   printf("opencl.h standalone test PASSED.\n");
   return 0;


### PR DESCRIPTION
This is a straw-man PR that formats and enable stye checking for the headers.

The reasoning behind this PR is thus:
 - Generating the headers from the xml specification is something the working group has been discussing for a long time;
 - Validating a newly generated set of headers would be difficult if sources cannot be easily compared;
 - Using an agreed upon style for the headers (eventually fixing inconsistencies) and enforcing it, would allow using the formatting tool on the generated headers;
 - This should allow easy validation of any change.

For now this PR uses clang-format using a custom style derived from Mozilla, which was the closest to ours. I assume it can still be refined. To apply the style to the headers run `clang-format -i -style=file **/*.h **/*.c` from the headers directory.