### PR TITLE
Install pkgconfig file in CMAKE_INSTALL_DATADIR

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -212,4 +212,4 @@ jobs:
 
     - name: Test pkg-config
       shell: bash
-      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig" pkg-config OpenCL-Headers --cflags | grep -q "\-I$GITHUB_WORKSPACE/install/include"
+      run: PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/share/pkgconfig" pkg-config OpenCL-Headers --cflags | grep -q "\-I$GITHUB_WORKSPACE/install/include"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,4 +60,4 @@ jobs:
       shell: bash
       run: |
         if [[ ! `which pkg-config` ]]; then brew install pkg-config; fi;
-        PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/lib/pkgconfig" pkg-config OpenCL-Headers --cflags | grep -q "\-I$GITHUB_WORKSPACE/install/include"
+        PKG_CONFIG_PATH="$GITHUB_WORKSPACE/install/share/pkgconfig" pkg-config OpenCL-Headers --cflags | grep -q "\-I$GITHUB_WORKSPACE/install/include"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 join_paths(OPENCL_INCLUDEDIR_PC "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
 
 configure_file(OpenCL-Headers.pc.in OpenCL-Headers.pc @ONLY)
-set(pkg_config_location ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+set(pkg_config_location ${CMAKE_INSTALL_DATADIR}/pkgconfig)
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenCL-Headers.pc
   DESTINATION ${pkg_config_location})


### PR DESCRIPTION
Install pkgconfig file in CMAKE_INSTALL_DATADIR as headers are architecture independent.

This resolves issue https://github.com/KhronosGroup/OpenCL-Headers/issues/217

Once this is merged, the Loader CI will break, and I will make an accompanying pull request to resolve this as well.