### PR TITLE
CI Fixes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   compatibility:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: streamhpc/opencl-sdk-base:ubuntu-18.04-20220127
     strategy:
       matrix:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,6 +24,10 @@ jobs:
         # Install Ninja only if it's the selected generator and it's not available.
         cmake --version
 
+    - name: Install gcc if required
+      run: |
+        if [[ ! `which /usr/local/bin/gcc-${{matrix.VER}}` ]]; then brew install gcc@${{matrix.VER}}; fi;
+
     - name: Configure CMake
       shell: bash
       run: cmake


### PR DESCRIPTION
This fix two Issues we've been having recently withe the CI:
 - MacOS images are sometimes missing gcc-9, (seems to be transitioned out) so this checks for it and installs it if required.
 - Ubuntu 18.04 is deprecated, but as we run in a container we can safely update the Ubuntu version we are using so I bumped it to 20.04