### PR TITLE
Add enum for command-buffer context query

### DIFF
--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -70,6 +70,7 @@ typedef struct _cl_mutable_command_khr* cl_mutable_command_khr;
 #define CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR               0x1296
 #define CL_COMMAND_BUFFER_STATE_KHR                         0x1297
 #define CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR              0x1298
+#define CL_COMMAND_BUFFER_CONTEXT_KHR                       0x1299
 
 /* cl_command_buffer_state_khr */
 #define CL_COMMAND_BUFFER_STATE_RECORDING_KHR               0


### PR DESCRIPTION
Define `0x1299` as `CL_COMMAND_BUFFER_CONTEXT_KHR` to reflect merged spec PR https://github.com/KhronosGroup/OpenCL-Docs/pull/899

See also original issue https://github.com/KhronosGroup/OpenCL-Docs/issues/898