### PR TITLE
fix the OpenCL version for the CL_DEPTH enum

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -569,11 +569,8 @@ typedef struct _cl_name_version {
 #define CL_RGx                                      0x10BB
 #define CL_RGBx                                     0x10BC
 #endif
-#ifdef CL_VERSION_1_2
-#define CL_DEPTH                                    0x10BD
-#define CL_DEPTH_STENCIL                            0x10BE
-#endif
 #ifdef CL_VERSION_2_0
+#define CL_DEPTH                                    0x10BD
 #define CL_sRGB                                     0x10BF
 #define CL_sRGBx                                    0x10C0
 #define CL_sRGBA                                    0x10C1
@@ -597,9 +594,6 @@ typedef struct _cl_name_version {
 #define CL_UNSIGNED_INT32                           0x10DC
 #define CL_HALF_FLOAT                               0x10DD
 #define CL_FLOAT                                    0x10DE
-#ifdef CL_VERSION_1_2
-#define CL_UNORM_INT24                              0x10DF
-#endif
 #ifdef CL_VERSION_2_1
 #define CL_UNORM_INT_101010_2                       0x10E0
 #endif

--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -3437,11 +3437,11 @@ clGetICDLoaderInfoOCLICD(
 #define CL_KHR_DEPTH_IMAGES_EXTENSION_NAME \
     "cl_khr_depth_images"
 
-#if !defined(CL_VERSION_1_2)
-/* cl_channel_order - defined in CL.h for OpenCL 1.2 (?) and newer */
+#if !defined(CL_VERSION_2_0)
+/* cl_channel_order - defined in CL.h for OpenCL 2.0 and newer */
 #define CL_DEPTH                                            0x10BD
 
-#endif /* !defined(CL_VERSION_1_2) */
+#endif /* !defined(CL_VERSION_2_0) */
 
 /***************************************************************
 * cl_ext_float_atomics

--- a/CL/cl_gl.h
+++ b/CL/cl_gl.h
@@ -345,17 +345,11 @@ clCreateEventFromGLsyncKHR(
 #define CL_KHR_GL_DEPTH_IMAGES_EXTENSION_NAME \
     "cl_khr_gl_depth_images"
 
-#if !defined(CL_VERSION_1_2)
-/* cl_channel_order - defined in CL.h for OpenCL 1.2 and newer */
+/* cl_channel_order */
 #define CL_DEPTH_STENCIL                                    0x10BE
 
-#endif /* !defined(CL_VERSION_1_2) */
-
-#if !defined(CL_VERSION_1_2)
-/* cl_channel_type - defined in CL.h for OpenCL 1.2 and newer */
+/* cl_channel_type */
 #define CL_UNORM_INT24                                      0x10DF
-
-#endif /* !defined(CL_VERSION_1_2) */
 
 /***************************************************************
 * cl_khr_gl_msaa_sharing


### PR DESCRIPTION
Fixes #117.

This change corrects the OpenCL version for the `CL_DEPTH` enum.  `CL_DEPTH` was an extension until OpenCL 2.0, not OpenCL 1.2, so it shouldn't be in the core `cl.h` until OpenCL 2.0.

Also fixes the extension enums `CL_DEPTH_STENCIL` and `CL_UNORM_INT24`, which were never core enums and hence should not be in the core `cl.h` at all.

The extension header fixes were made by regenerating headers using the XML from https://github.com/KhronosGroup/OpenCL-Docs/pull/930, so this change should not be merged until the XML changes are merged.