### PR TITLE
sort new extensions programmatically

### DIFF
--- a/scripts/cl_ext.h.mako
+++ b/scripts/cl_ext.h.mako
@@ -162,7 +162,16 @@ orderedExtensions = [
 
 def getExtensionSortKey(item):
     name = item.get('name')
-    return orderedExtensions.index(name)
+    try:
+        index = orderedExtensions.index(name)
+    except ValueError:
+        if name.startswith('cl_khr'):
+            index = 10000
+        elif name.startswith('cl_ext'):
+            index = 10001
+        else:
+            index = 10002
+    return index, name
 
 # Order the extensions should be emitted in the headers.
 # KHR -> EXT -> Vendor Extensions


### PR DESCRIPTION
The generated extension headers maintained an ordered list of older extensions to minimize diffs with the non-generated extension headers, but there is no reason to require this for new extensions.  If a new extension is not found in the list, sort it at the end automatically. Note, Khronos (KHR) extensions will also be sorted before multi-vendor (EXT) extensions, and before vendor extensions.