### PR TITLE
add compatibility notes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,12 @@
 name: Linux
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   compatibility:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,12 @@
 name: MacOS
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   compatibility:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,12 @@
 name: Windows
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   compatibility:

--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ break backward compatibility:
 * The OpenCL API headers for provisional features or provisional extensions may
   be changed in a way that breaks compatibility.
 
-Applications are encouraged to use tagged or released OpenCL API headers to
-avoid rare compatibility issues, if desired.  The OpenCL API headers are tagged
-at least as often as each OpenCL specification release.
+Applications or libraries that require stable OpenCL API headers are encouraged
+to use tagged or released OpenCL API headers.  We will do our best to document
+any breaking changes in the description of each release.  The OpenCL API headers
+are tagged at least as often as each OpenCL specification release.
 
 ## Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ break backward compatibility:
 * The OpenCL API headers for provisional features or provisional extensions may
   be changed in a way that breaks compatibility.
 
-Applications are encouraged to use a tagged or released version of the OpenCL
-API headers to avoid potential compatibility issues, if desired.  The OpenCL API
-headers are tagged at least as often as each OpenCL specification release.
+Applications are encouraged to use tagged or released OpenCL API headers to
+avoid rare compatibility issues, if desired.  The OpenCL API headers are tagged
+at least as often as each OpenCL specification release.
 
 ## Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ may include the OpenCL API headers as follows:
 #include <CL/opencl.h>
 ```
 
+## Compatibility Notes
+
+OpenCL values backward compatibility and in most cases an application using an
+older version of the OpenCL API headers can seamlessly update to a newer version
+of the OpenCL API headers.  In rare cases, though, the OpenCL API headers may
+break backward compatibility:
+
+* Very rarely, there may be bugs or other issues in the OpenCL API headers that
+  cannot be fixed without breaking compatibility.
+* The OpenCL API headers for provisional features or provisional extensions may
+  be changed in a way that breaks compatibility.
+
+Applications are encouraged to use a tagged or released version of the OpenCL
+API headers to avoid potential compatibility issues, if desired.  The OpenCL API
+headers are tagged at least as often as each OpenCL specification release.
+
 ## Directory Structure
 
 ```


### PR DESCRIPTION
Adds a short section to the README to describe the OpenCL headers compatibility policy.  In general, we will strive to maintain backward compatibility, but in rare cases we may break backward compatibility, especially for provisional features or extensions.

Also updates the CI scripts to skip GitHub actions if only README files are updated.