### PR TITLE
fix VME skip block type enum to match spec

### DIFF
--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -2520,7 +2520,7 @@ typedef struct _cl_motion_estimation_desc_intel {
 #define CL_ME_LUMA_INTRA_PREDICT_ENABLED_INTEL              0x2
 
 #define CL_ME_SKIP_BLOCK_TYPE_16x16_INTEL                   0x0
-#define CL_ME_SKIP_BLOCK_TYPE_8x8_INTEL                     0x1
+#define CL_ME_SKIP_BLOCK_TYPE_8x8_INTEL                     0x4
 
 #define CL_ME_COST_PENALTY_NONE_INTEL                       0x0
 #define CL_ME_COST_PENALTY_LOW_INTEL                        0x1


### PR DESCRIPTION
see: https://github.com/intel/compute-runtime/issues/677

Fixes the value of the enum CL_ME_SKIP_BLOCK_TYPE_8x8_INTEL from [cl_intel_advanced_motion_estimation](https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_advanced_motion_estimation.txt) to match the specification.

This is done by regenerating headers with the changes from https://github.com/KhronosGroup/OpenCL-Docs/pull/972.

Note that this PR only fixes this one issue and I have not fully regenerated the headers with the latest XML file, to simplify review and to avoid merge conflicts.
