### PR TITLE
Add cl_mutable_dispatch_asserts_khr definitions

### DIFF
--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -624,6 +624,7 @@ typedef struct _cl_mutable_base_config_khr {
     cl_uint num_mutable_dispatch;
     const cl_mutable_dispatch_config_khr* mutable_dispatch_list;
 } cl_mutable_base_config_khr;
+typedef cl_bitfield         cl_mutable_dispatch_asserts_khr;
 
 /* cl_command_buffer_flags_khr - bitfield */
 #define CL_COMMAND_BUFFER_MUTABLE_KHR                       (1 << 1)
@@ -658,6 +659,15 @@ typedef struct _cl_mutable_base_config_khr {
 /* cl_command_buffer_structure_type_khr */
 #define CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR           0
 #define CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR       1
+
+/* cl_command_buffer_properties_khr */
+#define CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR      0x12B7
+
+/* cl_ndrange_kernel_command_properties_khr */
+#define CL_MUTABLE_DISPATCH_ASSERTS_KHR                     0x12B8
+
+/* cl_mutable_dispatch_asserts_khr - bitfield */
+#define CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR (1 << 0)
 
 
 typedef cl_int CL_API_CALL


### PR DESCRIPTION
Created from https://github.com/KhronosGroup/OpenCL-Docs/pull/992 by running the `generate_headers` build target and taking only the related changes to `cl_ext.h`