### PR TITLE
Fix CMake deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.0...3.22)
+cmake_minimum_required(VERSION 3.0...3.22)
 
 # Include guard for including this project multiple times
 if(TARGET Headers)


### PR DESCRIPTION
Recent versions of CMake issue a deprecation warning:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

Silence this warning by using a `...<max>` suffix
in `cmake_minimum_required` invocation.
No functional change intended.