### PR TITLE
update extension headers with latest extensions

### DIFF
--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -295,37 +295,6 @@ typedef clCommandNDRangeKernelKHR_t *
 clCommandNDRangeKernelKHR_fn ;
 
 typedef cl_int CL_API_CALL
-clCommandSVMMemcpyKHR_t(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    void* dst_ptr,
-    const void* src_ptr,
-    size_t size,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle);
-
-typedef clCommandSVMMemcpyKHR_t *
-clCommandSVMMemcpyKHR_fn CL_API_SUFFIX__VERSION_2_0;
-
-typedef cl_int CL_API_CALL
-clCommandSVMMemFillKHR_t(
-    cl_command_buffer_khr command_buffer,
-    cl_command_queue command_queue,
-    void* svm_ptr,
-    const void* pattern,
-    size_t pattern_size,
-    size_t size,
-    cl_uint num_sync_points_in_wait_list,
-    const cl_sync_point_khr* sync_point_wait_list,
-    cl_sync_point_khr* sync_point,
-    cl_mutable_command_khr* mutable_handle);
-
-typedef clCommandSVMMemFillKHR_t *
-clCommandSVMMemFillKHR_fn CL_API_SUFFIX__VERSION_2_0;
-
-typedef cl_int CL_API_CALL
 clGetCommandBufferInfoKHR_t(
     cl_command_buffer_khr command_buffer,
     cl_command_buffer_info_khr param_name,
@@ -492,6 +461,51 @@ clCommandNDRangeKernelKHR(
     cl_mutable_command_khr* mutable_handle) ;
 
 extern CL_API_ENTRY cl_int CL_API_CALL
+clGetCommandBufferInfoKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_buffer_info_khr param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret) ;
+
+#endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
+
+/* From version 0.9.4 of the extension */
+
+typedef cl_int CL_API_CALL
+clCommandSVMMemcpyKHR_t(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    void* dst_ptr,
+    const void* src_ptr,
+    size_t size,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+typedef clCommandSVMMemcpyKHR_t *
+clCommandSVMMemcpyKHR_fn CL_API_SUFFIX__VERSION_2_0;
+
+typedef cl_int CL_API_CALL
+clCommandSVMMemFillKHR_t(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    void* svm_ptr,
+    const void* pattern,
+    size_t pattern_size,
+    size_t size,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+typedef clCommandSVMMemFillKHR_t *
+clCommandSVMMemFillKHR_fn CL_API_SUFFIX__VERSION_2_0;
+
+#if !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES)
+
+extern CL_API_ENTRY cl_int CL_API_CALL
 clCommandSVMMemcpyKHR(
     cl_command_buffer_khr command_buffer,
     cl_command_queue command_queue,
@@ -515,14 +529,6 @@ clCommandSVMMemFillKHR(
     const cl_sync_point_khr* sync_point_wait_list,
     cl_sync_point_khr* sync_point,
     cl_mutable_command_khr* mutable_handle) CL_API_SUFFIX__VERSION_2_0;
-
-extern CL_API_ENTRY cl_int CL_API_CALL
-clGetCommandBufferInfoKHR(
-    cl_command_buffer_khr command_buffer,
-    cl_command_buffer_info_khr param_name,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_value_size_ret) ;
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
@@ -1441,6 +1447,14 @@ clEnqueueGenerateMipmapIMG(
 
 /* cl_mem_alloc_flags_img */
 #define CL_MEM_ALLOC_RELAX_REQUIREMENTS_IMG                 (1 << 0)
+#define CL_MEM_ALLOC_GPU_WRITE_COMBINE_IMG                  (1 << 1)
+#define CL_MEM_ALLOC_GPU_CACHED_IMG                         (1 << 2)
+#define CL_MEM_ALLOC_CPU_LOCAL_IMG                          (1 << 3)
+#define CL_MEM_ALLOC_GPU_LOCAL_IMG                          (1 << 4)
+#define CL_MEM_ALLOC_GPU_PRIVATE_IMG                        (1 << 5)
+
+/* cl_device_info */
+#define CL_DEVICE_MEMORY_CAPABILITIES_IMG                   0x40D8
 
 /***************************************************************
 * cl_khr_subgroups
@@ -3610,6 +3624,247 @@ clSetContentSizeBufferPoCL(
 /* cl_channel_type */
 #define CL_UNSIGNED_INT_RAW10_EXT                           0x10E3
 #define CL_UNSIGNED_INT_RAW12_EXT                           0x10E4
+
+/***************************************************************
+* cl_khr_3d_image_writes
+***************************************************************/
+#define cl_khr_3d_image_writes 1
+#define CL_KHR_3D_IMAGE_WRITES_EXTENSION_NAME \
+    "cl_khr_3d_image_writes"
+
+/***************************************************************
+* cl_khr_async_work_group_copy_fence
+***************************************************************/
+#define cl_khr_async_work_group_copy_fence 1
+#define CL_KHR_ASYNC_WORK_GROUP_COPY_FENCE_EXTENSION_NAME \
+    "cl_khr_async_work_group_copy_fence"
+
+/***************************************************************
+* cl_khr_byte_addressable_store
+***************************************************************/
+#define cl_khr_byte_addressable_store 1
+#define CL_KHR_BYTE_ADDRESSABLE_STORE_EXTENSION_NAME \
+    "cl_khr_byte_addressable_store"
+
+/***************************************************************
+* cl_khr_device_enqueue_local_arg_types
+***************************************************************/
+#define cl_khr_device_enqueue_local_arg_types 1
+#define CL_KHR_DEVICE_ENQUEUE_LOCAL_ARG_TYPES_EXTENSION_NAME \
+    "cl_khr_device_enqueue_local_arg_types"
+
+/***************************************************************
+* cl_khr_expect_assume
+***************************************************************/
+#define cl_khr_expect_assume 1
+#define CL_KHR_EXPECT_ASSUME_EXTENSION_NAME \
+    "cl_khr_expect_assume"
+
+/***************************************************************
+* cl_khr_extended_async_copies
+***************************************************************/
+#define cl_khr_extended_async_copies 1
+#define CL_KHR_EXTENDED_ASYNC_COPIES_EXTENSION_NAME \
+    "cl_khr_extended_async_copies"
+
+/***************************************************************
+* cl_khr_extended_bit_ops
+***************************************************************/
+#define cl_khr_extended_bit_ops 1
+#define CL_KHR_EXTENDED_BIT_OPS_EXTENSION_NAME \
+    "cl_khr_extended_bit_ops"
+
+/***************************************************************
+* cl_khr_global_int32_base_atomics
+***************************************************************/
+#define cl_khr_global_int32_base_atomics 1
+#define CL_KHR_GLOBAL_INT32_BASE_ATOMICS_EXTENSION_NAME \
+    "cl_khr_global_int32_base_atomics"
+
+/***************************************************************
+* cl_khr_global_int32_extended_atomics
+***************************************************************/
+#define cl_khr_global_int32_extended_atomics 1
+#define CL_KHR_GLOBAL_INT32_EXTENDED_ATOMICS_EXTENSION_NAME \
+    "cl_khr_global_int32_extended_atomics"
+
+/***************************************************************
+* cl_khr_int64_base_atomics
+***************************************************************/
+#define cl_khr_int64_base_atomics 1
+#define CL_KHR_INT64_BASE_ATOMICS_EXTENSION_NAME \
+    "cl_khr_int64_base_atomics"
+
+/***************************************************************
+* cl_khr_int64_extended_atomics
+***************************************************************/
+#define cl_khr_int64_extended_atomics 1
+#define CL_KHR_INT64_EXTENDED_ATOMICS_EXTENSION_NAME \
+    "cl_khr_int64_extended_atomics"
+
+/***************************************************************
+* cl_khr_kernel_clock
+***************************************************************/
+#define cl_khr_kernel_clock 1
+#define CL_KHR_KERNEL_CLOCK_EXTENSION_NAME \
+    "cl_khr_kernel_clock"
+
+/* cl_device_info */
+#define CL_DEVICE_KERNEL_CLOCK_CAPABILITIES_KHR             0x1076
+
+typedef cl_bitfield         cl_device_kernel_clock_capabilities_khr;
+
+/* cl_device_kernel_clock_capabilities_khr */
+#define CL_DEVICE_KERNEL_CLOCK_SCOPE_DEVICE_KHR             (1 << 0)
+#define CL_DEVICE_KERNEL_CLOCK_SCOPE_WORK_GROUP_KHR         (1 << 1)
+#define CL_DEVICE_KERNEL_CLOCK_SCOPE_SUB_GROUP_KHR          (1 << 2)
+
+/***************************************************************
+* cl_khr_local_int32_base_atomics
+***************************************************************/
+#define cl_khr_local_int32_base_atomics 1
+#define CL_KHR_LOCAL_INT32_BASE_ATOMICS_EXTENSION_NAME \
+    "cl_khr_local_int32_base_atomics"
+
+/***************************************************************
+* cl_khr_local_int32_extended_atomics
+***************************************************************/
+#define cl_khr_local_int32_extended_atomics 1
+#define CL_KHR_LOCAL_INT32_EXTENDED_ATOMICS_EXTENSION_NAME \
+    "cl_khr_local_int32_extended_atomics"
+
+/***************************************************************
+* cl_khr_mipmap_image_writes
+***************************************************************/
+#define cl_khr_mipmap_image_writes 1
+#define CL_KHR_MIPMAP_IMAGE_WRITES_EXTENSION_NAME \
+    "cl_khr_mipmap_image_writes"
+
+/***************************************************************
+* cl_khr_select_fprounding_mode
+***************************************************************/
+#define cl_khr_select_fprounding_mode 1
+#define CL_KHR_SELECT_FPROUNDING_MODE_EXTENSION_NAME \
+    "cl_khr_select_fprounding_mode"
+
+/***************************************************************
+* cl_khr_spirv_extended_debug_info
+***************************************************************/
+#define cl_khr_spirv_extended_debug_info 1
+#define CL_KHR_SPIRV_EXTENDED_DEBUG_INFO_EXTENSION_NAME \
+    "cl_khr_spirv_extended_debug_info"
+
+/***************************************************************
+* cl_khr_spirv_linkonce_odr
+***************************************************************/
+#define cl_khr_spirv_linkonce_odr 1
+#define CL_KHR_SPIRV_LINKONCE_ODR_EXTENSION_NAME \
+    "cl_khr_spirv_linkonce_odr"
+
+/***************************************************************
+* cl_khr_spirv_no_integer_wrap_decoration
+***************************************************************/
+#define cl_khr_spirv_no_integer_wrap_decoration 1
+#define CL_KHR_SPIRV_NO_INTEGER_WRAP_DECORATION_EXTENSION_NAME \
+    "cl_khr_spirv_no_integer_wrap_decoration"
+
+/***************************************************************
+* cl_khr_srgb_image_writes
+***************************************************************/
+#define cl_khr_srgb_image_writes 1
+#define CL_KHR_SRGB_IMAGE_WRITES_EXTENSION_NAME \
+    "cl_khr_srgb_image_writes"
+
+/***************************************************************
+* cl_khr_subgroup_ballot
+***************************************************************/
+#define cl_khr_subgroup_ballot 1
+#define CL_KHR_SUBGROUP_BALLOT_EXTENSION_NAME \
+    "cl_khr_subgroup_ballot"
+
+/***************************************************************
+* cl_khr_subgroup_clustered_reduce
+***************************************************************/
+#define cl_khr_subgroup_clustered_reduce 1
+#define CL_KHR_SUBGROUP_CLUSTERED_REDUCE_EXTENSION_NAME \
+    "cl_khr_subgroup_clustered_reduce"
+
+/***************************************************************
+* cl_khr_subgroup_extended_types
+***************************************************************/
+#define cl_khr_subgroup_extended_types 1
+#define CL_KHR_SUBGROUP_EXTENDED_TYPES_EXTENSION_NAME \
+    "cl_khr_subgroup_extended_types"
+
+/***************************************************************
+* cl_khr_subgroup_non_uniform_arithmetic
+***************************************************************/
+#define cl_khr_subgroup_non_uniform_arithmetic 1
+#define CL_KHR_SUBGROUP_NON_UNIFORM_ARITHMETIC_EXTENSION_NAME \
+    "cl_khr_subgroup_non_uniform_arithmetic"
+
+/***************************************************************
+* cl_khr_subgroup_non_uniform_vote
+***************************************************************/
+#define cl_khr_subgroup_non_uniform_vote 1
+#define CL_KHR_SUBGROUP_NON_UNIFORM_VOTE_EXTENSION_NAME \
+    "cl_khr_subgroup_non_uniform_vote"
+
+/***************************************************************
+* cl_khr_subgroup_rotate
+***************************************************************/
+#define cl_khr_subgroup_rotate 1
+#define CL_KHR_SUBGROUP_ROTATE_EXTENSION_NAME \
+    "cl_khr_subgroup_rotate"
+
+/***************************************************************
+* cl_khr_subgroup_shuffle
+***************************************************************/
+#define cl_khr_subgroup_shuffle 1
+#define CL_KHR_SUBGROUP_SHUFFLE_EXTENSION_NAME \
+    "cl_khr_subgroup_shuffle"
+
+/***************************************************************
+* cl_khr_subgroup_shuffle_relative
+***************************************************************/
+#define cl_khr_subgroup_shuffle_relative 1
+#define CL_KHR_SUBGROUP_SHUFFLE_RELATIVE_EXTENSION_NAME \
+    "cl_khr_subgroup_shuffle_relative"
+
+/***************************************************************
+* cl_khr_work_group_uniform_arithmetic
+***************************************************************/
+#define cl_khr_work_group_uniform_arithmetic 1
+#define CL_KHR_WORK_GROUP_UNIFORM_ARITHMETIC_EXTENSION_NAME \
+    "cl_khr_work_group_uniform_arithmetic"
+
+/***************************************************************
+* cl_img_cancel_command
+***************************************************************/
+#define cl_img_cancel_command 1
+#define CL_IMG_CANCEL_COMMAND_EXTENSION_NAME \
+    "cl_img_cancel_command"
+
+/* Error codes */
+#define CL_CANCELLED_IMG                                    -1126
+
+
+typedef cl_int CL_API_CALL
+clCancelCommandsIMG_t(
+    const cl_event* event_list,
+    size_t num_events_in_list);
+
+typedef clCancelCommandsIMG_t *
+clCancelCommandsIMG_fn ;
+
+#if !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES)
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clCancelCommandsIMG(
+    const cl_event* event_list,
+    size_t num_events_in_list) ;
+
+#endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Re-generates extension headers with the latest XML file.

Adds extensions:

* cl_khr_kernel_clock
* cl_img_cancel_command

Updates extension:

* cl_img_mem_properties

Adds an extension name define for many previously missing OpenCL C or SPIR-V-specific extensions.

Requesting a review from @paulfradgley for the IMG extensions specifically - thanks!