### PR TITLE
Disable gcc-11 on MacOS

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -531,8 +531,9 @@ jobs:
         COMPILER:
         - CC: /usr/bin/clang
           CXX: /usr/bin/clang++
-        - CC: gcc-11
-          CXX: g++-11
+        # Disabled due to "Could not find compiler set in environment variable CC: gcc-11.
+        # - CC: gcc-11
+        #   CXX: g++-11
         # Disabled due to problems with the __API_AVAILABLE macro
         # - CC: gcc-13
         #   CXX: g++-13


### PR DESCRIPTION
On MacOS, CI is failing with: 

> Could not find compiler set in environment variable CC: gcc-11

I don't know if it is related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114007
Since gcc-11 has been disable for our other repositories, I don't think disabling it here is going to be a problem.