### PR TITLE
guard provisional extensions with an opt-in define

### DIFF
--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -45,8 +45,10 @@ extern "C" {
 #endif
 
 /***************************************************************
-* cl_khr_command_buffer
+* cl_khr_command_buffer (provisional)
 ***************************************************************/
+#if defined(CL_PROVISIONAL_EXTENSIONS)
+
 #define cl_khr_command_buffer 1
 #define CL_KHR_COMMAND_BUFFER_EXTENSION_NAME \
     "cl_khr_command_buffer"
@@ -555,9 +557,13 @@ clCommandSVMMemFillKHR(
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
+#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
+
 /***************************************************************
-* cl_khr_command_buffer_multi_device
+* cl_khr_command_buffer_multi_device (provisional)
 ***************************************************************/
+#if defined(CL_PROVISIONAL_EXTENSIONS)
+
 #define cl_khr_command_buffer_multi_device 1
 #define CL_KHR_COMMAND_BUFFER_MULTI_DEVICE_EXTENSION_NAME \
     "cl_khr_command_buffer_multi_device"
@@ -615,9 +621,13 @@ clRemapCommandBufferKHR(
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
+#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
+
 /***************************************************************
-* cl_khr_command_buffer_mutable_dispatch
+* cl_khr_command_buffer_mutable_dispatch (provisional)
 ***************************************************************/
+#if defined(CL_PROVISIONAL_EXTENSIONS)
+
 #define cl_khr_command_buffer_mutable_dispatch 1
 #define CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_NAME \
     "cl_khr_command_buffer_mutable_dispatch"
@@ -735,6 +745,8 @@ clGetMutableCommandInfoKHR(
     size_t* param_value_size_ret) ;
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
+
+#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_fp64
@@ -2048,8 +2060,10 @@ clReImportSemaphoreSyncFdKHR(
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
 /***************************************************************
-* cl_khr_external_semaphore_win32
+* cl_khr_external_semaphore_win32 (provisional)
 ***************************************************************/
+#if defined(CL_PROVISIONAL_EXTENSIONS)
+
 #define cl_khr_external_semaphore_win32 1
 #define CL_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME \
     "cl_khr_external_semaphore_win32"
@@ -2061,6 +2075,8 @@ clReImportSemaphoreSyncFdKHR(
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR                0x2056
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR            0x2057
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR           0x2068
+
+#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_semaphore
@@ -3987,8 +4003,10 @@ clSetContentSizeBufferPoCL(
 #define CL_KHR_INT64_EXTENDED_ATOMICS_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
 
 /***************************************************************
-* cl_khr_kernel_clock
+* cl_khr_kernel_clock (provisional)
 ***************************************************************/
+#if defined(CL_PROVISIONAL_EXTENSIONS)
+
 #define cl_khr_kernel_clock 1
 #define CL_KHR_KERNEL_CLOCK_EXTENSION_NAME \
     "cl_khr_kernel_clock"
@@ -4005,6 +4023,8 @@ typedef cl_bitfield         cl_device_kernel_clock_capabilities_khr;
 #define CL_DEVICE_KERNEL_CLOCK_SCOPE_DEVICE_KHR             (1 << 0)
 #define CL_DEVICE_KERNEL_CLOCK_SCOPE_WORK_GROUP_KHR         (1 << 1)
 #define CL_DEVICE_KERNEL_CLOCK_SCOPE_SUB_GROUP_KHR          (1 << 2)
+
+#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_local_int32_base_atomics

--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -47,7 +47,7 @@ extern "C" {
 /***************************************************************
 * cl_khr_command_buffer (provisional)
 ***************************************************************/
-#if defined(CL_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
 
 #define cl_khr_command_buffer 1
 #define CL_KHR_COMMAND_BUFFER_EXTENSION_NAME \
@@ -557,12 +557,12 @@ clCommandSVMMemFillKHR(
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
-#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_command_buffer_multi_device (provisional)
 ***************************************************************/
-#if defined(CL_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
 
 #define cl_khr_command_buffer_multi_device 1
 #define CL_KHR_COMMAND_BUFFER_MULTI_DEVICE_EXTENSION_NAME \
@@ -621,12 +621,12 @@ clRemapCommandBufferKHR(
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
-#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_command_buffer_mutable_dispatch (provisional)
 ***************************************************************/
-#if defined(CL_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
 
 #define cl_khr_command_buffer_mutable_dispatch 1
 #define CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_NAME \
@@ -746,7 +746,7 @@ clGetMutableCommandInfoKHR(
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
-#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_fp64
@@ -2062,7 +2062,7 @@ clReImportSemaphoreSyncFdKHR(
 /***************************************************************
 * cl_khr_external_semaphore_win32 (provisional)
 ***************************************************************/
-#if defined(CL_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
 
 #define cl_khr_external_semaphore_win32 1
 #define CL_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME \
@@ -2076,7 +2076,7 @@ clReImportSemaphoreSyncFdKHR(
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR            0x2057
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR           0x2068
 
-#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_semaphore
@@ -4005,7 +4005,7 @@ clSetContentSizeBufferPoCL(
 /***************************************************************
 * cl_khr_kernel_clock (provisional)
 ***************************************************************/
-#if defined(CL_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
 
 #define cl_khr_kernel_clock 1
 #define CL_KHR_KERNEL_CLOCK_EXTENSION_NAME \
@@ -4024,7 +4024,7 @@ typedef cl_bitfield         cl_device_kernel_clock_capabilities_khr;
 #define CL_DEVICE_KERNEL_CLOCK_SCOPE_WORK_GROUP_KHR         (1 << 1)
 #define CL_DEVICE_KERNEL_CLOCK_SCOPE_SUB_GROUP_KHR          (1 << 2)
 
-#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_local_int32_base_atomics

--- a/README.md
+++ b/README.md
@@ -115,12 +115,31 @@ to use tagged or released OpenCL API headers.  We will do our best to document
 any breaking changes in the description of each release.  The OpenCL API headers
 are tagged at least as often as each OpenCL specification release.
 
+## Provisional Extensions
+
+Provisional extensions are extensions that are still in development and are
+hence subject to change. To further improve compatibility for applications that
+do not use provisional features, support for provisional extension must be
+explicitly enabled.  Support for provisional extensions is controlled by the
+`CL_ENABLE_PROVISIONAL_EXTENSIONS` preprocessor define.
+
+For example, to enable support for OpenCL 3.0 APIs and all extensions, including
+provisional extensions, you may include the OpenCL API headers as follows:
+
+```c
+#define CL_TARGET_OPENCL_VERSION 300
+#define CL_ENABLE_PROVISIONAL_EXTENSIONS
+#include <CL/opencl.h>
+```
+
 ## Directory Structure
 
 ```
 README.md               This file
 LICENSE                 Source license for the OpenCL API headers
 CL/                     Unified OpenCL API headers tree
+scripts/                Scripts for generating OpenCL extension headers
+tests/                  OpenCL API header tests
 ```
 
 ## Packaging

--- a/scripts/cl_ext.h.mako
+++ b/scripts/cl_ext.h.mako
@@ -321,7 +321,7 @@ extern "C" {
 * ${name}${provisional_label}
 ***************************************************************/
 %if is_provisional:
-#if defined(CL_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
 
 %endif
 %if extension.get('condition'):
@@ -446,7 +446,7 @@ ${api.Name}(
 
 %endif
 %if is_provisional:
-#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
 
 %endif
 %  endif

--- a/scripts/cl_ext.h.mako
+++ b/scripts/cl_ext.h.mako
@@ -304,9 +304,26 @@ extern "C" {
 %  if shouldGenerate(extension.get('name')):
 <%
     name = extension.get('name')
+
+    # Use re.match to parse semantic major.minor.patch version
+    sem_ver = match('[0-9]+\.[0-9]+\.?[0-9]+', extension.get('revision'))
+    if not sem_ver:
+        raise TypeError(name +
+        ' XML revision field is not semantically versioned as "major.minor.patch"')
+    version = sem_ver[0].split('.')
+    version_major = version[0]
+    version_minor = version[1]
+    version_patch = version[2]
+
+    is_provisional = extension.get('provisional') == 'true'
+    provisional_label = ' (provisional)' if is_provisional else ''
 %>/***************************************************************
-* ${name}
+* ${name}${provisional_label}
 ***************************************************************/
+%if is_provisional:
+#if defined(CL_PROVISIONAL_EXTENSIONS)
+
+%endif
 %if extension.get('condition'):
 #if ${extension.get('condition')}
 
@@ -315,18 +332,8 @@ extern "C" {
 #define ${name.upper()}_EXTENSION_NAME ${"\\"}
     "${name}"
 
-<%
-  # Use re.match to parse semantic major.minor.patch version
-  sem_ver = match('[0-9]+\.[0-9]+\.?[0-9]+', extension.get('revision'))
-  if not sem_ver:
-    raise TypeError(name +
-      ' XML revision field is not semantically versioned as "major.minor.patch"')
-  version = sem_ver[0].split('.')
-  major = version[0]
-  minor = version[1]
-  patch = version[2]
-%>
-#define ${name.upper()}_EXTENSION_VERSION CL_MAKE_VERSION(${major}, ${minor}, ${patch})
+
+#define ${name.upper()}_EXTENSION_VERSION CL_MAKE_VERSION(${version_major}, ${version_minor}, ${version_patch})
 
 %for block in extension.findall('require'):
 %  if shouldEmit(block):
@@ -436,6 +443,10 @@ ${api.Name}(
 %endfor
 %if extension.get('condition'):
 #endif /* ${extension.get('condition')} */
+
+%endif
+%if is_provisional:
+#endif /* defined(CL_PROVISIONAL_EXTENSIONS) */
 
 %endif
 %  endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,18 +34,31 @@ function(add_header_test NAME SOURCE)
     set(LANG c)
   endif()
   foreach(VERSION 100 110 120 200 210 220 300)
-    set(TEST_EXE ${NAME}_${LANG}_${VERSION})
-    list(FIND TEST_SKIP_ANSI_TESTING ${NAME} TEST_SKIP_INDEX)
-    if(NOT (${TEST_SKIP_INDEX} GREATER -1 AND MSVC AND CMAKE_C_FLAGS MATCHES "/Za"))
-      add_executable(${TEST_EXE} "${SOURCE_PATH}")
-      target_compile_definitions(${TEST_EXE}
-        PUBLIC -DCL_TARGET_OPENCL_VERSION=${VERSION}
-      )
-      target_include_directories(${TEST_EXE}
-        PUBLIC ${PROJECT_SOURCE_DIR}
-      )
-      add_test(NAME ${TEST_EXE} COMMAND ${TEST_EXE})
-    endif()
+    foreach(OPTION "" CL_ENABLE_PROVISIONAL_EXTENSIONS)
+      if(OPTION STREQUAL "")
+        # The empty string means we're not setting any special option.
+        set(UNDERSCORE_OPTION "${OPTION}")
+        set(DEFINE_OPTION "")
+      elseif(VERSION EQUAL 300)
+        # Only test special options for OpenCL 3.0.
+        set(UNDERSCORE_OPTION "_${OPTION}")
+        set(DEFINE_OPTION "-D${OPTION}")
+      else()
+        continue()
+      endif()
+      set(TEST_EXE ${NAME}_${LANG}_${VERSION}${UNDERSCORE_OPTION})
+      list(FIND TEST_SKIP_ANSI_TESTING ${NAME} TEST_SKIP_INDEX)
+      if(NOT (${TEST_SKIP_INDEX} GREATER -1 AND MSVC AND CMAKE_C_FLAGS MATCHES "/Za"))
+        add_executable(${TEST_EXE} "${SOURCE_PATH}")
+        target_compile_definitions(${TEST_EXE}
+          PUBLIC -DCL_TARGET_OPENCL_VERSION=${VERSION} ${DEFINE_OPTION}
+        )
+        target_include_directories(${TEST_EXE}
+          PUBLIC ${PROJECT_SOURCE_DIR}
+        )
+        add_test(NAME ${TEST_EXE} COMMAND ${TEST_EXE})
+      endif()
+    endforeach(OPTION)
   endforeach(VERSION)
 endfunction(add_header_test)
 


### PR DESCRIPTION
fixes #247 

Wraps provisional extensions in an opt-in define so applications that do not use provisional extensions do not get broken by non-backwards compatible changes.

Notes:

* The define gets added automatically during header generation based on the `provisional="true"` line in the XML file.
* The define is currently an opt-in named `CL_PROVISIONAL_EXTENSIONS`, but it's trivial to change this if desired.
* Because it is an opt-in define, the current implementation does break backwards compatiblity, and applications using provisional extensions will need to add the opt-in define.
* We should consider how much additional testing we want to add (in this repo and in others) with this change.  For example, do we want to run some of the header tests with and without provisional extensions?