### PR TITLE
Rename CL_ENABLE_PROVISIONAL_EXTENSIONS to CL_ENABLE_BETA_EXTENSIONS

### DIFF
--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -45,9 +45,9 @@ extern "C" {
 #endif
 
 /***************************************************************
-* cl_khr_command_buffer (provisional)
+* cl_khr_command_buffer (beta)
 ***************************************************************/
-#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
 
 #define cl_khr_command_buffer 1
 #define CL_KHR_COMMAND_BUFFER_EXTENSION_NAME \
@@ -557,12 +557,12 @@ clCommandSVMMemFillKHR(
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
-#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
 
 /***************************************************************
-* cl_khr_command_buffer_multi_device (provisional)
+* cl_khr_command_buffer_multi_device (beta)
 ***************************************************************/
-#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
 
 #define cl_khr_command_buffer_multi_device 1
 #define CL_KHR_COMMAND_BUFFER_MULTI_DEVICE_EXTENSION_NAME \
@@ -621,12 +621,12 @@ clRemapCommandBufferKHR(
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
-#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
 
 /***************************************************************
-* cl_khr_command_buffer_mutable_dispatch (provisional)
+* cl_khr_command_buffer_mutable_dispatch (beta)
 ***************************************************************/
-#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
 
 #define cl_khr_command_buffer_mutable_dispatch 1
 #define CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_NAME \
@@ -746,7 +746,7 @@ clGetMutableCommandInfoKHR(
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
-#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_fp64
@@ -2060,9 +2060,9 @@ clReImportSemaphoreSyncFdKHR(
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
 /***************************************************************
-* cl_khr_external_semaphore_win32 (provisional)
+* cl_khr_external_semaphore_win32 (beta)
 ***************************************************************/
-#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
 
 #define cl_khr_external_semaphore_win32 1
 #define CL_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME \
@@ -2076,7 +2076,7 @@ clReImportSemaphoreSyncFdKHR(
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR            0x2057
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR           0x2068
 
-#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_semaphore
@@ -4003,9 +4003,9 @@ clSetContentSizeBufferPoCL(
 #define CL_KHR_INT64_EXTENDED_ATOMICS_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
 
 /***************************************************************
-* cl_khr_kernel_clock (provisional)
+* cl_khr_kernel_clock (beta)
 ***************************************************************/
-#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
 
 #define cl_khr_kernel_clock 1
 #define CL_KHR_KERNEL_CLOCK_EXTENSION_NAME \
@@ -4024,7 +4024,7 @@ typedef cl_bitfield         cl_device_kernel_clock_capabilities_khr;
 #define CL_DEVICE_KERNEL_CLOCK_SCOPE_WORK_GROUP_KHR         (1 << 1)
 #define CL_DEVICE_KERNEL_CLOCK_SCOPE_SUB_GROUP_KHR          (1 << 2)
 
-#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_local_int32_base_atomics

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ break backward compatibility:
 
 * Very rarely, there may be bugs or other issues in the OpenCL API headers that
   cannot be fixed without breaking compatibility.
-* The OpenCL API headers for provisional features or provisional extensions may
+* The OpenCL API headers for beta features or beta extensions may
   be changed in a way that breaks compatibility.
 
 Applications or libraries that require stable OpenCL API headers are encouraged
@@ -115,20 +115,20 @@ to use tagged or released OpenCL API headers.  We will do our best to document
 any breaking changes in the description of each release.  The OpenCL API headers
 are tagged at least as often as each OpenCL specification release.
 
-## Provisional Extensions
+## Beta Extensions
 
-Provisional extensions are extensions that are still in development and are
+Beta extensions are extensions that are still in development and are
 hence subject to change. To further improve compatibility for applications that
-do not use provisional features, support for provisional extension must be
-explicitly enabled.  Support for provisional extensions is controlled by the
-`CL_ENABLE_PROVISIONAL_EXTENSIONS` preprocessor define.
+do not use beta features, support for beta extensions must be
+explicitly enabled.  Support for beta extensions is controlled by the
+`CL_ENABLE_BETA_EXTENSIONS` preprocessor define.
 
 For example, to enable support for OpenCL 3.0 APIs and all extensions, including
-provisional extensions, you may include the OpenCL API headers as follows:
+beta extensions, you may include the OpenCL API headers as follows:
 
 ```c
 #define CL_TARGET_OPENCL_VERSION 300
-#define CL_ENABLE_PROVISIONAL_EXTENSIONS
+#define CL_ENABLE_BETA_EXTENSIONS
 #include <CL/opencl.h>
 ```
 

--- a/scripts/cl_ext.h.mako
+++ b/scripts/cl_ext.h.mako
@@ -315,13 +315,13 @@ extern "C" {
     version_minor = version[1]
     version_patch = version[2]
 
-    is_provisional = extension.get('provisional') == 'true'
-    provisional_label = ' (provisional)' if is_provisional else ''
+    is_beta = extension.get('provisional') == 'true'
+    beta_label = ' (beta)' if is_beta else ''
 %>/***************************************************************
-* ${name}${provisional_label}
+* ${name}${beta_label}
 ***************************************************************/
-%if is_provisional:
-#if defined(CL_ENABLE_PROVISIONAL_EXTENSIONS)
+%if is_beta:
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
 
 %endif
 %if extension.get('condition'):
@@ -445,8 +445,8 @@ ${api.Name}(
 #endif /* ${extension.get('condition')} */
 
 %endif
-%if is_provisional:
-#endif /* defined(CL_ENABLE_PROVISIONAL_EXTENSIONS) */
+%if is_beta:
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
 
 %endif
 %  endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ function(add_header_test NAME SOURCE)
     set(LANG c)
   endif()
   foreach(VERSION 100 110 120 200 210 220 300)
-    foreach(OPTION "" CL_ENABLE_PROVISIONAL_EXTENSIONS)
+    foreach(OPTION "" CL_ENABLE_BETA_EXTENSIONS)
       if(OPTION STREQUAL "")
         # The empty string means we're not setting any special option.
         set(UNDERSCORE_OPTION "${OPTION}")

--- a/tests/test_ext_headers.c
+++ b/tests/test_ext_headers.c
@@ -20,7 +20,7 @@
 
 int extVersionMacro(void)
 {
-    // Test a non-provisional extension with non-placeholder semantic version.
+    // Test a non-beta extension with non-placeholder semantic version.
     printf("Checking version macro for the cl_khr_integer_dot_product "
            "extension\n");
 


### PR DESCRIPTION
We want to leverage the mechanism for non-ratified extensions too. We cannot use the word provisional in that case as, according to the Khronos guidelines, it only applies to ratified extensions.


Change-Id: Ibb162050d7ad7b1a8f01fc5ef115d8952064e2da