### PR TITLE
add support for the experimental tag in the XML file

### DIFF
--- a/scripts/cl_ext.h.mako
+++ b/scripts/cl_ext.h.mako
@@ -315,7 +315,8 @@ extern "C" {
     version_minor = version[1]
     version_patch = version[2]
 
-    is_beta = extension.get('provisional') == 'true'
+    # Note: when "provisional" is phased out of the XML file, it can be removed here, too
+    is_beta = extension.get('experimental') == 'true' or extension.get('provisional') == 'true'
     beta_label = ' (beta)' if is_beta else ''
 %>/***************************************************************
 * ${name}${beta_label}


### PR DESCRIPTION
Updates the extension header generation scripts to check for the newer "experimental" tag in addition to the prior "provisional" tag. Once usage of the "provisional" tag is phased out of the XML file, support for it can be removed from the header generation scripts, also.

see: https://github.com/KhronosGroup/OpenCL-Docs/pull/1383