### PR TITLE
add support for cl_khr_spirv_queries

### DIFF
--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -4130,6 +4130,21 @@ typedef cl_bitfield         cl_device_kernel_clock_capabilities_khr;
 #define CL_KHR_SPIRV_NO_INTEGER_WRAP_DECORATION_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
 
 /***************************************************************
+* cl_khr_spirv_queries
+***************************************************************/
+#define cl_khr_spirv_queries 1
+#define CL_KHR_SPIRV_QUERIES_EXTENSION_NAME \
+    "cl_khr_spirv_queries"
+
+
+#define CL_KHR_SPIRV_QUERIES_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
+
+/* cl_device_info */
+#define CL_DEVICE_SPIRV_EXTENDED_INSTRUCTION_SETS_KHR       0x12B9
+#define CL_DEVICE_SPIRV_EXTENSIONS_KHR                      0x12BA
+#define CL_DEVICE_SPIRV_CAPABILITIES_KHR                    0x12BB
+
+/***************************************************************
 * cl_khr_srgb_image_writes
 ***************************************************************/
 #define cl_khr_srgb_image_writes 1


### PR DESCRIPTION
Adds support for the cl_khr_spirv_queries extension.

See: https://github.com/KhronosGroup/OpenCL-Docs/pull/1385

Note: While the changes in this PR were generated from the XML file with cl_khr_spirv_queries support, there are some extensions in the XML file that are not currently included in the headers.  I will create a separate PR for those extensions.