### PR TITLE
[Important] Adds advanced flake.nix for `$ nix build github:KhronosGroup/OpenCL-Headers` and more

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = "Development environment & packaging for OpenCL-Headers";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        checks.c-tests = pkgs.stdenv.mkDerivation {
+          name = "opencl-headers-c-tests";
+          nativeBuildInputs = [ pkgs.cmake ];
+
+          src = ./.;
+
+          cmakeFlags = [
+            "-DOPENCL_HEADERS_BUILD_TESTING=ON"
+            "-DOPENCL_HEADERS_BUILD_CXX_TESTS=OFF"
+          ];
+
+          doCheck = true;
+        };
+        checks.cpp-tests = self.packages.${system}.default;
+        checks.pkg-config = self.packages.${system}.default.passthru.tests.pkg-config;
+
+        packages.default = pkgs.stdenv.mkDerivation (finalAttrs: rec {
+          name = "opencl-headers";
+          nativeBuildInputs = [ pkgs.cmake ];
+
+          src = ./.;
+
+          doCheck = true;
+
+          passthru.tests = with pkgs; {
+            pkg-config = pkgs.testers.hasPkgConfigModules {
+              package = finalAttrs.finalPackage;
+              moduleNames = [ "OpenCL-Headers" ];
+            };
+          };
+        });
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.pkg-config
+            self.packages.${system}.default 
+          ];
+
+          doCheck = false; # Disables automatically running tests for `$ nix develop` and direnv
+
+          shellHook = ''
+            export ZDOTDIR=$(mktemp -d)
+            cat > "$ZDOTDIR/.zshrc" << 'EOF'
+              source ~/.zshrc # Source the original ~/.zshrc, required.
+
+              function parse_git_branch {
+                git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\ ->\ \1/'
+              }
+
+              function display_jobs_count_if_needed {
+                local job_count=$(jobs -s | wc -l | tr -d " ")
+
+                if [ $job_count -gt 0 ]; then
+                  echo "%B%F{yellow}%j| ";
+                fi
+              }
+
+              # NOTE: Custom prompt with a snowflake: signals we are in `$ nix develop` shell
+              PROMPT="%F{blue}$(date +%H:%M:%S) $(display_jobs_count_if_needed)%B%F{green}%n %F{blue}%~%F{cyan} ❄%F{yellow}$(parse_git_branch) %f%{$reset_color%}"
+            EOF
+
+            if [ -z "$DIRENV_IN_ENVRC" ]; then # This makes `$ nix develop` universally working with direnv without infinite loop
+              exec ${pkgs.zsh}/bin/zsh -i
+            fi
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Hi there,

Currently I'm working on standardizing, further specifying and simplifying the build, test and release of all the GPU based software for nix: which should eventually allow all standard bodies and hardware/software vendors to further standardize their build workflows.

We already have `opencl-headers` on nixpkgs here: https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/op/opencl-headers/package.nix

This `flake.nix` serves as an additional release channel for a direct specific github branch on any machine that has `nix` via:

```zsh
$ nix build github:KhronosGroup/OpenCL-Headers # or:
$ nix build github:KhronosGroup/OpenCL-Headers/b79b358ff6b9998d3fc65a5f55083db3d651d55d # or:
$ nix build github:KhronosGroup/OpenCL-Headers/cl_khr_unified_svm
```

Also serves as a further documentation as code for all the important build targets.

It also standardizes the builds under a single command:

```zsh
$ nix build ".#" # Runs the unit tests as well, nix testing convention, there is doCheck = true
$ tree ./result
result
├── include
│   └── CL
│       ├── cl_d3d10.h
│       ├── cl_d3d11.h
│       ├── cl_dx9_media_sharing.h
│       ├── cl_dx9_media_sharing_intel.h
│       ├── cl_egl.h
│       ├── cl_ext.h
│       ├── cl_ext_intel.h
│       ├── cl_function_types.h
│       ├── cl_gl_ext.h
│       ├── cl_gl.h
│       ├── cl.h
│       ├── cl_half.h
│       ├── cl_icd.h
│       ├── cl_layer.h
│       ├── cl_platform.h
│       ├── cl_va_api_media_sharing_intel.h
│       ├── cl_version.h
│       └── opencl.h
└── share
    ├── cmake
    │   └── OpenCLHeaders
    │       ├── OpenCLHeadersConfig.cmake
    │       ├── OpenCLHeadersConfigVersion.cmake
    │       └── OpenCLHeadersTargets.cmake
    └── pkgconfig
        └── OpenCL-Headers.pc

7 directories, 22 files
```

A contributor can have standardized development environment via:

```zsh
$ nix develop # Could also automatically if the developer has `direnv` installed & configured
# With the current flake.nix, then developer can see the output:
$ pkg-config --list-all --cflags
OpenCL-Headers OpenCL-Headers - Khronos OpenCL Headers
```

Lastly, in the future, if there is enough interest, this could enhance the existing CI workflow(with additional PRs) via: 

```zsh
$ nix flake check --all-systems # Runs all the checks(unit tests, pkg-config checks etc) on all CPU architectures
````

On a corollary note, I suggest all software developers to install and use nix for all its benefits. I think there is enough documentation online, however I currently find the documentation lacking for conventions around testing. So I documented it here for the ones interested:  https://gist.github.com/izelnakri/06d7286fe9ab5f15acee9cbeace1c1b1