### PR TITLE
Add macros for anonymous union support

### DIFF
--- a/CL/cl.h
+++ b/CL/cl.h
@@ -139,11 +139,11 @@ typedef struct _cl_image_desc {
     size_t                  image_slice_pitch;
     cl_uint                 num_mip_levels;
     cl_uint                 num_samples;
-#if defined(CL_VERSION_2_0) && __CL_HAS_ANON_STRUCT__
-    __CL_ANON_STRUCT__ union {
+#if defined(CL_VERSION_2_0) && __CL_HAS_ANON_UNION__
+    __CL_ANON_UNION__ union {
 #endif
       cl_mem                  buffer;
-#if defined(CL_VERSION_2_0) && __CL_HAS_ANON_STRUCT__
+#if defined(CL_VERSION_2_0) && __CL_HAS_ANON_UNION__
       cl_mem                  mem_object;
     };
 #endif

--- a/CL/cl_icd.h
+++ b/CL/cl_icd.h
@@ -44,11 +44,11 @@ extern "C" {
 
 typedef struct _cl_icd_dispatch {
   /* OpenCL 1.0 */
-#if __CL_HAS_ANON_STRUCT__
-  __CL_ANON_STRUCT__ union {
+#if __CL_HAS_ANON_UNION__
+  __CL_ANON_UNION__ union {
 #endif
     clGetPlatformIDs_t *clGetPlatformIDs;
-#if __CL_HAS_ANON_STRUCT__
+#if __CL_HAS_ANON_UNION__
     /* Set to CL_ICD2_TAG_KHR for cl_khr_icd 2.0.0 */
     intptr_t clGetPlatformIDs_icd2_tag;
   };
@@ -83,11 +83,11 @@ typedef struct _cl_icd_dispatch {
   clRetainProgram_t *clRetainProgram;
   clReleaseProgram_t *clReleaseProgram;
   clBuildProgram_t *clBuildProgram;
-#if __CL_HAS_ANON_STRUCT__
-  __CL_ANON_STRUCT__ union {
+#if __CL_HAS_ANON_UNION__
+  __CL_ANON_UNION__ union {
 #endif
     clUnloadCompiler_t *clUnloadCompiler;
-#if __CL_HAS_ANON_STRUCT__
+#if __CL_HAS_ANON_UNION__
     /* Set to CL_ICD2_TAG_KHR for cl_khr_icd 2.0.0 */
     intptr_t clUnloadCompiler_icd2_tag;
   };

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -519,6 +519,16 @@ typedef double          cl_double;
 #define  __CL_ANON_STRUCT__
 #endif
 
+/* Define capabilities for anonymous union members. */
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#define  __CL_HAS_ANON_UNION__ 1
+#define  __CL_ANON_UNION__
+#else
+    /* Follow anonymous struct logic */
+#define  __CL_HAS_ANON_UNION__ __CL_HAS_ANON_STRUCT__
+#define  __CL_ANON_UNION__ __CL_ANON_STRUCT__
+#endif
+
 #if defined(_WIN32) && defined(_MSC_VER) && __CL_HAS_ANON_STRUCT__
    /* Disable warning C4201: nonstandard extension used : nameless struct/union */
     #pragma warning( push )


### PR DESCRIPTION
Introduce `__CL_HAS_ANON_UNION__` and `__CL_ANON_UNION__` for anonymous union support.
Anonymous unions are supported in C++11 and later versions, but not anonymous structs.
This change explicitly enables anonymous unions for C++11 or later, otherwise, it will fall back to the previous anonymous structs logic.
