### PR TITLE
Fix warning in header generation script

### DIFF
--- a/scripts/cl_ext.h.mako
+++ b/scripts/cl_ext.h.mako
@@ -307,7 +307,7 @@ extern "C" {
     name = extension.get('name')
 
     # Use re.match to parse semantic major.minor.patch version
-    sem_ver = match('[0-9]+\.[0-9]+\.?[0-9]+', extension.get('revision'))
+    sem_ver = match(r'[0-9]+\.[0-9]+\.?[0-9]+', extension.get('revision'))
     if not sem_ver:
         raise TypeError(name +
         ' XML revision field is not semantically versioned as "major.minor.patch"')


### PR DESCRIPTION
This fixes the following warning seen during header generation:

<unknown>:4: SyntaxWarning: invalid escape sequence '\.'
cl_ext_h_mako:313: SyntaxWarning: invalid escape sequence '\.'

match takes a regular expression string.


Change-Id: I3bd5aa1770760227bca1f070fe2440525369fafd