### PR TITLE
Remove __stdcall warnings in ARM

### DIFF
--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -23,31 +23,23 @@
 extern "C" {
 #endif
 
-#if defined(_WIN32)
-    #if !defined(CL_API_ENTRY)
-        #define CL_API_ENTRY
-    #endif
-    #if !defined(CL_API_CALL)
-        #if !defined(__aarch64__) && !defined(__arm64__)
-            #define CL_API_CALL __stdcall
-        #else
-            #define CL_API_CALL
-        #endif
-    #endif
-    #if !defined(CL_CALLBACK)
-        #define CL_CALLBACK     __stdcall
-    #endif
+#if defined(_WIN32) && !defined(__aarch64__) && !defined(__arm64__)
+    #define _CL_STD_CALL __stdcall
 #else
-    #if !defined(CL_API_ENTRY)
-        #define CL_API_ENTRY
-    #endif
-    #if !defined(CL_API_CALL)
-        #define CL_API_CALL
-    #endif
-    #if !defined(CL_CALLBACK)
-        #define CL_CALLBACK
-    #endif
+    #define _CL_STD_CALL
 #endif
+
+#if !defined(CL_API_ENTRY)
+    #define CL_API_ENTRY
+#endif
+#if !defined(CL_API_CALL)
+    #define CL_API_CALL     _CL_STD_CALL
+#endif
+#if !defined(CL_CALLBACK)
+    #define CL_CALLBACK     _CL_STD_CALL
+#endif
+
+#undef _CL_STD_CALL
 
 /*
  * Deprecation flags refer to the last version of the header in which the

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -28,7 +28,11 @@ extern "C" {
         #define CL_API_ENTRY
     #endif
     #if !defined(CL_API_CALL)
-        #define CL_API_CALL     __stdcall
+        #if !defined(__aarch64__) && !defined(__arm64__)
+            #define CL_API_CALL __stdcall
+        #else
+            #define CL_API_CALL
+        #endif
     #endif
     #if !defined(CL_CALLBACK)
         #define CL_CALLBACK     __stdcall

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -33,13 +33,11 @@ extern "C" {
     #define CL_API_ENTRY
 #endif
 #if !defined(CL_API_CALL)
-    #define CL_API_CALL     _CL_STD_CALL
+    #define CL_API_CALL _CL_STD_CALL
 #endif
 #if !defined(CL_CALLBACK)
-    #define CL_CALLBACK     _CL_STD_CALL
+    #define CL_CALLBACK _CL_STD_CALL
 #endif
-
-#undef _CL_STD_CALL
 
 /*
  * Deprecation flags refer to the last version of the header in which the

--- a/CL/cl_platform.h
+++ b/CL/cl_platform.h
@@ -23,20 +23,22 @@
 extern "C" {
 #endif
 
-#if defined(_WIN32) && !defined(__aarch64__) && !defined(__arm64__)
-    #define _CL_STD_CALL __stdcall
-#else
-    #define _CL_STD_CALL
-#endif
-
 #if !defined(CL_API_ENTRY)
     #define CL_API_ENTRY
 #endif
 #if !defined(CL_API_CALL)
-    #define CL_API_CALL _CL_STD_CALL
+    #if defined(_WIN32) && !defined(__aarch64__) && !defined(__arm64__)
+        #define CL_API_CALL __stdcall
+    #else
+        #define CL_API_CALL
+    #endif
 #endif
 #if !defined(CL_CALLBACK)
-    #define CL_CALLBACK _CL_STD_CALL
+    #if defined(_WIN32) && !defined(__aarch64__) && !defined(__arm64__)
+        #define CL_CALLBACK __stdcall
+    #else
+        #define CL_CALLBACK
+    #endif
 #endif
 
 /*


### PR DESCRIPTION
In ARM architectures the `__stdcall` calling convention is ignored.