### PR TITLE
move CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR to cl_khr_egl_event

### DIFF
--- a/CL/cl_egl.h
+++ b/CL/cl_egl.h
@@ -55,7 +55,6 @@ extern "C" {
 #define CL_KHR_EGL_IMAGE_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
 
 /* Command type for events created with clEnqueueAcquireEGLObjectsKHR */
-#define CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR                0x202F
 #define CL_COMMAND_ACQUIRE_EGL_OBJECTS_KHR                  0x202D
 #define CL_COMMAND_RELEASE_EGL_OBJECTS_KHR                  0x202E
 
@@ -149,6 +148,9 @@ clEnqueueReleaseEGLObjectsKHR(
 
 
 #define CL_KHR_EGL_EVENT_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
+
+/* cl_command_type */
+#define CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR                0x202F
 
 /* CLeglDisplayKHR is an opaque handle to an EGLDisplay */
 /* type CLeglDisplayKHR */

--- a/CL/cl_ext.h
+++ b/CL/cl_ext.h
@@ -4690,7 +4690,7 @@ typedef struct _cl_kernel_allocation_info_intel {
     cl_int arg_index;
 } cl_kernel_allocation_info_intel;
 
-/* cl_kernel_workgroup_info */
+/* cl_kernel_work_group_info */
 #define CL_KERNEL_ALLOCATIONS_INFO_INTEL                    0x425A
 
 /***************************************************************

--- a/CL/cl_function_types.h
+++ b/CL/cl_function_types.h
@@ -1189,7 +1189,7 @@ typedef cl_int CL_API_CALL clGetKernelSuggestedLocalWorkSize_t(
     cl_uint work_dim,
     const size_t* global_work_offset,
     const size_t* global_work_size,
-    size_t* suggested_local_work_size) CL_API_SUFFIX__VERSION_3_1;
+    size_t* suggested_local_work_size);
 
 typedef clGetKernelSuggestedLocalWorkSize_t *
 clGetKernelSuggestedLocalWorkSize_fn CL_API_SUFFIX__VERSION_3_1;


### PR DESCRIPTION
Header changes for https://github.com/KhronosGroup/OpenCL-Docs/pull/1592.

I'll keep this a draft until the spec changes are merged.

Note that this includes a few other fixes due to changes to the XML file:

* Fixes the typo in the comment for `cl_kernel_work_group_info`.
* Removes an extraneous API suffix macro for `clGetKernelSuggestedLocalWorkSize_t`.

There have been some additional Arm and Imagination extension changes in the XML file as well, however I have NOT incorporated those changes in order to keep this PR small.